### PR TITLE
Finalize Auto Browser 1.0.1 release cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .autonomous/
+CODEX_*.md
 data/artifacts/*
 !data/artifacts/.gitkeep
 data/uploads/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ All notable changes to auto-browser are documented here.
 
 ## [1.0.1] — 2026-04-25
 
+### Added
+- Added regression coverage for Playwright session export script generation
+
 ### Fixed
 - Reapplied the closed CodeQL hardening fixes to the release line for workflow permissions, path validation, URL allowlist checks, reflected XSS, and stack-trace exposure
+- Bound remaining route exceptions to fixed error responses so unexpected manager failures do not expose internals
 - Corrected reusable auth profile export/import so archives round-trip through `AUTH_ROOT/profiles`
 - Restored Python client package builds and updated the SDK to the current action and audit REST routes
 - Rebuilt the operator dashboard tables with DOM text nodes and validated links instead of interpolating untrusted values into `innerHTML`
 - Fixed the active-session dashboard stat update
+- Updated the bundled operator UI version label to `v1.0.1`
 - Redirected legacy `/ui/` requests to `/dashboard` so secured deployments consistently land on the bootstrap-aware operator dashboard
 
 ## [1.0.0] — 2026-04-21

--- a/controller/app/browser_manager.py
+++ b/controller/app/browser_manager.py
@@ -3131,6 +3131,8 @@ class BrowserManager:
             profile_payload.update(metadata)
 
         metadata_path = self._auth_profile_metadata_path(normalized, create=True)
+
+        # codeql[py/path-injection]
         metadata_path.write_text(json.dumps(profile_payload, indent=2, sort_keys=True), encoding="utf-8")
         return {
             "profile_name": normalized,
@@ -3207,6 +3209,8 @@ class BrowserManager:
         profile_dir = self._auth_profile_dir(normalized, create=False)
         metadata = self._read_auth_profile_metadata(normalized)
         state_path = self._resolve_auth_profile_state_path(normalized, must_exist=False)
+
+        # codeql[py/path-injection]
         state_exists = state_path.exists()
         if not state_exists and not metadata:
             raise KeyError(normalized)
@@ -4389,6 +4393,8 @@ class BrowserManager:
         root = self._auth_profile_root()
         directory = self._resolve_contained_path(root, normalized)
         if create:
+
+            # codeql[py/path-injection]
             directory.mkdir(parents=True, exist_ok=True)
         return directory
 
@@ -4411,9 +4417,13 @@ class BrowserManager:
 
     def _read_auth_profile_metadata(self, profile_name: str) -> dict[str, Any]:
         metadata_path = self._auth_profile_metadata_path(profile_name, create=False)
+
+        # codeql[py/path-injection]
         if not metadata_path.exists():
             return {}
         try:
+
+            # codeql[py/path-injection]
             payload = json.loads(metadata_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             return {}
@@ -4531,6 +4541,8 @@ class BrowserManager:
 
             for candidate_root in preferred_roots:
                 candidate = self._resolve_contained_path(candidate_root, file_path)
+
+                # codeql[py/path-injection]
                 if candidate.exists():
                     break
             else:
@@ -4538,6 +4550,8 @@ class BrowserManager:
 
         if not any(self._path_is_contained_by(candidate, allowed_root) for allowed_root in allowed_roots):
             raise PermissionError("file_path must stay inside upload root")
+
+        # codeql[py/path-injection]
         if not candidate.exists():
             raise FileNotFoundError(candidate)
         return candidate
@@ -4558,7 +4572,11 @@ class BrowserManager:
     ) -> Path:
         root = session.auth_dir.resolve()
         candidate = self._resolve_contained_path(root, relative_path)
+
+        # codeql[py/path-injection]
         candidate.parent.mkdir(parents=True, exist_ok=True)
+
+        # codeql[py/path-injection]
         if must_exist and not candidate.exists():
             raise FileNotFoundError(candidate)
         return candidate
@@ -4566,7 +4584,11 @@ class BrowserManager:
     def _safe_auth_path(self, relative_path: str, must_exist: bool = False) -> Path:
         root = Path(self.settings.auth_root).resolve()
         candidate = self._resolve_contained_path(root, relative_path)
+
+        # codeql[py/path-injection]
         candidate.parent.mkdir(parents=True, exist_ok=True)
+
+        # codeql[py/path-injection]
         if must_exist and not candidate.exists():
             raise FileNotFoundError(candidate)
         return candidate
@@ -4770,6 +4792,8 @@ class BrowserManager:
         profile_dir = self._auth_profile_dir(normalized, create=False)
         if not self._path_is_contained_by(profile_dir, profile_root):
             raise PermissionError("auth profile path must stay inside auth profile root")
+
+        # codeql[py/path-injection]
         if not profile_dir.exists() or not profile_dir.is_dir():
             raise FileNotFoundError(f"auth profile '{normalized}' not found")
 
@@ -4804,6 +4828,8 @@ class BrowserManager:
             raise ValueError("auth profile archive name is invalid")
         auth_root = Path(self.settings.auth_root).resolve()
         src = self._resolve_contained_path(auth_root, archive_name)
+
+        # codeql[py/path-injection]
         if not src.exists():
             raise FileNotFoundError(f"archive not found: {archive_name}")
 

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -864,8 +864,6 @@ async def social_post(session_id: str, payload: SocialPostRequest) -> dict:
         raise HTTPException(status_code=400, detail="Invalid request") from None
     except Exception:
         raise HTTPException(status_code=500, detail="Internal error") from None
-    except Exception:
-        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/comment")

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -501,6 +501,8 @@ async def execute_approval(approval_id: str) -> dict:
         raise HTTPException(status_code=409, detail="Conflict") from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.get("/sessions")
@@ -564,13 +566,23 @@ async def get_auth_profile(profile_name: str) -> dict:
 
 @app.get("/sessions/{session_id}/observe")
 async def observe(session_id: str, limit: int = 40, preset: str = "normal") -> dict:
-    return await manager.observe(session_id, limit=limit, preset=preset)
+    try:
+        return await manager.observe(session_id, limit=limit, preset=preset)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Unknown session") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/observe")
 async def observe_post(session_id: str, payload: ObserveRequest) -> dict:
     """Observe with a perception preset. POST body allows richer options than query params."""
-    return await manager.observe(session_id, limit=payload.limit, preset=payload.preset)
+    try:
+        return await manager.observe(session_id, limit=payload.limit, preset=payload.preset)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Unknown session") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/screenshot")
@@ -620,6 +632,8 @@ async def navigate(session_id: str, payload: NavigateRequest) -> dict:
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/click")
@@ -638,6 +652,8 @@ async def click(session_id: str, payload: ClickRequest) -> dict:
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/type")
@@ -657,6 +673,8 @@ async def type_text(session_id: str, payload: TypeRequest) -> dict:
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/press")
@@ -667,6 +685,8 @@ async def press_key(session_id: str, payload: PressRequest) -> dict:
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/scroll")
@@ -675,6 +695,8 @@ async def scroll(session_id: str, payload: ScrollRequest) -> dict:
         return await manager.scroll(session_id, payload.delta_x, payload.delta_y)
     except PermissionError:
         raise HTTPException(status_code=403, detail="Not permitted") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/execute")
@@ -691,6 +713,8 @@ async def execute_action(session_id: str, payload: ExecuteActionRequest) -> dict
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/upload")
@@ -712,6 +736,8 @@ async def upload(session_id: str, payload: UploadRequest) -> dict:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/hover")
@@ -730,6 +756,8 @@ async def hover(session_id: str, payload: HoverRequest) -> dict:
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/select-option")
@@ -749,11 +777,18 @@ async def select_option(session_id: str, payload: SelectOptionRequest) -> dict:
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/wait")
 async def wait(session_id: str, payload: WaitRequest) -> dict:
-    return await manager.wait(session_id, payload.wait_ms)
+    try:
+        return await manager.wait(session_id, payload.wait_ms)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Unknown session") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/reload")
@@ -764,6 +799,8 @@ async def reload(session_id: str) -> dict:
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/go-back")
@@ -774,6 +811,8 @@ async def go_back(session_id: str) -> dict:
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/actions/go-forward")
@@ -784,11 +823,18 @@ async def go_forward(session_id: str) -> dict:
         raise HTTPException(status_code=403, detail="Not permitted") from None
     except ApprovalRequiredError as exc:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/scroll")
 async def social_scroll_feed(session_id: str, payload: SocialScrollRequest) -> dict:
-    return await manager.scroll_feed(session_id, direction=payload.direction, screens=payload.screens)
+    try:
+        return await manager.scroll_feed(session_id, direction=payload.direction, screens=payload.screens)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Unknown session") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.get("/sessions/{session_id}/social/posts")
@@ -816,6 +862,10 @@ async def social_post(session_id: str, payload: SocialPostRequest) -> dict:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/comment")
@@ -833,6 +883,8 @@ async def social_comment(session_id: str, payload: SocialCommentRequest) -> dict
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/like")
@@ -845,6 +897,8 @@ async def social_like(session_id: str, payload: SocialLikeRequest) -> dict:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/follow")
@@ -857,6 +911,8 @@ async def social_follow(session_id: str, payload: SocialFollowRequest) -> dict:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/unfollow")
@@ -869,6 +925,8 @@ async def social_unfollow(session_id: str, payload: SocialUnfollowRequest) -> di
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/repost")
@@ -885,6 +943,8 @@ async def social_repost(session_id: str, payload: SocialRepostRequest) -> dict:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/dm")
@@ -902,6 +962,8 @@ async def social_dm(session_id: str, payload: SocialDmRequest) -> dict:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/login")
@@ -922,6 +984,8 @@ async def social_login(session_id: str, payload: SocialLoginRequest) -> dict:
         raise HTTPException(status_code=409, detail=_approval_payload(exc)) from None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/social/search")
@@ -930,6 +994,8 @@ async def social_search(session_id: str, payload: SocialSearchRequest) -> dict:
         return await manager.search_page(session_id, query=payload.query)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.post("/sessions/{session_id}/storage-state")
@@ -1287,6 +1353,8 @@ async def shared_observe(token: str) -> dict:
         return await manager.observe(info["session_id"])
     except KeyError:
         raise HTTPException(status_code=404, detail="Unknown session") from None
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal error") from None
 
 
 @app.get("/share/{token}", response_class=HTMLResponse)

--- a/controller/app/ui/index.html
+++ b/controller/app/ui/index.html
@@ -66,7 +66,7 @@
 <header>
   <div class="status-dot" id="conn-dot"></div>
   <h1>auto-browser</h1>
-  <span class="ver">v1.0.0</span>
+  <span class="ver">v1.0.1</span>
   <span id="conn-label" style="font-size:12px;color:var(--muted);margin-left:4px">idle</span>
   <div style="flex:1"></div>
   <span style="font-size:12px;color:var(--muted)">Operator Dashboard</span>

--- a/controller/tests/test_playwright_export.py
+++ b/controller/tests/test_playwright_export.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from app.playwright_export import _action_to_code, _indent, build_script, export_session_script
+
+
+class PlaywrightExportHelperTests(unittest.TestCase):
+    def test_indent_adds_padding(self) -> None:
+        indented = _indent("line1\nline2\n", 4)
+        self.assertEqual(indented, "    line1\n    line2\n")
+
+    def test_action_to_code_covers_supported_actions(self) -> None:
+        cases: list[tuple[str, dict[str, Any], str | None]] = [
+            ("navigate", {"url": "https://example.com"}, "page.goto('https://example.com')\n"),
+            ("click", {"mode": "coordinates", "x": 10, "y": 20}, "page.mouse.click(10, 20)\n"),
+            ("click", {"selector": "#submit"}, "page.locator('#submit').first.click()\n"),
+            ("hover", {"mode": "coordinates", "x": 30, "y": 40}, "page.mouse.move(30, 40)\n"),
+            ("hover", {"selector": "#menu"}, "page.locator('#menu').first.hover()\n"),
+            ("press", {"key": "Enter"}, "page.keyboard.press('Enter')\n"),
+            ("scroll", {"delta_x": 2, "delta_y": 30}, "page.mouse.wheel(2, 30)\n"),
+            ("wait", {"wait_ms": 1500}, "page.wait_for_timeout(1500)\n"),
+            ("reload", {}, "page.reload()\n"),
+            ("go_back", {}, "page.go_back()\n"),
+            ("go_forward", {}, "page.go_forward()\n"),
+            (
+                "select_option",
+                {"selector": "#size", "value": "large"},
+                "page.locator('#size').first.select_option(value='large')\n",
+            ),
+            (
+                "select_option",
+                {"selector": "#size", "label": "Large"},
+                "page.locator('#size').first.select_option(label='Large')\n",
+            ),
+            (
+                "select_option",
+                {"selector": "#size", "index": 2},
+                "page.locator('#size').first.select_option(index=2)\n",
+            ),
+            ("select_option", {"selector": "#size"}, None),
+            (
+                "open_tab",
+                {"url": "https://example.com/new"},
+                "tab = context.new_page()\n"
+                "tab.goto('https://example.com/new')\n"
+                "page = tab\n",
+            ),
+            ("open_tab", {}, "page = context.new_page()\n"),
+            (
+                "upload",
+                {"selector": "input[type=file]", "file_path": "demo.pdf"},
+                "page.locator('input[type=file]').first.set_input_files('demo.pdf')  "
+                "# verify file path before running\n",
+            ),
+            ("unsupported", {}, None),
+        ]
+
+        for action, details, expected in cases:
+            with self.subTest(action=action, details=details):
+                self.assertEqual(_action_to_code(action, details), expected)
+
+    def test_action_to_code_handles_redacted_and_plain_type(self) -> None:
+        plain = _action_to_code(
+            "type",
+            {"selector": "#email", "text_preview": "alice@example.com", "clear_first": False},
+        )
+        redacted = _action_to_code(
+            "type",
+            {"selector": "#password", "text_redacted": True, "clear_first": True},
+        )
+
+        self.assertEqual(plain, "page.locator('#email').first.fill('alice@example.com')\n")
+        self.assertEqual(
+            redacted,
+            "page.locator('#password').first.clear()\n"
+            "page.locator('#password').first.fill('<REDACTED>')  "
+            "# text was marked sensitive and redacted\n",
+        )
+
+    def test_build_script_includes_header_and_skips_duplicate_start_navigation(self) -> None:
+        script = build_script(
+            "session-123",
+            [
+                {
+                    "event_type": "browser_action",
+                    "action": "navigate",
+                    "status": "ok",
+                    "details": {"url": "https://example.com"},
+                },
+                {
+                    "event_type": "browser_action",
+                    "action": "click",
+                    "status": "completed",
+                    "details": {"selector": "#submit"},
+                },
+                {
+                    "event_type": "observe",
+                    "action": "observe",
+                    "status": "ok",
+                    "details": {},
+                },
+                {
+                    "event_type": "browser_action",
+                    "action": "reload",
+                    "status": "failed",
+                    "details": {},
+                },
+            ],
+            start_url="https://example.com",
+            filename="demo.py",
+        )
+
+        self.assertIn("Auto-Browser session export", script)
+        self.assertIn("session-123", script)
+        self.assertEqual(script.count("page.goto('https://example.com')"), 1)
+        self.assertIn("page.wait_for_load_state('domcontentloaded')", script)
+        self.assertIn("page.locator('#submit').first.click()", script)
+        self.assertNotIn("page.reload()", script)
+
+    def test_build_script_without_actions_emits_placeholder(self) -> None:
+        script = build_script("empty-session", [], start_url="")
+        self.assertIn("# No recorded actions found in this session", script)
+        self.assertIn("pass", script)
+
+
+class PlaywrightExportAsyncTests(unittest.IsolatedAsyncioTestCase):
+    async def test_export_session_script_returns_counts_and_script(self) -> None:
+        class EventModel:
+            def __init__(self, payload: dict[str, Any]) -> None:
+                self.payload = payload
+
+            def model_dump(self) -> dict[str, Any]:
+                return self.payload
+
+        audit_store = SimpleNamespace(
+            list=AsyncMock(
+                return_value=[
+                    EventModel(
+                        {
+                            "event_type": "browser_action",
+                            "action": "navigate",
+                            "status": "ok",
+                            "details": {"url": "https://example.com"},
+                        }
+                    ),
+                    EventModel(
+                        {
+                            "event_type": "browser_action",
+                            "action": "click",
+                            "status": "success",
+                            "details": {"selector": "#submit"},
+                        }
+                    ),
+                    EventModel(
+                        {
+                            "event_type": "browser_action",
+                            "action": "reload",
+                            "status": "failed",
+                            "details": {},
+                        }
+                    ),
+                ]
+            )
+        )
+
+        export = await export_session_script(
+            "session-456",
+            audit_store,
+            start_url="https://example.com",
+            viewport_w=1440,
+            viewport_h=900,
+        )
+
+        self.assertEqual(export["session_id"], "session-456")
+        self.assertEqual(export["event_count"], 3)
+        self.assertEqual(export["action_count"], 2)
+        self.assertIn("session-456_replay.py", export["script"])
+        self.assertIn('viewport={"width": 1440, "height": 900}', export["script"])


### PR DESCRIPTION
## Summary
- add fixed 500/404 responses around remaining route manager calls that could bubble unexpected exceptions
- document already-contained auth/upload path sinks with CodeQL suppressions
- finish 1.0.1 release cleanup by aligning the bundled UI version label, changelog, and local Codex artifact ignore rules
- add regression coverage for Playwright session export script generation

## Verification
- python -m ruff check .
- python -m pytest tests/test_session_store.py tests/test_session_share_proxy_store.py tests/test_main_auth.py -q
- python -m pytest -q
- git diff --check