### PR TITLE
[codex] ship 1.0.1 security update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.0.1] — 2026-04-25
+
 ### Fixed
+- Reapplied the closed CodeQL hardening fixes to the release line for workflow permissions, path validation, URL allowlist checks, reflected XSS, and stack-trace exposure
+- Corrected reusable auth profile export/import so archives round-trip through `AUTH_ROOT/profiles`
+- Restored Python client package builds and updated the SDK to the current action and audit REST routes
+- Rebuilt the operator dashboard tables with DOM text nodes and validated links instead of interpolating untrusted values into `innerHTML`
+- Fixed the active-session dashboard stat update
 - Redirected legacy `/ui/` requests to `/dashboard` so secured deployments consistently land on the bootstrap-aware operator dashboard
 
 ## [1.0.0] — 2026-04-21

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Works with:
 - **Local-first by default.** Run the full stack on your own box with Docker Compose, or use Codespaces for a quick hosted demo.
 - **Safety rails built in.** Approvals, operator identity, PII scrubbing, Witness receipts, and compliance templates are all part of the product surface.
 
-## Release Highlights (v1.0.0)
+## Release Highlights (v1.0.1)
 
-- **Signed mesh delegation** for trusted peer-to-peer workflow routing
-- **Operator dashboard and workflow surfaces** under `/dashboard`, `/workflows`, `/social/empire`, and the extended session network/CDP routes
-- **Readiness advisor, compliance templates, and memory profiles** for safer repeatable automation
-- **Codespaces support and integration packages** for one-click demos and downstream orchestration
-- **Hardening fixes** across auth bootstrap, recipient-bound mesh envelopes, Windows job persistence, audit retention, and archive import safety
+- **Security hardening** for CodeQL-reported workflow permissions, path validation, URL matching, reflected output, and error exposure
+- **Auth profile archive fixes** so saved reusable profiles export and import under `AUTH_ROOT/profiles`
+- **Python client SDK repair** with packageable wheels and current action/audit REST paths
+- **Dashboard XSS hardening** with DOM text rendering, validated links, and a working active-session counter
+- **1.0 platform surface** including signed mesh delegation, workflow routes, `/dashboard`, noVNC takeover, MCP transport, audit trails, and readiness checks
 
 See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,12 @@
+# auto-browser-client
+
+Python SDK for the Auto Browser REST API.
+
+```python
+from auto_browser_client import AutoBrowserClient
+
+client = AutoBrowserClient("http://localhost:8000", token="secret")
+session = client.create_session(start_url="https://example.com")
+client.navigate(session["id"], "https://example.com/dashboard")
+client.close_session(session["id"])
+```

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -2,4 +2,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/client/auto_browser_client/client.py
+++ b/client/auto_browser_client/client.py
@@ -210,10 +210,10 @@ class AutoBrowserClient:
     # ── Navigation & actions ─────────────────────────────────────────────────
 
     def navigate(self, session_id: str, url: str) -> dict:
-        return self._post(f"/sessions/{session_id}/navigate", {"url": url})
+        return self._post(f"/sessions/{session_id}/actions/navigate", {"url": url})
 
     async def async_navigate(self, session_id: str, url: str) -> dict:
-        return await self._apost(f"/sessions/{session_id}/navigate", {"url": url})
+        return await self._apost(f"/sessions/{session_id}/actions/navigate", {"url": url})
 
     def click(self, session_id: str, *, selector: str | None = None, element_id: str | None = None, x: float | None = None, y: float | None = None) -> dict:
         body: dict[str, Any] = {}
@@ -225,7 +225,7 @@ class AutoBrowserClient:
             body["x"] = x
         if y is not None:
             body["y"] = y
-        return self._post(f"/sessions/{session_id}/click", body)
+        return self._post(f"/sessions/{session_id}/actions/click", body)
 
     async def async_click(self, session_id: str, *, selector: str | None = None, element_id: str | None = None, x: float | None = None, y: float | None = None) -> dict:
         body: dict[str, Any] = {}
@@ -237,7 +237,7 @@ class AutoBrowserClient:
             body["x"] = x
         if y is not None:
             body["y"] = y
-        return await self._apost(f"/sessions/{session_id}/click", body)
+        return await self._apost(f"/sessions/{session_id}/actions/click", body)
 
     def type_text(self, session_id: str, text: str, *, selector: str | None = None, element_id: str | None = None, clear_first: bool = True) -> dict:
         body: dict[str, Any] = {"text": text, "clear_first": clear_first}
@@ -245,7 +245,7 @@ class AutoBrowserClient:
             body["selector"] = selector
         if element_id:
             body["element_id"] = element_id
-        return self._post(f"/sessions/{session_id}/type", body)
+        return self._post(f"/sessions/{session_id}/actions/type", body)
 
     async def async_type_text(self, session_id: str, text: str, *, selector: str | None = None, element_id: str | None = None, clear_first: bool = True) -> dict:
         body: dict[str, Any] = {"text": text, "clear_first": clear_first}
@@ -253,13 +253,13 @@ class AutoBrowserClient:
             body["selector"] = selector
         if element_id:
             body["element_id"] = element_id
-        return await self._apost(f"/sessions/{session_id}/type", body)
+        return await self._apost(f"/sessions/{session_id}/actions/type", body)
 
     def scroll(self, session_id: str, *, delta_x: float = 0, delta_y: float = 600) -> dict:
-        return self._post(f"/sessions/{session_id}/scroll", {"delta_x": delta_x, "delta_y": delta_y})
+        return self._post(f"/sessions/{session_id}/actions/scroll", {"delta_x": delta_x, "delta_y": delta_y})
 
     async def async_scroll(self, session_id: str, *, delta_x: float = 0, delta_y: float = 600) -> dict:
-        return await self._apost(f"/sessions/{session_id}/scroll", {"delta_x": delta_x, "delta_y": delta_y})
+        return await self._apost(f"/sessions/{session_id}/actions/scroll", {"delta_x": delta_x, "delta_y": delta_y})
 
     def screenshot(self, session_id: str, label: str = "manual") -> dict:
         return self._post(f"/sessions/{session_id}/screenshot", {"label": label})
@@ -365,10 +365,10 @@ class AutoBrowserClient:
         params: dict[str, Any] = {"limit": limit}
         if session_id:
             params["session_id"] = session_id
-        return self._get("/audit", **params)
+        return self._get("/audit/events", **params)
 
     async def async_list_audit_events(self, *, limit: int = 50, session_id: str | None = None) -> list[dict]:
         params: dict[str, Any] = {"limit": limit}
         if session_id:
             params["session_id"] = session_id
-        return await self._aget("/audit", **params)
+        return await self._aget("/audit/events", **params)

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,14 +1,17 @@
 [build-system]
 requires = ["setuptools>=68"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python client SDK for auto-browser"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = ["httpx>=0.27"]
+
+[tool.setuptools.packages.find]
+include = ["auto_browser_client*"]
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-asyncio", "respx"]

--- a/client/tests/test_client_paths.py
+++ b/client/tests/test_client_paths.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import unittest
+from typing import Any
+
+import httpx
+
+from auto_browser_client import AutoBrowserClient
+
+
+def _json_body(request: httpx.Request) -> dict[str, Any]:
+    return json.loads(request.content.decode("utf-8"))
+
+
+class ClientPathTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.requests: list[httpx.Request] = []
+        self.client = AutoBrowserClient("http://auto-browser.test")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.requests.append(request)
+            return httpx.Response(200, json={"ok": True})
+
+        self.client._sync_client = httpx.Client(
+            base_url=self.client.base_url,
+            transport=httpx.MockTransport(handler),
+        )
+
+    def tearDown(self) -> None:
+        if self.client._sync_client is not None:
+            self.client._sync_client.close()
+
+    def test_actions_use_server_action_routes(self) -> None:
+        self.client.navigate("session-1", "https://example.com")
+        self.client.click("session-1", selector="#submit")
+        self.client.type_text("session-1", "hello", selector="#search", clear_first=False)
+        self.client.scroll("session-1", delta_x=2, delta_y=300)
+
+        self.assertEqual(
+            [request.url.path for request in self.requests],
+            [
+                "/sessions/session-1/actions/navigate",
+                "/sessions/session-1/actions/click",
+                "/sessions/session-1/actions/type",
+                "/sessions/session-1/actions/scroll",
+            ],
+        )
+        self.assertEqual(_json_body(self.requests[0]), {"url": "https://example.com"})
+        self.assertEqual(_json_body(self.requests[1]), {"selector": "#submit"})
+        self.assertEqual(
+            _json_body(self.requests[2]),
+            {"text": "hello", "clear_first": False, "selector": "#search"},
+        )
+        self.assertEqual(_json_body(self.requests[3]), {"delta_x": 2, "delta_y": 300})
+
+    def test_audit_events_use_server_route(self) -> None:
+        self.client.list_audit_events(limit=10, session_id="session-1")
+
+        request = self.requests[-1]
+        self.assertEqual(request.url.path, "/audit/events")
+        self.assertEqual(dict(request.url.params), {"limit": "10", "session_id": "session-1"})
+
+
+class AsyncClientPathTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.requests: list[httpx.Request] = []
+        self.client = AutoBrowserClient("http://auto-browser.test")
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            self.requests.append(request)
+            return httpx.Response(200, json={"ok": True})
+
+        self.client._async_client = httpx.AsyncClient(
+            base_url=self.client.base_url,
+            transport=httpx.MockTransport(handler),
+        )
+
+    async def asyncTearDown(self) -> None:
+        if self.client._async_client is not None:
+            await self.client._async_client.aclose()
+
+    async def test_async_actions_and_audit_use_server_routes(self) -> None:
+        await self.client.async_navigate("session-1", "https://example.com")
+        await self.client.async_click("session-1", element_id="submit")
+        await self.client.async_type_text("session-1", "hello", element_id="search")
+        await self.client.async_scroll("session-1")
+        await self.client.async_list_audit_events(limit=5)
+
+        self.assertEqual(
+            [request.url.path for request in self.requests],
+            [
+                "/sessions/session-1/actions/navigate",
+                "/sessions/session-1/actions/click",
+                "/sessions/session-1/actions/type",
+                "/sessions/session-1/actions/scroll",
+                "/audit/events",
+            ],
+        )

--- a/controller/app/browser_manager.py
+++ b/controller/app/browser_manager.py
@@ -1807,15 +1807,24 @@ class BrowserManager:
             return "outlook"
         return normalized
 
+    @staticmethod
+    def _host_matches(host: str, *domains: str) -> bool:
+        host = host.lower().rstrip(".")
+        for domain in domains:
+            domain = domain.lower().rstrip(".")
+            if host == domain or host.endswith("." + domain):
+                return True
+        return False
+
     def _current_platform(self, session: BrowserSession) -> str | None:
         host = (urlparse(session.page.url).hostname or "").lower()
-        if "x.com" in host or "twitter.com" in host:
+        if self._host_matches(host, "x.com", "twitter.com"):
             return "x"
-        if "instagram.com" in host:
+        if self._host_matches(host, "instagram.com"):
             return "instagram"
-        if "linkedin.com" in host:
+        if self._host_matches(host, "linkedin.com"):
             return "linkedin"
-        if "outlook.live.com" in host or "outlook.office.com" in host or "outlook.office365.com" in host:
+        if self._host_matches(host, "outlook.live.com", "outlook.office.com", "outlook.office365.com"):
             return "outlook"
         return None
 
@@ -4360,7 +4369,7 @@ class BrowserManager:
         normalized = self._normalize_auth_profile_name(profile_name)
         root = self._auth_profile_root()
         directory = (root / normalized).resolve()
-        if root not in directory.parents and directory != root:
+        if not directory.is_relative_to(root):
             raise PermissionError("auth profile path must stay inside auth root")
         if create:
             directory.mkdir(parents=True, exist_ok=True)
@@ -4511,7 +4520,7 @@ class BrowserManager:
             else:
                 candidate = (preferred_roots[0] / file_path).resolve()
 
-        if not any(candidate == allowed_root or allowed_root in candidate.parents for allowed_root in allowed_roots):
+        if not any(candidate.is_relative_to(allowed_root) for allowed_root in allowed_roots):
             raise PermissionError("file_path must stay inside upload root")
         if not candidate.exists():
             raise FileNotFoundError(candidate)
@@ -4526,7 +4535,7 @@ class BrowserManager:
     ) -> Path:
         root = session.auth_dir.resolve()
         candidate = (root / relative_path).resolve()
-        if root not in candidate.parents and candidate != root:
+        if not candidate.is_relative_to(root):
             raise PermissionError("auth path must stay inside the session auth root")
         candidate.parent.mkdir(parents=True, exist_ok=True)
         if must_exist and not candidate.exists():
@@ -4536,7 +4545,7 @@ class BrowserManager:
     def _safe_auth_path(self, relative_path: str, must_exist: bool = False) -> Path:
         root = Path(self.settings.auth_root).resolve()
         candidate = (root / relative_path).resolve()
-        if root not in candidate.parents and candidate != root:
+        if not candidate.is_relative_to(root):
             raise PermissionError("auth path must stay inside auth root")
         candidate.parent.mkdir(parents=True, exist_ok=True)
         if must_exist and not candidate.exists():
@@ -4736,18 +4745,23 @@ class BrowserManager:
 
     async def export_auth_profile(self, profile_name: str) -> dict[str, Any]:
         """Package an auth profile dir as a .tar.gz and return the artifact path."""
-        auth_root = Path(self.settings.auth_root)
-        profile_dir = auth_root / profile_name
+        normalized = self._normalize_auth_profile_name(profile_name)
+        auth_root = Path(self.settings.auth_root).resolve()
+        profile_dir = (auth_root / normalized).resolve()
+        if not profile_dir.is_relative_to(auth_root):
+            raise PermissionError("auth profile path must stay inside auth root")
         if not profile_dir.exists() or not profile_dir.is_dir():
-            raise FileNotFoundError(f"auth profile '{profile_name}' not found")
+            raise FileNotFoundError(f"auth profile '{normalized}' not found")
 
         ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-        archive_name = f"{profile_name}-{ts}.tar.gz"
-        archive_path = auth_root / archive_name
+        archive_name = f"{normalized}-{ts}.tar.gz"
+        archive_path = (auth_root / archive_name).resolve()
+        if not archive_path.is_relative_to(auth_root):
+            raise PermissionError("archive path must stay inside auth root")
 
         await asyncio.to_thread(self._write_tar, profile_dir, archive_path)
         return {
-            "profile_name": profile_name,
+            "profile_name": normalized,
             "archive_path": str(archive_path),
             "archive_name": archive_name,
             "download_url": f"/auth-export/{archive_name}",

--- a/controller/app/browser_manager.py
+++ b/controller/app/browser_manager.py
@@ -11,7 +11,7 @@ import shutil
 import tarfile
 from dataclasses import dataclass, field
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Awaitable, Callable
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -4747,9 +4747,10 @@ class BrowserManager:
         """Package an auth profile dir as a .tar.gz and return the artifact path."""
         normalized = self._normalize_auth_profile_name(profile_name)
         auth_root = Path(self.settings.auth_root).resolve()
-        profile_dir = (auth_root / normalized).resolve()
-        if not profile_dir.is_relative_to(auth_root):
-            raise PermissionError("auth profile path must stay inside auth root")
+        profile_root = self._auth_profile_root()
+        profile_dir = self._auth_profile_dir(normalized, create=False)
+        if not profile_dir.is_relative_to(profile_root):
+            raise PermissionError("auth profile path must stay inside auth profile root")
         if not profile_dir.exists() or not profile_dir.is_dir():
             raise FileNotFoundError(f"auth profile '{normalized}' not found")
 
@@ -4772,30 +4773,76 @@ class BrowserManager:
         with tarfile.open(str(dest), "w:gz") as tar:
             tar.add(str(source_dir), arcname=source_dir.name)
 
+    @staticmethod
+    def _safe_auth_archive_member_name(member_name: str) -> PurePosixPath:
+        candidate = PurePosixPath(member_name.replace("\\", "/"))
+        if candidate.is_absolute() or not candidate.parts or ".." in candidate.parts:
+            raise ValueError("archive contains an unsafe path")
+        return candidate
+
     async def import_auth_profile(self, archive_path: str, *, overwrite: bool = False) -> dict[str, Any]:
-        """Extract a .tar.gz archive into the auth root."""
-        src = Path(archive_path)
+        """Extract a .tar.gz archive into the reusable auth profile root."""
+        src = Path(archive_path).resolve()
         if not src.exists():
             raise FileNotFoundError(f"archive not found: {archive_path}")
 
-        auth_root = Path(self.settings.auth_root)
+        profile_root = self._auth_profile_root()
 
         def _extract() -> str:
             with tarfile.open(str(src), "r:gz") as tar:
-                # Determine profile name from top-level dir in archive
                 members = tar.getmembers()
                 if not members:
                     raise ValueError("archive is empty")
-                top = members[0].name.split("/")[0]
-                dest_dir = auth_root / top
+
+                safe_members: list[tuple[tarfile.TarInfo, PurePosixPath]] = []
+                top_level: str | None = None
+                for member in members:
+                    if member.issym() or member.islnk() or member.isdev():
+                        raise ValueError("archive contains an unsupported member type")
+                    if not member.isdir() and not member.isfile():
+                        continue
+                    safe_path = self._safe_auth_archive_member_name(member.name)
+                    if len(safe_path.parts) == 1 and not member.isdir():
+                        raise ValueError("archive must contain a top-level profile directory")
+                    top = safe_path.parts[0]
+                    if top_level is None:
+                        top_level = top
+                    elif top != top_level:
+                        raise ValueError("archive must contain a single top-level profile directory")
+                    safe_members.append((member, safe_path))
+
+                if top_level is None:
+                    raise ValueError("archive contains no importable files")
+
+                profile_name = self._normalize_auth_profile_name(top_level)
+                dest_dir = (profile_root / profile_name).resolve()
+                if not dest_dir.is_relative_to(profile_root):
+                    raise PermissionError("auth profile path must stay inside auth profile root")
                 if dest_dir.exists() and not overwrite:
-                    raise FileExistsError(f"profile '{top}' already exists — pass overwrite=true")
-                tar.extractall(path=str(auth_root), filter="data")
-                return top
+                    raise FileExistsError(f"profile '{profile_name}' already exists; pass overwrite=true")
+                if dest_dir.exists():
+                    shutil.rmtree(dest_dir)
+
+                for member, safe_path in safe_members:
+                    relative = Path(*safe_path.parts)
+                    target = (profile_root / relative).resolve()
+                    if not target.is_relative_to(profile_root):
+                        raise PermissionError("archive member escapes auth profile root")
+                    if member.isdir():
+                        target.mkdir(parents=True, exist_ok=True)
+                        continue
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    source = tar.extractfile(member)
+                    if source is None:
+                        raise ValueError("archive member could not be read")
+                    with source, target.open("wb") as output:
+                        shutil.copyfileobj(source, output)
+
+                return profile_name
 
         profile_name = await asyncio.to_thread(_extract)
         return {
             "profile_name": profile_name,
-            "profile_path": str(auth_root / profile_name),
+            "profile_path": str(profile_root / profile_name),
             "imported": True,
         }

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -1105,11 +1105,16 @@ async def session_replay(session_id: str) -> HTMLResponse:
 
     # Gather screenshots, constrained to the artifact root.
     artifact_root = Path(settings.artifact_root).resolve()
-    artifact_dir = (artifact_root / safe_session_id).resolve()
-    if not artifact_dir.is_relative_to(artifact_root):
-        raise HTTPException(status_code=400, detail="Invalid session_id")
+    artifact_dir: Path | None = None
+    if artifact_root.is_dir():
+        for child in artifact_root.iterdir():
+            if child.name == safe_session_id and child.is_dir():
+                candidate = child.resolve()
+                if candidate.is_relative_to(artifact_root):
+                    artifact_dir = candidate
+                break
     screenshots: list[tuple[str, str]] = []  # (url, label)
-    if artifact_dir.is_dir():
+    if artifact_dir is not None:
         for f in sorted(artifact_dir.glob("*.png")):
             label = f.stem.replace("-", " ")
             screenshots.append((f"/artifacts/{safe_session_id}/{f.name}", label))

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -81,7 +81,7 @@ _log_level = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), loggi
 logging.basicConfig(level=_log_level)
 logger = logging.getLogger(__name__)
 
-_VERSION = "1.0.0"
+_VERSION = "1.0.1"
 
 _SAFE_PATH_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import html as _html
 import json
 import logging
 import os
+import re
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -80,6 +82,45 @@ logging.basicConfig(level=_log_level)
 logger = logging.getLogger(__name__)
 
 _VERSION = "1.0.0"
+
+_SAFE_PATH_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _require_safe_segment(value: str, *, field: str) -> str:
+    """Validate that *value* is a single safe path segment (no traversal).
+
+    Accepts only characters that can't form path traversal sequences so the
+    result is safe to join with a trusted base directory.
+    """
+    if not isinstance(value, str) or not _SAFE_PATH_SEGMENT.fullmatch(value):
+        raise HTTPException(status_code=400, detail=f"Invalid {field}")
+    return value
+
+
+def _http_detail(exc: Exception, fallback: str) -> str:
+    """Return a safe HTTP detail string for *exc*.
+
+    Logs the exception server-side with full context but returns only the
+    provided *fallback*, so no stack-trace, chained exception, or internal
+    state flows back to the client.
+    """
+    logger.warning("HTTP error (%s): %s", type(exc).__name__, exc)
+    return fallback
+
+
+def _approval_payload(exc: ApprovalRequiredError) -> dict[str, object]:
+    """Return a safe approval-required response payload.
+
+    Rebuilds the payload from the typed ``ApprovalRecord`` attribute so no
+    tainted exception attribute reaches the client.
+    """
+    record = exc.approval
+    return {
+        "status": "approval_required",
+        "message": f"{record.kind} actions require human approval",
+        "approval": record.model_dump(),
+    }
+
 
 settings = get_settings()
 _compliance_template = settings.compliance_template.upper().strip() if settings.compliance_template else None
@@ -350,7 +391,7 @@ async def readyz() -> dict[str, str]:
         await manager.ensure_browser()
         return {"status": "ready", "environment": settings.environment_name}
     except Exception as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        raise HTTPException(status_code=503, detail=_http_detail(exc, "Service unavailable")) from exc
 
 
 @app.get("/metrics", include_in_schema=False)
@@ -451,7 +492,7 @@ async def approve_approval(approval_id: str, payload: ApprovalDecisionRequest) -
     try:
         return await manager.approve(approval_id, comment=payload.comment)
     except PermissionError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
 
 
 @app.post("/approvals/{approval_id}/reject")
@@ -459,7 +500,7 @@ async def reject_approval(approval_id: str, payload: ApprovalDecisionRequest) ->
     try:
         return await manager.reject(approval_id, comment=payload.comment)
     except PermissionError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
 
 
 @app.post("/approvals/{approval_id}/execute")
@@ -467,11 +508,11 @@ async def execute_approval(approval_id: str) -> dict:
     try:
         return await manager.execute_approval(approval_id)
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.get("/sessions")
@@ -497,17 +538,17 @@ async def create_session(payload: CreateSessionRequest) -> dict:
             totp_secret=payload.totp_secret,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=_http_detail(exc, "Internal error")) from exc
 
 
 @app.get("/sessions/{session_id}")
@@ -530,7 +571,7 @@ async def get_auth_profile(profile_name: str) -> dict:
     try:
         return await manager.get_auth_profile(profile_name)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.get("/sessions/{session_id}/observe")
@@ -564,7 +605,7 @@ async def activate_tab(session_id: str, payload: TabIndexRequest) -> dict:
     try:
         return await manager.activate_tab(session_id, payload.index)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/tabs/close")
@@ -572,7 +613,7 @@ async def close_tab(session_id: str, payload: TabIndexRequest) -> dict:
     try:
         return await manager.close_tab(session_id, payload.index)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/tabs/open")
@@ -580,7 +621,7 @@ async def open_tab(session_id: str, payload: OpenTabRequest) -> dict:
     try:
         return await manager.open_tab(session_id, payload.url, payload.activate)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/actions/navigate")
@@ -588,9 +629,9 @@ async def navigate(session_id: str, payload: NavigateRequest) -> dict:
     try:
         return await manager.navigate(session_id, payload.url)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/actions/click")
@@ -604,11 +645,11 @@ async def click(session_id: str, payload: ClickRequest) -> dict:
             y=payload.y,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/actions/type")
@@ -623,11 +664,11 @@ async def type_text(session_id: str, payload: TypeRequest) -> dict:
             sensitive=payload.sensitive,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/actions/press")
@@ -635,9 +676,9 @@ async def press_key(session_id: str, payload: PressRequest) -> dict:
     try:
         return await manager.press(session_id, payload.key)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/actions/scroll")
@@ -645,7 +686,7 @@ async def scroll(session_id: str, payload: ScrollRequest) -> dict:
     try:
         return await manager.scroll(session_id, payload.delta_x, payload.delta_y)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
 
 
 @app.post("/sessions/{session_id}/actions/execute")
@@ -657,11 +698,11 @@ async def execute_action(session_id: str, payload: ExecuteActionRequest) -> dict
             approval_id=payload.approval_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/actions/upload")
@@ -676,13 +717,13 @@ async def upload(session_id: str, payload: UploadRequest) -> dict:
             approval_id=payload.approval_id,
         )
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/actions/hover")
@@ -696,11 +737,11 @@ async def hover(session_id: str, payload: HoverRequest) -> dict:
             y=payload.y,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/actions/select-option")
@@ -715,11 +756,11 @@ async def select_option(session_id: str, payload: SelectOptionRequest) -> dict:
             index=payload.index,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/actions/wait")
@@ -732,9 +773,9 @@ async def reload(session_id: str) -> dict:
     try:
         return await manager.reload(session_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/actions/go-back")
@@ -742,9 +783,9 @@ async def go_back(session_id: str) -> dict:
     try:
         return await manager.go_back(session_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/actions/go-forward")
@@ -752,9 +793,9 @@ async def go_forward(session_id: str) -> dict:
     try:
         return await manager.go_forward(session_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
 
 @app.post("/sessions/{session_id}/social/scroll")
@@ -782,11 +823,11 @@ async def social_post(session_id: str, payload: SocialPostRequest) -> dict:
     try:
         return await manager.post_content(session_id, text=payload.text, approval_id=payload.approval_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/social/comment")
@@ -799,11 +840,11 @@ async def social_comment(session_id: str, payload: SocialCommentRequest) -> dict
             approval_id=payload.approval_id,
         )
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/social/like")
@@ -811,11 +852,11 @@ async def social_like(session_id: str, payload: SocialLikeRequest) -> dict:
     try:
         return await manager.like_post(session_id, post_index=payload.post_index, approval_id=payload.approval_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/social/follow")
@@ -823,11 +864,11 @@ async def social_follow(session_id: str, payload: SocialFollowRequest) -> dict:
     try:
         return await manager.follow_user(session_id, approval_id=payload.approval_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/social/unfollow")
@@ -835,11 +876,11 @@ async def social_unfollow(session_id: str, payload: SocialUnfollowRequest) -> di
     try:
         return await manager.unfollow_user(session_id, approval_id=payload.approval_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/social/repost")
@@ -851,11 +892,11 @@ async def social_repost(session_id: str, payload: SocialRepostRequest) -> dict:
             approval_id=payload.approval_id,
         )
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/social/dm")
@@ -868,11 +909,11 @@ async def social_dm(session_id: str, payload: SocialDmRequest) -> dict:
             approval_id=payload.approval_id,
         )
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/social/login")
@@ -888,11 +929,11 @@ async def social_login(session_id: str, payload: SocialLoginRequest) -> dict:
             totp_secret=payload.totp_secret,
         )
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except ApprovalRequiredError as exc:
-        raise HTTPException(status_code=409, detail=exc.payload) from exc
+        raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/social/search")
@@ -900,7 +941,7 @@ async def social_search(session_id: str, payload: SocialSearchRequest) -> dict:
     try:
         return await manager.search_page(session_id, query=payload.query)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.post("/sessions/{session_id}/storage-state")
@@ -908,7 +949,7 @@ async def save_storage_state(session_id: str, payload: SaveStorageStateRequest) 
     try:
         return await manager.save_storage_state(session_id, payload.path)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
 
 
 @app.post("/sessions/{session_id}/auth-profiles")
@@ -916,9 +957,9 @@ async def save_auth_profile(session_id: str, payload: SaveAuthProfileRequest) ->
     try:
         return await manager.save_auth_profile(session_id, payload.profile_name)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
 
 
 @app.post("/sessions/{session_id}/takeover")
@@ -946,7 +987,7 @@ async def run_agent_step(session_id: str, payload: AgentStepRequest) -> dict:
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=f"Unknown session: {session_id}") from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        raise HTTPException(status_code=503, detail=_http_detail(exc, "Service unavailable")) from exc
 
 
 @app.post("/sessions/{session_id}/agent/jobs/step", status_code=202)
@@ -973,7 +1014,7 @@ async def run_agent_loop(session_id: str, payload: AgentRunRequest) -> dict:
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=f"Unknown session: {session_id}") from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        raise HTTPException(status_code=503, detail=_http_detail(exc, "Service unavailable")) from exc
 
 
 @app.post("/sessions/{session_id}/agent/jobs/run", status_code=202)
@@ -1054,16 +1095,19 @@ async def screenshot_compare(session_id: str) -> dict:
     try:
         return await manager.screenshot_diff(session_id)
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=_http_detail(exc, "Internal error")) from exc
 
 
 @app.get("/sessions/{session_id}/replay", response_class=HTMLResponse)
 async def session_replay(session_id: str) -> HTMLResponse:
     """Session replay — HTML viewer showing screenshots, audit events, and approvals."""
-    import html as _html
+    _require_safe_segment(session_id, field="session_id")
 
-    # Gather screenshots
-    artifact_dir = Path(settings.artifact_root) / session_id
+    # Gather screenshots, constrained to the artifact root.
+    artifact_root = Path(settings.artifact_root).resolve()
+    artifact_dir = (artifact_root / session_id).resolve()
+    if not artifact_dir.is_relative_to(artifact_root):
+        raise HTTPException(status_code=400, detail="Invalid session_id")
     screenshots: list[tuple[str, str]] = []  # (url, label)
     if artifact_dir.is_dir():
         for f in sorted(artifact_dir.glob("*.png")):
@@ -1158,14 +1202,18 @@ async def session_replay(session_id: str) -> HTMLResponse:
 @app.get("/auth-profiles/{profile_name}/export")
 async def export_auth_profile(profile_name: str):
     """Download an auth profile as a .tar.gz archive."""
+    _require_safe_segment(profile_name, field="profile_name")
     try:
         result = await manager.export_auth_profile(profile_name)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=_http_detail(exc, "Internal error")) from exc
 
-    archive_path = Path(result["archive_path"])
+    auth_root = Path(settings.auth_root).resolve()
+    archive_path = Path(result["archive_path"]).resolve()
+    if not archive_path.is_relative_to(auth_root):
+        raise HTTPException(status_code=500, detail="archive path outside auth root")
     if not archive_path.exists():
         raise HTTPException(status_code=500, detail="archive file not found after export")
 
@@ -1182,11 +1230,11 @@ async def import_auth_profile(payload: ImportAuthProfileRequest) -> dict:
     try:
         return await manager.import_auth_profile(payload.archive_path, overwrite=payload.overwrite)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
     except FileExistsError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=_http_detail(exc, "Internal error")) from exc
 
 
 @app.delete("/sessions/{session_id}")
@@ -1213,7 +1261,7 @@ async def fork_session(session_id: str, name: str | None = None, start_url: str 
     try:
         return await manager.fork_session(session_id, name=name, start_url=start_url)
     except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
 
 
 @app.post("/sessions/{session_id}/share")
@@ -1227,7 +1275,7 @@ async def share_session(session_id: str, payload: ShareSessionRequest | None = N
     try:
         return share_manager.create_token(session_id, ttl_seconds=ttl_minutes * 60)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.get("/share/{token}/observe")
@@ -1255,12 +1303,13 @@ async def shared_session_view(token: str) -> HTMLResponse:
 
     token_json = json.dumps(token)
     session_id_json = json.dumps(info["session_id"])
+    session_id_html = _html.escape(str(info["session_id"]), quote=True)
     html = f"""<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Shared Session {info["session_id"]}</title>
+    <title>Shared Session {session_id_html}</title>
     <style>
       :root {{
         color-scheme: dark;
@@ -1416,7 +1465,7 @@ async def enable_shadow_browse(session_id: str) -> dict:
     try:
         return await manager.enable_shadow_browse(session_id)
     except RuntimeError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.get("/sessions/{session_id}/audit")
@@ -1503,7 +1552,7 @@ async def set_proxy_persona(payload: CreateProxyPersonaInput) -> dict:
             description=payload.description,
         )
     except (ValueError, RuntimeError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.get("/proxy-personas/{name}")
@@ -1511,7 +1560,7 @@ async def get_proxy_persona(name: str) -> dict:
     try:
         return proxy_store.get_persona(name)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
 
 
 @app.delete("/proxy-personas/{name}")
@@ -1545,7 +1594,7 @@ async def create_cron_job(payload: CreateCronJobInput) -> dict:
             webhook_enabled=payload.webhook_enabled,
         )
     except (ValueError, TypeError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
 
 
 @app.get("/crons/{job_id}")
@@ -1569,8 +1618,8 @@ async def trigger_cron_job_via_webhook(job_id: str, request: Request) -> dict:
         payload = TriggerCronJobInput.model_validate({"job_id": job_id, **body})
         return await cron_service.trigger_via_webhook(payload.job_id, payload.webhook_key or "")
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
     except (ValidationError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -1101,33 +1101,33 @@ async def screenshot_compare(session_id: str) -> dict:
 @app.get("/sessions/{session_id}/replay", response_class=HTMLResponse)
 async def session_replay(session_id: str) -> HTMLResponse:
     """Session replay — HTML viewer showing screenshots, audit events, and approvals."""
-    _require_safe_segment(session_id, field="session_id")
+    safe_session_id = _require_safe_segment(session_id, field="session_id")
 
     # Gather screenshots, constrained to the artifact root.
     artifact_root = Path(settings.artifact_root).resolve()
-    artifact_dir = (artifact_root / session_id).resolve()
+    artifact_dir = (artifact_root / safe_session_id).resolve()
     if not artifact_dir.is_relative_to(artifact_root):
         raise HTTPException(status_code=400, detail="Invalid session_id")
     screenshots: list[tuple[str, str]] = []  # (url, label)
     if artifact_dir.is_dir():
         for f in sorted(artifact_dir.glob("*.png")):
             label = f.stem.replace("-", " ")
-            screenshots.append((f"/artifacts/{session_id}/{f.name}", label))
+            screenshots.append((f"/artifacts/{safe_session_id}/{f.name}", label))
 
     # Gather audit events for this session
     try:
-        events = await manager.list_audit_events(session_id=session_id, limit=200)
+        events = await manager.list_audit_events(session_id=safe_session_id, limit=200)
     except Exception:
         events = []
 
     # Gather session info
     session_info: dict = {}
     try:
-        session = manager.sessions.get(session_id)
+        session = manager.sessions.get(safe_session_id)
         if session:
             session_info = await manager._session_summary(session)
         else:
-            record = await manager.session_store.get(session_id)
+            record = await manager.session_store.get(safe_session_id)
             session_info = record.model_dump()
     except Exception:
         pass
@@ -1181,7 +1181,7 @@ async def session_replay(session_id: str) -> HTMLResponse:
 <body>
 <h1>Session Replay</h1>
 <div class="meta">
-  <span>ID: <strong>{esc(session_id)}</strong></span>
+  <span>ID: <strong>{esc(safe_session_id)}</strong></span>
   <span>Status: <strong>{status}</strong></span>
   <span>Created: {created}</span>
   <span>Title: {title}</span>
@@ -1202,9 +1202,9 @@ async def session_replay(session_id: str) -> HTMLResponse:
 @app.get("/auth-profiles/{profile_name}/export")
 async def export_auth_profile(profile_name: str):
     """Download an auth profile as a .tar.gz archive."""
-    _require_safe_segment(profile_name, field="profile_name")
+    safe_profile_name = _require_safe_segment(profile_name, field="profile_name")
     try:
-        result = await manager.export_auth_profile(profile_name)
+        result = await manager.export_auth_profile(safe_profile_name)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
     except Exception as exc:

--- a/controller/app/routes/extensions.py
+++ b/controller/app/routes/extensions.py
@@ -561,13 +561,20 @@ const api = (path) =>
       return r.json();
     })
     .catch(e => ({}));
+const asText = (value, fallback = '—') => {
+  if (value === null || value === undefined || value === '') return fallback;
+  return String(value);
+};
 const statusBadge = (s) => {
   const map = {active:'green', running:'green', completed:'green', ok:'green',
                 failed:'red', error:'red', rejected:'red',
                 pending:'yellow', approval_required:'yellow',
                 interrupted:'gray', closed:'gray'};
-  const cls = map[s] || 'gray';
-  return `<span class="badge badge-${cls}">${s}</span>`;
+  const label = asText(s, 'unknown');
+  const span = document.createElement('span');
+  span.className = `badge badge-${map[label] || 'gray'}`;
+  span.textContent = label;
+  return span;
 };
 const timeAgo = (ts) => {
   if (!ts) return '—';
@@ -575,6 +582,48 @@ const timeAgo = (ts) => {
   if (s < 60) return `${s}s ago`;
   if (s < 3600) return `${Math.floor(s/60)}m ago`;
   return `${Math.floor(s/3600)}h ago`;
+};
+const formatEventTime = (ts) => {
+  if (!ts) return '—';
+  const numeric = Number(ts);
+  const date = Number.isFinite(numeric) ? new Date(numeric * 1000) : new Date(String(ts));
+  return Number.isNaN(date.getTime()) ? '—' : date.toLocaleTimeString();
+};
+const appendCell = (row, value, options = {}) => {
+  const td = document.createElement('td');
+  if (options.className) td.className = options.className;
+  if (options.maxWidth) {
+    td.style.maxWidth = options.maxWidth;
+    td.style.overflow = 'hidden';
+    td.style.textOverflow = 'ellipsis';
+  }
+  td.textContent = asText(value);
+  row.appendChild(td);
+  return td;
+};
+const appendNodeCell = (row, node) => {
+  const td = document.createElement('td');
+  td.appendChild(node);
+  row.appendChild(td);
+  return td;
+};
+const appendEmptyRow = (tbody, colspan, message) => {
+  tbody.replaceChildren();
+  const row = document.createElement('tr');
+  const cell = document.createElement('td');
+  cell.colSpan = colspan;
+  cell.className = 'empty';
+  cell.textContent = message;
+  row.appendChild(cell);
+  tbody.appendChild(row);
+};
+const safeHttpUrl = (value) => {
+  if (!value) return null;
+  try {
+    const parsed = new URL(String(value), window.location.origin);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return parsed.href;
+  } catch (_) {}
+  return null;
 };
 
 async function loadAll() {
@@ -589,17 +638,35 @@ async function loadIdentity() {
 async function loadSessions() {
   const d = await api('/sessions');
   const sessions = d.sessions || d || [];
-  document.getElementById('stat-sessions', sessions.filter?.(s=>s.status==='active').length||0);
+  document.getElementById('stat-sessions').textContent = sessions.filter?.(s=>s.status==='active').length||0;
   const tbody = document.getElementById('sessions-tbody');
-  if (!sessions.length) { tbody.innerHTML='<tr><td colspan="6" class="empty">No sessions</td></tr>'; return; }
-  tbody.innerHTML = sessions.map(s => `<tr>
-    <td class="mono">${(s.session_id||s.id||'').slice(0,12)}...</td>
-    <td>${s.name||'—'}</td>
-    <td>${statusBadge(s.status||'unknown')}</td>
-    <td>${s.operator_id||'—'}</td>
-    <td class="mono" style="max-width:200px;overflow:hidden;text-overflow:ellipsis">${s.current_url||s.start_url||'—'}</td>
-    <td><a href="${s.takeover_url||'#'}" target="_blank" style="color:var(--accent);text-decoration:none">↗ noVNC</a></td>
-  </tr>`).join('');
+  if (!sessions.length) { appendEmptyRow(tbody, 6, 'No sessions'); return; }
+  tbody.replaceChildren();
+  sessions.forEach(s => {
+    const row = document.createElement('tr');
+    const sessionId = asText(s.session_id || s.id, '').slice(0, 12);
+    appendCell(row, sessionId ? `${sessionId}...` : '—', {className: 'mono'});
+    appendCell(row, s.name);
+    appendNodeCell(row, statusBadge(s.status || 'unknown'));
+    appendCell(row, s.operator_id);
+    appendCell(row, s.current_url || s.start_url, {className: 'mono', maxWidth: '200px'});
+    const actionCell = document.createElement('td');
+    const href = safeHttpUrl(s.takeover_url);
+    if (href) {
+      const link = document.createElement('a');
+      link.href = href;
+      link.target = '_blank';
+      link.rel = 'noreferrer';
+      link.style.color = 'var(--accent)';
+      link.style.textDecoration = 'none';
+      link.textContent = 'Open noVNC';
+      actionCell.appendChild(link);
+    } else {
+      actionCell.textContent = '—';
+    }
+    row.appendChild(actionCell);
+    tbody.appendChild(row);
+  });
 }
 
 async function loadWorkflows() {
@@ -607,17 +674,19 @@ async function loadWorkflows() {
   const runs = d.runs || [];
   document.getElementById('stat-workflows').textContent = runs.length;
   const tbody = document.getElementById('workflows-tbody');
-  if (!runs.length) { tbody.innerHTML='<tr><td colspan="5" class="empty">No runs yet</td></tr>'; return; }
-  tbody.innerHTML = runs.slice(0,50).map(r => {
+  if (!runs.length) { appendEmptyRow(tbody, 5, 'No runs yet'); return; }
+  tbody.replaceChildren();
+  runs.slice(0,50).forEach(r => {
     const dur = r.finished_at && r.started_at ? `${((r.finished_at-r.started_at)).toFixed(1)}s` : '—';
-    return `<tr>
-      <td class="mono">${(r.run_id||'').slice(0,12)}...</td>
-      <td>${r.workflow_id||'—'}</td>
-      <td>${statusBadge(r.status||'unknown')}</td>
-      <td>${timeAgo(r.started_at)}</td>
-      <td>${dur}</td>
-    </tr>`;
-  }).join('');
+    const row = document.createElement('tr');
+    const runId = asText(r.run_id, '').slice(0, 12);
+    appendCell(row, runId ? `${runId}...` : '—', {className: 'mono'});
+    appendCell(row, r.workflow_id);
+    appendNodeCell(row, statusBadge(r.status || 'unknown'));
+    appendCell(row, timeAgo(r.started_at));
+    appendCell(row, dur);
+    tbody.appendChild(row);
+  });
 }
 
 async function loadPeers() {
@@ -625,20 +694,31 @@ async function loadPeers() {
   const peers = d.peers || [];
   document.getElementById('stat-peers').textContent = peers.length;
   const tbody = document.getElementById('peers-tbody');
-  if (!peers.length) { tbody.innerHTML='<tr><td colspan="6" class="empty">No peers registered</td></tr>'; return; }
-  tbody.innerHTML = peers.map(p => `<tr>
-    <td class="mono">${(p.node_id||'').slice(0,16)}...</td>
-    <td>${p.display_name||'—'}</td>
-    <td class="mono">${p.endpoint||'—'}</td>
-    <td>${timeAgo(p.last_seen)}</td>
-    <td>${(p.grants||[]).length} grants</td>
-    <td><button class="btn btn-danger btn-sm" onclick="removePeer('${p.node_id}')">Remove</button></td>
-  </tr>`).join('');
+  if (!peers.length) { appendEmptyRow(tbody, 6, 'No peers registered'); return; }
+  tbody.replaceChildren();
+  peers.forEach(p => {
+    const row = document.createElement('tr');
+    const nodeId = asText(p.node_id, '').slice(0, 16);
+    appendCell(row, nodeId ? `${nodeId}...` : '—', {className: 'mono'});
+    appendCell(row, p.display_name);
+    appendCell(row, p.endpoint, {className: 'mono'});
+    appendCell(row, timeAgo(p.last_seen));
+    appendCell(row, `${(p.grants||[]).length} grants`);
+    const actionCell = document.createElement('td');
+    const button = document.createElement('button');
+    button.className = 'btn btn-danger btn-sm';
+    button.type = 'button';
+    button.textContent = 'Remove';
+    button.addEventListener('click', () => removePeer(asText(p.node_id, '')));
+    actionCell.appendChild(button);
+    row.appendChild(actionCell);
+    tbody.appendChild(row);
+  });
 }
 
 async function removePeer(nodeId) {
   if (!confirm('Remove peer ' + nodeId + '?')) return;
-  await fetch('/mesh/peers/' + nodeId, {method:'DELETE', headers: _authHeaders()});
+  await fetch('/mesh/peers/' + encodeURIComponent(nodeId), {method:'DELETE', headers: _authHeaders()});
   loadPeers();
 }
 
@@ -647,14 +727,17 @@ async function loadAudit() {
   const events = d.events || d || [];
   if (Array.isArray(events)) document.getElementById('stat-audit').textContent = events.length;
   const tbody = document.getElementById('audit-tbody');
-  if (!events.length) { tbody.innerHTML='<tr><td colspan="5" class="empty">No audit events</td></tr>'; return; }
-  tbody.innerHTML = events.slice(0,50).map(e => `<tr>
-    <td class="mono">${e.timestamp ? new Date(e.timestamp*1000).toLocaleTimeString() : '—'}</td>
-    <td>${e.operator_id||'—'}</td>
-    <td>${e.action||e.event_type||'—'}</td>
-    <td class="mono">${(e.session_id||'').slice(0,8)||'—'}</td>
-    <td>${statusBadge(e.status||'ok')}</td>
-  </tr>`).join('');
+  if (!events.length) { appendEmptyRow(tbody, 5, 'No audit events'); return; }
+  tbody.replaceChildren();
+  events.slice(0,50).forEach(e => {
+    const row = document.createElement('tr');
+    appendCell(row, formatEventTime(e.timestamp), {className: 'mono'});
+    appendCell(row, e.operator_id);
+    appendCell(row, e.action || e.event_type);
+    appendCell(row, asText(e.session_id, '').slice(0, 8) || '—', {className: 'mono'});
+    appendNodeCell(row, statusBadge(e.status || 'ok'));
+    tbody.appendChild(row);
+  });
 }
 
 // Auto-refresh every 15s

--- a/controller/app/webhooks.py
+++ b/controller/app/webhooks.py
@@ -58,7 +58,7 @@ async def dispatch_approval_event(
         body.update(extra)
 
     raw = json.dumps(body, separators=(",", ":")).encode()
-    headers: dict[str, str] = {"Content-Type": "application/json", "User-Agent": "auto-browser/1.0.0"}
+    headers: dict[str, str] = {"Content-Type": "application/json", "User-Agent": "auto-browser/1.0.1"}
     if webhook_secret:
         headers["X-Webhook-Signature"] = _sign(raw, webhook_secret)
 

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.0.0"
+version = "1.0.1"
 description = "Controller API for auto-browser"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]

--- a/controller/tests/test_dashboard_security.py
+++ b/controller/tests/test_dashboard_security.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import unittest
+
+from app.routes.extensions import _DASHBOARD_HTML
+
+
+class DashboardSecurityTests(unittest.TestCase):
+    def test_dashboard_dynamic_tables_do_not_use_inner_html(self) -> None:
+        self.assertIn("appendCell(row, s.name)", _DASHBOARD_HTML)
+        self.assertIn("document.getElementById('stat-sessions').textContent", _DASHBOARD_HTML)
+        self.assertNotIn("innerHTML", _DASHBOARD_HTML)
+        self.assertNotIn("onclick=\"removePeer", _DASHBOARD_HTML)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_session_store.py
+++ b/controller/tests/test_session_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import tempfile
 import unittest
 from datetime import datetime
@@ -202,3 +203,42 @@ class SessionStoreTests(unittest.IsolatedAsyncioTestCase):
 
         profiles = await self.manager.list_auth_profiles()
         self.assertEqual([item["profile_name"] for item in profiles], ["outlook-default"])
+
+    async def test_auth_profile_export_import_round_trips_profiles_root(self) -> None:
+        artifact_dir = Path(self.settings.artifact_root) / "session-export"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        session = BrowserSession(
+            id="session-export",
+            name="session-export",
+            created_at=datetime.now(UTC),
+            context=FakeContext(),  # type: ignore[arg-type]
+            page=FakePage("https://example.com/export"),  # type: ignore[arg-type]
+            artifact_dir=artifact_dir,
+            auth_dir=Path(self.settings.auth_root) / "session-export",
+            upload_dir=Path(self.settings.upload_root) / "session-export",
+            takeover_url="http://127.0.0.1:6080/vnc.html",
+            trace_path=artifact_dir / "trace.zip",
+        )
+        session.auth_dir.mkdir(parents=True, exist_ok=True)
+        session.upload_dir.mkdir(parents=True, exist_ok=True)
+        self.manager.sessions[session.id] = session
+        self.manager._append_jsonl = AsyncMock()  # type: ignore[method-assign]
+
+        await self.manager.save_auth_profile(session.id, "src-profile")
+        profile_dir = Path(self.settings.auth_root) / "profiles" / "src-profile"
+
+        exported = await self.manager.export_auth_profile("src-profile")
+
+        archive_path = Path(exported["archive_path"])
+        self.assertTrue(archive_path.exists())
+        shutil.rmtree(profile_dir)
+        imported = await self.manager.import_auth_profile(str(archive_path))
+
+        self.assertEqual(imported["profile_name"], "src-profile")
+        self.assertEqual(Path(imported["profile_path"]), profile_dir)
+        self.assertTrue((profile_dir / "state.json").exists())
+        self.assertTrue((profile_dir / "profile.json").exists())
+        self.assertFalse((Path(self.settings.auth_root) / "src-profile").exists())
+
+        profiles = await self.manager.list_auth_profiles()
+        self.assertEqual([item["profile_name"] for item in profiles], ["src-profile"])


### PR DESCRIPTION
## Summary
- reapply the closed CodeQL hardening commit to the main release line
- fix reusable auth profile export/import to round-trip under AUTH_ROOT/profiles
- repair the Python client package build and update stale action/audit REST paths
- render operator dashboard rows with DOM text nodes and validated links instead of innerHTML
- bump controller to 1.0.1 and client SDK to 0.3.1

## Validation
- python -m ruff check . (controller)
- python -m pytest tests/test_session_store.py tests/test_dashboard_security.py -q
- PYTHONPATH=. python -m pytest -q (client)
- python -m pytest tracked controller tests --cov=app --cov-report=term-missing --cov-fail-under=65 -q
- python -m pytest tests -q --ignore=tests/test_playwright_export.py
- python -m unittest discover -s tests -v
- python -m compileall -q controller client integrations
- python -m pip wheel ./client --no-deps
- python -m pip wheel ./controller --no-deps
- python -m pip wheel ./integrations/langchain --no-deps
