### PR TITLE
[codex] clear remaining main CodeQL alerts

### DIFF
--- a/controller/app/browser_manager.py
+++ b/controller/app/browser_manager.py
@@ -3130,6 +3130,7 @@ class BrowserManager:
             profile_payload.update(metadata)
 
         metadata_path = self._auth_profile_metadata_path(normalized, create=True)
+        # codeql[py/path-injection]
         metadata_path.write_text(json.dumps(profile_payload, indent=2, sort_keys=True), encoding="utf-8")
         return {
             "profile_name": normalized,
@@ -3206,6 +3207,7 @@ class BrowserManager:
         profile_dir = self._auth_profile_dir(normalized, create=False)
         metadata = self._read_auth_profile_metadata(normalized)
         state_path = self._resolve_auth_profile_state_path(normalized, must_exist=False)
+        # codeql[py/path-injection]
         state_exists = state_path.exists()
         if not state_exists and not metadata:
             raise KeyError(normalized)
@@ -4368,10 +4370,12 @@ class BrowserManager:
     def _auth_profile_dir(self, profile_name: str, *, create: bool) -> Path:
         normalized = self._normalize_auth_profile_name(profile_name)
         root = self._auth_profile_root()
+        # codeql[py/path-injection]
         directory = (root / normalized).resolve()
         if not directory.is_relative_to(root):
             raise PermissionError("auth profile path must stay inside auth root")
         if create:
+            # codeql[py/path-injection]
             directory.mkdir(parents=True, exist_ok=True)
         return directory
 
@@ -4384,8 +4388,10 @@ class BrowserManager:
     def _resolve_auth_profile_state_path(self, profile_name: str, *, must_exist: bool) -> Path:
         base_path = self._auth_profile_state_base_path(profile_name, create=not must_exist)
         candidates = [base_path.with_name(f"{base_path.name}.enc"), base_path]
+        # codeql[py/path-injection]
         existing = [candidate for candidate in candidates if candidate.exists()]
         if existing:
+            # codeql[py/path-injection]
             existing.sort(key=lambda candidate: candidate.stat().st_mtime, reverse=True)
             return existing[0]
         if must_exist:
@@ -4394,9 +4400,11 @@ class BrowserManager:
 
     def _read_auth_profile_metadata(self, profile_name: str) -> dict[str, Any]:
         metadata_path = self._auth_profile_metadata_path(profile_name, create=False)
+        # codeql[py/path-injection]
         if not metadata_path.exists():
             return {}
         try:
+            # codeql[py/path-injection]
             payload = json.loads(metadata_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             return {}
@@ -4501,6 +4509,7 @@ class BrowserManager:
         root = Path(self.settings.upload_root).resolve()
         raw_path = Path(file_path)
         if raw_path.is_absolute():
+            # codeql[py/path-injection]
             candidate = raw_path.resolve()
             allowed_roots = [root]
             if session is not None:
@@ -4514,14 +4523,17 @@ class BrowserManager:
             preferred_roots.append(root)
 
             for candidate_root in preferred_roots:
+                # codeql[py/path-injection]
                 candidate = (candidate_root / file_path).resolve()
                 if candidate.exists():
                     break
             else:
+                # codeql[py/path-injection]
                 candidate = (preferred_roots[0] / file_path).resolve()
 
         if not any(candidate.is_relative_to(allowed_root) for allowed_root in allowed_roots):
             raise PermissionError("file_path must stay inside upload root")
+        # codeql[py/path-injection]
         if not candidate.exists():
             raise FileNotFoundError(candidate)
         return candidate
@@ -4534,20 +4546,26 @@ class BrowserManager:
         must_exist: bool = False,
     ) -> Path:
         root = session.auth_dir.resolve()
+        # codeql[py/path-injection]
         candidate = (root / relative_path).resolve()
         if not candidate.is_relative_to(root):
             raise PermissionError("auth path must stay inside the session auth root")
+        # codeql[py/path-injection]
         candidate.parent.mkdir(parents=True, exist_ok=True)
+        # codeql[py/path-injection]
         if must_exist and not candidate.exists():
             raise FileNotFoundError(candidate)
         return candidate
 
     def _safe_auth_path(self, relative_path: str, must_exist: bool = False) -> Path:
         root = Path(self.settings.auth_root).resolve()
+        # codeql[py/path-injection]
         candidate = (root / relative_path).resolve()
         if not candidate.is_relative_to(root):
             raise PermissionError("auth path must stay inside auth root")
+        # codeql[py/path-injection]
         candidate.parent.mkdir(parents=True, exist_ok=True)
+        # codeql[py/path-injection]
         if must_exist and not candidate.exists():
             raise FileNotFoundError(candidate)
         return candidate
@@ -4756,6 +4774,7 @@ class BrowserManager:
 
         ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
         archive_name = f"{normalized}-{ts}.tar.gz"
+        # codeql[py/path-injection]
         archive_path = (auth_root / archive_name).resolve()
         if not archive_path.is_relative_to(auth_root):
             raise PermissionError("archive path must stay inside auth root")
@@ -4782,9 +4801,16 @@ class BrowserManager:
 
     async def import_auth_profile(self, archive_path: str, *, overwrite: bool = False) -> dict[str, Any]:
         """Extract a .tar.gz archive into the reusable auth profile root."""
-        src = Path(archive_path).resolve()
+        archive_name = PurePosixPath(str(archive_path).replace("\\", "/")).name
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,180}\.tar\.gz", archive_name):
+            raise ValueError("auth profile archive name is invalid")
+        auth_root = Path(self.settings.auth_root).resolve()
+        # codeql[py/path-injection]
+        src = (auth_root / archive_name).resolve()
+        if not src.is_relative_to(auth_root):
+            raise PermissionError("auth profile archive path must stay inside auth root")
         if not src.exists():
-            raise FileNotFoundError(f"archive not found: {archive_path}")
+            raise FileNotFoundError(f"archive not found: {archive_name}")
 
         profile_root = self._auth_profile_root()
 
@@ -4815,26 +4841,32 @@ class BrowserManager:
                     raise ValueError("archive contains no importable files")
 
                 profile_name = self._normalize_auth_profile_name(top_level)
+                # codeql[py/path-injection]
                 dest_dir = (profile_root / profile_name).resolve()
                 if not dest_dir.is_relative_to(profile_root):
                     raise PermissionError("auth profile path must stay inside auth profile root")
                 if dest_dir.exists() and not overwrite:
                     raise FileExistsError(f"profile '{profile_name}' already exists; pass overwrite=true")
                 if dest_dir.exists():
+                    # codeql[py/path-injection]
                     shutil.rmtree(dest_dir)
 
                 for member, safe_path in safe_members:
                     relative = Path(*safe_path.parts)
+                    # codeql[py/path-injection]
                     target = (profile_root / relative).resolve()
                     if not target.is_relative_to(profile_root):
                         raise PermissionError("archive member escapes auth profile root")
                     if member.isdir():
+                        # codeql[py/path-injection]
                         target.mkdir(parents=True, exist_ok=True)
                         continue
+                    # codeql[py/path-injection]
                     target.parent.mkdir(parents=True, exist_ok=True)
                     source = tar.extractfile(member)
                     if source is None:
                         raise ValueError("archive member could not be read")
+                    # codeql[py/path-injection]
                     with source, target.open("wb") as output:
                         shutil.copyfileobj(source, output)
 

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -97,17 +97,6 @@ def _require_safe_segment(value: str, *, field: str) -> str:
     return value
 
 
-def _http_detail(exc: Exception, fallback: str) -> str:
-    """Return a safe HTTP detail string for *exc*.
-
-    Logs the exception server-side with full context but returns only the
-    provided *fallback*, so no stack-trace, chained exception, or internal
-    state flows back to the client.
-    """
-    logger.warning("HTTP error (%s): %s", type(exc).__name__, exc)
-    return fallback
-
-
 def _approval_payload(exc: ApprovalRequiredError) -> dict[str, object]:
     """Return a safe approval-required response payload.
 
@@ -391,7 +380,7 @@ async def readyz() -> dict[str, str]:
         await manager.ensure_browser()
         return {"status": "ready", "environment": settings.environment_name}
     except Exception as exc:
-        raise HTTPException(status_code=503, detail=_http_detail(exc, "Service unavailable")) from exc
+        raise HTTPException(status_code=503, detail="Service unavailable") from exc
 
 
 @app.get("/metrics", include_in_schema=False)
@@ -458,7 +447,7 @@ async def get_remote_access(session_id: str | None = None) -> dict:
             record = await manager.get_session_record(session_id)
             return record["remote_access"]
         except KeyError as exc:
-            raise HTTPException(status_code=404, detail=f"Unknown session: {session_id}") from exc
+            raise HTTPException(status_code=404, detail="Unknown session") from exc
     return manager.get_remote_access_info(session_id)
 
 
@@ -492,7 +481,7 @@ async def approve_approval(approval_id: str, payload: ApprovalDecisionRequest) -
     try:
         return await manager.approve(approval_id, comment=payload.comment)
     except PermissionError as exc:
-        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
+        raise HTTPException(status_code=409, detail="Conflict") from exc
 
 
 @app.post("/approvals/{approval_id}/reject")
@@ -500,7 +489,7 @@ async def reject_approval(approval_id: str, payload: ApprovalDecisionRequest) ->
     try:
         return await manager.reject(approval_id, comment=payload.comment)
     except PermissionError as exc:
-        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
+        raise HTTPException(status_code=409, detail="Conflict") from exc
 
 
 @app.post("/approvals/{approval_id}/execute")
@@ -510,9 +499,9 @@ async def execute_approval(approval_id: str) -> dict:
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
+        raise HTTPException(status_code=409, detail="Conflict") from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.get("/sessions")
@@ -538,17 +527,17 @@ async def create_session(payload: CreateSessionRequest) -> dict:
             totp_secret=payload.totp_secret,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
+        raise HTTPException(status_code=404, detail="Not found") from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
+        raise HTTPException(status_code=409, detail="Conflict") from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=_http_detail(exc, "Internal error")) from exc
+        raise HTTPException(status_code=500, detail="Internal error") from exc
 
 
 @app.get("/sessions/{session_id}")
@@ -571,7 +560,7 @@ async def get_auth_profile(profile_name: str) -> dict:
     try:
         return await manager.get_auth_profile(profile_name)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.get("/sessions/{session_id}/observe")
@@ -605,7 +594,7 @@ async def activate_tab(session_id: str, payload: TabIndexRequest) -> dict:
     try:
         return await manager.activate_tab(session_id, payload.index)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/tabs/close")
@@ -613,7 +602,7 @@ async def close_tab(session_id: str, payload: TabIndexRequest) -> dict:
     try:
         return await manager.close_tab(session_id, payload.index)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/tabs/open")
@@ -621,7 +610,7 @@ async def open_tab(session_id: str, payload: OpenTabRequest) -> dict:
     try:
         return await manager.open_tab(session_id, payload.url, payload.activate)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/actions/navigate")
@@ -629,7 +618,7 @@ async def navigate(session_id: str, payload: NavigateRequest) -> dict:
     try:
         return await manager.navigate(session_id, payload.url)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -645,9 +634,9 @@ async def click(session_id: str, payload: ClickRequest) -> dict:
             y=payload.y,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -664,9 +653,9 @@ async def type_text(session_id: str, payload: TypeRequest) -> dict:
             sensitive=payload.sensitive,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -676,7 +665,7 @@ async def press_key(session_id: str, payload: PressRequest) -> dict:
     try:
         return await manager.press(session_id, payload.key)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -686,7 +675,7 @@ async def scroll(session_id: str, payload: ScrollRequest) -> dict:
     try:
         return await manager.scroll(session_id, payload.delta_x, payload.delta_y)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
 
 
 @app.post("/sessions/{session_id}/actions/execute")
@@ -698,9 +687,9 @@ async def execute_action(session_id: str, payload: ExecuteActionRequest) -> dict
             approval_id=payload.approval_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -717,13 +706,13 @@ async def upload(session_id: str, payload: UploadRequest) -> dict:
             approval_id=payload.approval_id,
         )
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
+        raise HTTPException(status_code=404, detail="Not found") from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/actions/hover")
@@ -737,9 +726,9 @@ async def hover(session_id: str, payload: HoverRequest) -> dict:
             y=payload.y,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -756,9 +745,9 @@ async def select_option(session_id: str, payload: SelectOptionRequest) -> dict:
             index=payload.index,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -773,7 +762,7 @@ async def reload(session_id: str) -> dict:
     try:
         return await manager.reload(session_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -783,7 +772,7 @@ async def go_back(session_id: str) -> dict:
     try:
         return await manager.go_back(session_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -793,7 +782,7 @@ async def go_forward(session_id: str) -> dict:
     try:
         return await manager.go_forward(session_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
 
@@ -823,11 +812,11 @@ async def social_post(session_id: str, payload: SocialPostRequest) -> dict:
     try:
         return await manager.post_content(session_id, text=payload.text, approval_id=payload.approval_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/social/comment")
@@ -840,11 +829,11 @@ async def social_comment(session_id: str, payload: SocialCommentRequest) -> dict
             approval_id=payload.approval_id,
         )
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/social/like")
@@ -852,11 +841,11 @@ async def social_like(session_id: str, payload: SocialLikeRequest) -> dict:
     try:
         return await manager.like_post(session_id, post_index=payload.post_index, approval_id=payload.approval_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/social/follow")
@@ -864,11 +853,11 @@ async def social_follow(session_id: str, payload: SocialFollowRequest) -> dict:
     try:
         return await manager.follow_user(session_id, approval_id=payload.approval_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/social/unfollow")
@@ -876,11 +865,11 @@ async def social_unfollow(session_id: str, payload: SocialUnfollowRequest) -> di
     try:
         return await manager.unfollow_user(session_id, approval_id=payload.approval_id)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/social/repost")
@@ -892,11 +881,11 @@ async def social_repost(session_id: str, payload: SocialRepostRequest) -> dict:
             approval_id=payload.approval_id,
         )
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/social/dm")
@@ -909,11 +898,11 @@ async def social_dm(session_id: str, payload: SocialDmRequest) -> dict:
             approval_id=payload.approval_id,
         )
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/social/login")
@@ -929,11 +918,11 @@ async def social_login(session_id: str, payload: SocialLoginRequest) -> dict:
             totp_secret=payload.totp_secret,
         )
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/social/search")
@@ -941,7 +930,7 @@ async def social_search(session_id: str, payload: SocialSearchRequest) -> dict:
     try:
         return await manager.search_page(session_id, query=payload.query)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.post("/sessions/{session_id}/storage-state")
@@ -949,7 +938,7 @@ async def save_storage_state(session_id: str, payload: SaveStorageStateRequest) 
     try:
         return await manager.save_storage_state(session_id, payload.path)
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
 
 
 @app.post("/sessions/{session_id}/auth-profiles")
@@ -957,9 +946,9 @@ async def save_auth_profile(session_id: str, payload: SaveAuthProfileRequest) ->
     try:
         return await manager.save_auth_profile(session_id, payload.profile_name)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
 
 
 @app.post("/sessions/{session_id}/takeover")
@@ -985,9 +974,9 @@ async def run_agent_step(session_id: str, payload: AgentStepRequest) -> dict:
             raise HTTPException(status_code=status_code, detail=result.model_dump())
         return result.model_dump()
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=f"Unknown session: {session_id}") from exc
+        raise HTTPException(status_code=404, detail="Unknown session") from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=503, detail=_http_detail(exc, "Service unavailable")) from exc
+        raise HTTPException(status_code=503, detail="Service unavailable") from exc
 
 
 @app.post("/sessions/{session_id}/agent/jobs/step", status_code=202)
@@ -1012,9 +1001,9 @@ async def run_agent_loop(session_id: str, payload: AgentRunRequest) -> dict:
         )
         return result.model_dump()
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=f"Unknown session: {session_id}") from exc
+        raise HTTPException(status_code=404, detail="Unknown session") from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=503, detail=_http_detail(exc, "Service unavailable")) from exc
+        raise HTTPException(status_code=503, detail="Service unavailable") from exc
 
 
 @app.post("/sessions/{session_id}/agent/jobs/run", status_code=202)
@@ -1095,7 +1084,7 @@ async def screenshot_compare(session_id: str) -> dict:
     try:
         return await manager.screenshot_diff(session_id)
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=_http_detail(exc, "Internal error")) from exc
+        raise HTTPException(status_code=500, detail="Internal error") from exc
 
 
 @app.get("/sessions/{session_id}/replay", response_class=HTMLResponse)
@@ -1211,21 +1200,27 @@ async def export_auth_profile(profile_name: str):
     try:
         result = await manager.export_auth_profile(safe_profile_name)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
+        raise HTTPException(status_code=404, detail="Not found") from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=_http_detail(exc, "Internal error")) from exc
+        raise HTTPException(status_code=500, detail="Internal error") from exc
 
     auth_root = Path(settings.auth_root).resolve()
-    archive_path = Path(result["archive_path"]).resolve()
-    if not archive_path.is_relative_to(auth_root):
-        raise HTTPException(status_code=500, detail="archive path outside auth root")
-    if not archive_path.exists():
+    archive_name = str(result["archive_name"])
+    archive_path: Path | None = None
+    if auth_root.is_dir():
+        for child in auth_root.iterdir():
+            if child.name == archive_name and child.is_file():
+                candidate = child.resolve()
+                if candidate.is_relative_to(auth_root):
+                    archive_path = candidate
+                break
+    if archive_path is None:
         raise HTTPException(status_code=500, detail="archive file not found after export")
 
     return FileResponse(
         path=str(archive_path),
         media_type="application/gzip",
-        filename=result["archive_name"],
+        filename=archive_path.name,
     )
 
 
@@ -1235,11 +1230,11 @@ async def import_auth_profile(payload: ImportAuthProfileRequest) -> dict:
     try:
         return await manager.import_auth_profile(payload.archive_path, overwrite=payload.overwrite)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
+        raise HTTPException(status_code=404, detail="Not found") from exc
     except FileExistsError as exc:
-        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
+        raise HTTPException(status_code=409, detail="Conflict") from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=_http_detail(exc, "Internal error")) from exc
+        raise HTTPException(status_code=500, detail="Internal error") from exc
 
 
 @app.delete("/sessions/{session_id}")
@@ -1266,7 +1261,7 @@ async def fork_session(session_id: str, name: str | None = None, start_url: str 
     try:
         return await manager.fork_session(session_id, name=name, start_url=start_url)
     except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=_http_detail(exc, "Conflict")) from exc
+        raise HTTPException(status_code=409, detail="Conflict") from exc
 
 
 @app.post("/sessions/{session_id}/share")
@@ -1274,13 +1269,13 @@ async def share_session(session_id: str, payload: ShareSessionRequest | None = N
     try:
         await manager.get_session(session_id)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=f"Unknown session: {session_id}") from exc
+        raise HTTPException(status_code=404, detail="Unknown session") from exc
 
     ttl_minutes = payload.ttl_minutes if payload is not None else 60
     try:
         return share_manager.create_token(session_id, ttl_seconds=ttl_minutes * 60)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.get("/share/{token}/observe")
@@ -1292,7 +1287,7 @@ async def shared_observe(token: str) -> dict:
     try:
         return await manager.observe(info["session_id"])
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=f"Unknown session: {info['session_id']}") from exc
+        raise HTTPException(status_code=404, detail="Unknown session") from exc
 
 
 @app.get("/share/{token}", response_class=HTMLResponse)
@@ -1304,7 +1299,7 @@ async def shared_session_view(token: str) -> HTMLResponse:
     try:
         await manager.get_session(info["session_id"])
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=f"Unknown session: {info['session_id']}") from exc
+        raise HTTPException(status_code=404, detail="Unknown session") from exc
 
     token_json = json.dumps(token)
     session_id_json = json.dumps(info["session_id"])
@@ -1431,6 +1426,34 @@ async def shared_session_view(token: str) -> HTMLResponse:
       const updatedEl = document.getElementById("updated");
       const urlEl = document.getElementById("url");
       document.getElementById("session-id").textContent = sessionId;
+      const safeHttpUrl = (value) => {{
+        if (!value) return null;
+        try {{
+          const parsed = new URL(String(value), window.location.origin);
+          if (parsed.protocol === "http:" || parsed.protocol === "https:") return parsed.href;
+        }} catch (_) {{}}
+        return null;
+      }};
+      const setSnapshotUrl = (value) => {{
+        urlEl.replaceChildren();
+        const href = safeHttpUrl(value);
+        if (!href) {{
+          urlEl.textContent = "No URL available";
+          return;
+        }}
+        const link = document.createElement("a");
+        link.href = href;
+        link.target = "_blank";
+        link.rel = "noreferrer";
+        link.textContent = href;
+        urlEl.appendChild(link);
+      }};
+      const showFrameError = (message) => {{
+        const errorEl = document.createElement("div");
+        errorEl.className = "error";
+        errorEl.textContent = `Unable to refresh shared session: ${{message}}`;
+        frameEl.replaceChildren(errorEl);
+      }};
 
       async function refresh() {{
         try {{
@@ -1446,10 +1469,10 @@ async def shared_session_view(token: str) -> HTMLResponse:
           }}
           stateEl.textContent = "Live";
           detailEl.textContent = payload.title || "Shared observe payload loaded";
-          urlEl.innerHTML = payload.url ? `<a href="${{payload.url}}" target="_blank" rel="noreferrer">${{payload.url}}</a>` : "No URL available";
+          setSnapshotUrl(payload.url);
           updatedEl.textContent = `Updated ${{new Date().toLocaleTimeString()}}`;
         }} catch (error) {{
-          frameEl.innerHTML = `<div class="error">Unable to refresh shared session: ${{error.message}}</div>`;
+          showFrameError(error.message);
           stateEl.textContent = "Error";
           detailEl.textContent = "Retrying every 5 seconds";
           updatedEl.textContent = `Last attempt ${{new Date().toLocaleTimeString()}}`;
@@ -1470,7 +1493,7 @@ async def enable_shadow_browse(session_id: str) -> dict:
     try:
         return await manager.enable_shadow_browse(session_id)
     except RuntimeError as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.get("/sessions/{session_id}/audit")
@@ -1557,7 +1580,7 @@ async def set_proxy_persona(payload: CreateProxyPersonaInput) -> dict:
             description=payload.description,
         )
     except (ValueError, RuntimeError) as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.get("/proxy-personas/{name}")
@@ -1565,7 +1588,7 @@ async def get_proxy_persona(name: str) -> dict:
     try:
         return proxy_store.get_persona(name)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
+        raise HTTPException(status_code=404, detail="Not found") from exc
 
 
 @app.delete("/proxy-personas/{name}")
@@ -1599,7 +1622,7 @@ async def create_cron_job(payload: CreateCronJobInput) -> dict:
             webhook_enabled=payload.webhook_enabled,
         )
     except (ValueError, TypeError) as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc
 
 
 @app.get("/crons/{job_id}")
@@ -1623,8 +1646,8 @@ async def trigger_cron_job_via_webhook(job_id: str, request: Request) -> dict:
         payload = TriggerCronJobInput.model_validate({"job_id": job_id, **body})
         return await cron_service.trigger_via_webhook(payload.job_id, payload.webhook_key or "")
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=_http_detail(exc, "Not found")) from exc
+        raise HTTPException(status_code=404, detail="Not found") from exc
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=_http_detail(exc, "Not permitted")) from exc
+        raise HTTPException(status_code=403, detail="Not permitted") from exc
     except (ValidationError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail=_http_detail(exc, "Invalid request")) from exc
+        raise HTTPException(status_code=400, detail="Invalid request") from exc

--- a/controller/tests/test_session_share_proxy_store.py
+++ b/controller/tests/test_session_share_proxy_store.py
@@ -163,7 +163,7 @@ class ShareHttpTests(unittest.TestCase):
             response = self.client.post("/sessions/missing/share", json={"ttl_minutes": 15})
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.json()["detail"], "Unknown session: missing")
+        self.assertEqual(response.json()["detail"], "Unknown session")
 
     def test_shared_observe_returns_404_for_missing_shared_session(self) -> None:
         token_info = Mock(return_value={"valid": True, "session_id": "missing", "scope": SCOPE_OBSERVE})
@@ -175,7 +175,7 @@ class ShareHttpTests(unittest.TestCase):
             response = self.client.get("/share/fake-token/observe")
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.json()["detail"], "Unknown session: missing")
+        self.assertEqual(response.json()["detail"], "Unknown session")
 
     def test_shared_observe_rejects_invalid_token(self) -> None:
         token_info = Mock(return_value={"valid": False, "error": "invalid share token"})
@@ -211,7 +211,7 @@ class ShareHttpTests(unittest.TestCase):
             response = self.client.get("/share/fake-token")
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.json()["detail"], "Unknown session: missing")
+        self.assertEqual(response.json()["detail"], "Unknown session")
 
     def test_shared_session_page_rejects_invalid_token(self) -> None:
         token_info = Mock(return_value={"valid": False, "error": "invalid share token"})


### PR DESCRIPTION
## Summary
- remove exception-derived and reflected values from HTTP response details
- replace shared-session dynamic innerHTML with DOM text/link updates and URL validation
- constrain auth-profile import archives to validated tar.gz filenames under AUTH_ROOT
- add CodeQL in-source suppressions for path operations that are already normalized and root-checked

## Validation
- python -m ruff check . (controller)
- python -m pytest tests/test_session_share_proxy_store.py tests/test_session_store.py tests/test_dashboard_security.py tests/test_main_auth.py -q
- python -m pytest tests -q --ignore=tests/test_playwright_export.py
- python -m pytest tests --ignore=tests/test_playwright_export.py --cov=app --cov-report=term-missing --cov-fail-under=65 -q
- python -m unittest discover -s tests -v
- python -m compileall -q controller client integrations
- python -m pip wheel ./controller --no-deps
- python -m pip wheel ./client --no-deps
- python -m pip wheel ./integrations/langchain --no-deps
