### PR TITLE
[codex] prepare auto-browser 1.0.3 reliability release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: python -m pip install ruff
       - name: Ruff check
         run: make lint
+      - name: Validate agent eval matrix
+        run: python scripts/agent_eval.py --json --report-file /tmp/agent-evals.md
 
   host-tests:
     needs: lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.0.3] — 2026-05-05
+
 ### Added
 - Added request-level agent workflow profiles: `fast` for direct execution and `governed` for conservative review guidance.
 - Added durable per-step checkpoints for background agent jobs plus REST/MCP resume support for interrupted, failed, or step-limited runs.
+- Added dashboard controls for viewing, resuming, and discarding background agent jobs with checkpoint timelines.
+- Added a repeatable agent eval harness for provider/profile comparison in offline scoring or live-controller execution mode.
+
+### Changed
+- Split session artifact preparation, screenshots, trace payloads, and JSONL persistence into a dedicated artifact service.
 
 ## [1.0.2] — 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ All notable changes to auto-browser are documented here.
 - Added durable per-step checkpoints for background agent jobs plus REST/MCP resume support for interrupted, failed, or step-limited runs.
 - Added dashboard controls for viewing, resuming, and discarding background agent jobs with checkpoint timelines.
 - Added a repeatable agent eval harness for provider/profile comparison in offline scoring or live-controller execution mode.
+- Added explicit REST/MCP/dashboard cancellation for queued and running background agent jobs.
 
 ### Changed
 - Split session artifact preparation, screenshots, trace payloads, and JSONL persistence into a dedicated artifact service.
+- Split download capture persistence into a dedicated service and added CI validation for eval case files.
+- Added a committed browser-node package lock so npm audit produces a real release gate.
 
 ## [1.0.2] — 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+### Added
+- Added request-level agent workflow profiles: `fast` for direct execution and `governed` for conservative review guidance.
+- Added durable per-step checkpoints for background agent jobs plus REST/MCP resume support for interrupted, failed, or step-limited runs.
+
 ## [1.0.2] — 2026-04-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Works with:
 ## Release Highlights (v1.0.3)
 
 - **Resumable agent workflows** with `fast` and `governed` profiles plus durable per-step checkpoints
-- **Operator job controls** in `/dashboard` for viewing checkpoint timelines, resuming runs, and discarding stale jobs
-- **Agent eval harness** for repeatable provider/profile comparison in offline scoring or live-controller execution mode
-- **MCP/REST job management** including resume and discard operations for background browser-agent work
-- **Artifact service extraction** for cleaner screenshot, trace, and JSONL persistence boundaries
+- **Operator job controls** in `/dashboard` for checkpoint timelines, run resume, stale-job discard, and active-job cancel
+- **Agent eval harness** with Markdown reports and CI validation for repeatable provider/profile comparison
+- **MCP/REST job management** including resume, discard, and cancel operations for background browser-agent work
+- **Service extraction** for cleaner screenshot, trace, download, and JSONL persistence boundaries
 
 See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Works with:
 - **Local-first by default.** Run the full stack on your own box with Docker Compose, or use Codespaces for a quick hosted demo.
 - **Safety rails built in.** Approvals, operator identity, PII scrubbing, Witness receipts, and compliance templates are all part of the product surface.
 
-## Release Highlights (v1.0.2)
+## Release Highlights (v1.0.3)
 
-- **Framework security updates** with FastAPI and Starlette pinned to the current patched line
-- **Safer error boundaries** across browser actions, CDP, OCR, mesh, workflow, tunnel, social, and share-token surfaces
-- **Rate-limit hardening** with bounded buckets and hashed operator identifiers
-- **Host and path policy tightening** for production `ALLOWED_HOSTS`, auth profile paths, and upload roots
-- **1.0 platform surface** including signed mesh delegation, workflow routes, `/dashboard`, noVNC takeover, MCP transport, audit trails, and readiness checks
+- **Resumable agent workflows** with `fast` and `governed` profiles plus durable per-step checkpoints
+- **Operator job controls** in `/dashboard` for viewing checkpoint timelines, resuming runs, and discarding stale jobs
+- **Agent eval harness** for repeatable provider/profile comparison in offline scoring or live-controller execution mode
+- **MCP/REST job management** including resume and discard operations for background browser-agent work
+- **Artifact service extraction** for cleaner screenshot, trace, and JSONL persistence boundaries
 
 See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,6 @@ This is the near-term direction for Auto Browser.
 
 ## Next
 
-- better session recovery and resume flows (crash-tolerant agents)
 - cleaner multi-tab / popup management
 - MCP `resources/subscribe` push notifications (live browser state streaming)
 - stronger trace viewer integration in operator dashboard
@@ -35,6 +34,8 @@ This is the near-term direction for Auto Browser.
 ## Recently Shipped
 
 - v1.0.1 security hardening, auth-profile archive fixes, client SDK repair, and dashboard XSS cleanup
+- Durable background-agent checkpoints with REST/MCP resume support
+- Request-level `fast` and `governed` workflow profiles for agent runs
 - Agent memory profiles for cross-session context persistence
 - Deployment readiness advisor with compliance mode checks
 - Compliance templates (HIPAA, SOC2, GDPR, PCI-DSS) via a single env var

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This is the near-term direction for Auto Browser.
 
-## Now (current in v1.0.2)
+## Now (current in v1.0.3)
 
 - stable local-first browser control
 - reusable auth profiles + import/export
@@ -22,6 +22,8 @@ This is the near-term direction for Auto Browser.
 - Cron + webhook triggers — autonomous scheduled jobs
 - MCP Resources Protocol — live browser state as subscribable resources
 - Operator dashboard at `/dashboard` with SSE event stream
+- Durable background-agent checkpoints with dashboard resume/discard controls
+- Repeatable agent eval harness for provider and workflow-profile comparisons
 
 ## Next
 
@@ -34,6 +36,7 @@ This is the near-term direction for Auto Browser.
 ## Recently Shipped
 
 - v1.0.1 security hardening, auth-profile archive fixes, client SDK repair, and dashboard XSS cleanup
+- v1.0.3 resumable agent workflows, operator job controls, eval harness, and artifact service cleanup
 - Durable background-agent checkpoints with REST/MCP resume support
 - Request-level `fast` and `governed` workflow profiles for agent runs
 - Agent memory profiles for cross-session context persistence

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ This is the near-term direction for Auto Browser.
 - Cron + webhook triggers — autonomous scheduled jobs
 - MCP Resources Protocol — live browser state as subscribable resources
 - Operator dashboard at `/dashboard` with SSE event stream
-- Durable background-agent checkpoints with dashboard resume/discard controls
+- Durable background-agent checkpoints with dashboard resume/discard/cancel controls
 - Repeatable agent eval harness for provider and workflow-profile comparisons
 
 ## Next
@@ -36,7 +36,7 @@ This is the near-term direction for Auto Browser.
 ## Recently Shipped
 
 - v1.0.1 security hardening, auth-profile archive fixes, client SDK repair, and dashboard XSS cleanup
-- v1.0.3 resumable agent workflows, operator job controls, eval harness, and artifact service cleanup
+- v1.0.3 resumable/cancellable agent workflows, operator job controls, eval reporting, and artifact/download service cleanup
 - Durable background-agent checkpoints with REST/MCP resume support
 - Request-level `fast` and `governed` workflow profiles for agent runs
 - Agent memory profiles for cross-session context persistence

--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "auto-browser-browser-node",
+  "version": "1.0.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "auto-browser-browser-node",
+      "version": "1.0.3",
+      "dependencies": {
+        "playwright": "1.56.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -2,4 +2,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.0.2"
+version = "1.0.3"
 description = "Python client SDK for auto-browser"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/controller/app/agent_eval.py
+++ b/controller/app/agent_eval.py
@@ -195,6 +195,77 @@ def summarize_scores(scores: list[AgentEvalScore]) -> dict[str, Any]:
     }
 
 
+def plan_payload(specs: list[AgentEvalSpec]) -> dict[str, Any]:
+    return {
+        "cases": len({spec.case.id for spec in specs}),
+        "runs": [
+            {
+                "case_id": spec.case.id,
+                "name": spec.case.name,
+                "provider": spec.provider,
+                "workflow_profile": spec.workflow_profile,
+                "max_steps": spec.case.max_steps,
+                "result_file": spec.result_name,
+            }
+            for spec in specs
+        ],
+    }
+
+
+def render_markdown_report(
+    specs: list[AgentEvalSpec],
+    *,
+    scores: list[AgentEvalScore] | None = None,
+) -> str:
+    lines = ["# Auto Browser Agent Eval Report", ""]
+    if scores is None:
+        lines.extend(
+            [
+                "## Planned Matrix",
+                "",
+                "| Case | Provider | Profile | Max Steps | Result File |",
+                "| --- | --- | --- | ---: | --- |",
+            ]
+        )
+        for spec in specs:
+            lines.append(
+                f"| {spec.case.id} | {spec.provider} | {spec.workflow_profile} | "
+                f"{spec.case.max_steps} | {spec.result_name} |"
+            )
+        lines.append("")
+        lines.append(f"Planned runs: {len(specs)}")
+        return "\n".join(lines) + "\n"
+
+    summary = summarize_scores(scores)
+    lines.extend(
+        [
+            "## Summary",
+            "",
+            "| Provider/Profile | Runs | Successes | Average Score |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    for key, item in summary.items():
+        lines.append(f"| {key} | {item['runs']} | {item['successes']} | {item['average_score']:.4f} |")
+    lines.extend(
+        [
+            "",
+            "## Runs",
+            "",
+            "| Case | Provider | Profile | Status | Score | Failed Criteria |",
+            "| --- | --- | --- | --- | ---: | --- |",
+        ]
+    )
+    for score in scores:
+        failed = [criterion.name for criterion in score.criteria if not criterion.passed]
+        status = "PASS" if score.success else "FAIL"
+        lines.append(
+            f"| {score.case_id} | {score.provider} | {score.workflow_profile} | "
+            f"{status} | {score.score:.4f} | {', '.join(failed) if failed else '-'} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
 class ControllerEvalClient:
     def __init__(
         self,

--- a/controller/app/agent_eval.py
+++ b/controller/app/agent_eval.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AgentEvalCase:
+    id: str
+    name: str
+    goal: str
+    start_url: str | None = None
+    providers: tuple[str, ...] = ("openai",)
+    workflow_profiles: tuple[str, ...] = ("fast", "governed")
+    max_steps: int = 6
+    expected_statuses: tuple[str, ...] = ("done",)
+    expect_url_contains: tuple[str, ...] = ()
+    expect_actions: tuple[str, ...] = ()
+    min_step_count: int | None = None
+    max_step_count: int | None = None
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> AgentEvalCase:
+        return cls(
+            id=str(payload["id"]),
+            name=str(payload.get("name") or payload["id"]),
+            goal=str(payload["goal"]),
+            start_url=_optional_str(payload.get("start_url")),
+            providers=_string_tuple(payload.get("providers") or ("openai",)),
+            workflow_profiles=_string_tuple(payload.get("workflow_profiles") or ("fast", "governed")),
+            max_steps=int(payload.get("max_steps", 6)),
+            expected_statuses=_string_tuple(payload.get("expected_statuses") or ("done",)),
+            expect_url_contains=_string_tuple(payload.get("expect_url_contains") or ()),
+            expect_actions=_string_tuple(payload.get("expect_actions") or ()),
+            min_step_count=_optional_int(payload.get("min_step_count")),
+            max_step_count=_optional_int(payload.get("max_step_count")),
+        )
+
+
+@dataclass(frozen=True)
+class AgentEvalSpec:
+    case: AgentEvalCase
+    provider: str
+    workflow_profile: str
+
+    @property
+    def result_name(self) -> str:
+        return f"{self.case.id}__{self.provider}__{self.workflow_profile}.json"
+
+    def request_payload(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "goal": self.case.goal,
+            "max_steps": self.case.max_steps,
+            "workflow_profile": self.workflow_profile,
+        }
+
+
+@dataclass(frozen=True)
+class EvalCriterion:
+    name: str
+    passed: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class AgentEvalScore:
+    case_id: str
+    provider: str
+    workflow_profile: str
+    success: bool
+    score: float
+    criteria: tuple[EvalCriterion, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "provider": self.provider,
+            "workflow_profile": self.workflow_profile,
+            "success": self.success,
+            "score": round(self.score, 4),
+            "criteria": [criterion.__dict__ for criterion in self.criteria],
+        }
+
+
+def load_cases(path: str | Path) -> list[AgentEvalCase]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    raw_cases = payload.get("cases", payload) if isinstance(payload, dict) else payload
+    if not isinstance(raw_cases, list):
+        raise ValueError("eval cases must be a list or an object with a cases list")
+    return [AgentEvalCase.from_dict(item) for item in raw_cases]
+
+
+def build_matrix(
+    cases: list[AgentEvalCase],
+    *,
+    providers: tuple[str, ...] | None = None,
+    workflow_profiles: tuple[str, ...] | None = None,
+) -> list[AgentEvalSpec]:
+    matrix: list[AgentEvalSpec] = []
+    for case in cases:
+        case_providers = providers or case.providers
+        case_profiles = workflow_profiles or case.workflow_profiles
+        for provider in case_providers:
+            for profile in case_profiles:
+                matrix.append(AgentEvalSpec(case=case, provider=provider, workflow_profile=profile))
+    return matrix
+
+
+def score_result(spec: AgentEvalSpec, result: dict[str, Any]) -> AgentEvalScore:
+    criteria: list[EvalCriterion] = []
+    status = str(result.get("status") or "")
+    if spec.case.expected_statuses:
+        criteria.append(
+            EvalCriterion(
+                name="status",
+                passed=status in spec.case.expected_statuses,
+                detail=f"expected {', '.join(spec.case.expected_statuses)}; got {status or 'missing'}",
+            )
+        )
+
+    url = _current_url(result)
+    if spec.case.expect_url_contains:
+        criteria.append(
+            EvalCriterion(
+                name="url",
+                passed=any(fragment in url for fragment in spec.case.expect_url_contains),
+                detail=f"expected one of {', '.join(spec.case.expect_url_contains)}; got {url or 'missing'}",
+            )
+        )
+
+    actions = _action_names(result)
+    for action in spec.case.expect_actions:
+        criteria.append(
+            EvalCriterion(
+                name=f"action:{action}",
+                passed=action in actions,
+                detail=f"observed actions: {', '.join(actions) if actions else 'none'}",
+            )
+        )
+
+    step_count = len(_steps(result))
+    if spec.case.min_step_count is not None:
+        criteria.append(
+            EvalCriterion(
+                name="min_steps",
+                passed=step_count >= spec.case.min_step_count,
+                detail=f"expected >= {spec.case.min_step_count}; got {step_count}",
+            )
+        )
+    if spec.case.max_step_count is not None:
+        criteria.append(
+            EvalCriterion(
+                name="max_steps",
+                passed=step_count <= spec.case.max_step_count,
+                detail=f"expected <= {spec.case.max_step_count}; got {step_count}",
+            )
+        )
+
+    criteria.append(
+        EvalCriterion(
+            name="no_error",
+            passed=status != "error" and not result.get("error"),
+            detail=str(result.get("error") or "ok"),
+        )
+    )
+    passed = sum(1 for criterion in criteria if criterion.passed)
+    score = passed / len(criteria) if criteria else 0.0
+    return AgentEvalScore(
+        case_id=spec.case.id,
+        provider=spec.provider,
+        workflow_profile=spec.workflow_profile,
+        success=passed == len(criteria),
+        score=score,
+        criteria=tuple(criteria),
+    )
+
+
+def summarize_scores(scores: list[AgentEvalScore]) -> dict[str, Any]:
+    groups: dict[str, list[AgentEvalScore]] = {}
+    for score in scores:
+        key = f"{score.provider}/{score.workflow_profile}"
+        groups.setdefault(key, []).append(score)
+    return {
+        key: {
+            "runs": len(items),
+            "successes": sum(1 for item in items if item.success),
+            "average_score": round(sum(item.score for item in items) / len(items), 4),
+        }
+        for key, items in sorted(groups.items())
+    }
+
+
+class ControllerEvalClient:
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        bearer_token: str | None = None,
+        operator_id: str | None = None,
+        operator_name: str | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.headers = {"Content-Type": "application/json"}
+        if bearer_token:
+            self.headers["Authorization"] = f"Bearer {bearer_token}"
+        if operator_id:
+            self.headers["X-Operator-Id"] = operator_id
+        if operator_name:
+            self.headers["X-Operator-Name"] = operator_name
+
+    def run_spec(self, spec: AgentEvalSpec) -> dict[str, Any]:
+        session_payload: dict[str, Any] = {"name": f"eval-{spec.case.id}"}
+        if spec.case.start_url:
+            session_payload["start_url"] = spec.case.start_url
+        session = self._post("/sessions", session_payload)
+        session_id = session.get("id") or session.get("session_id")
+        if not session_id:
+            raise RuntimeError("controller did not return a session id")
+        return self._post(f"/sessions/{session_id}/agent/run", spec.request_payload())
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            self.base_url + path,
+            data=body,
+            headers=self.headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=120) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"controller request failed: {exc.code} {detail}") from exc
+
+
+def score_from_result_dir(specs: list[AgentEvalSpec], result_dir: str | Path) -> list[AgentEvalScore]:
+    root = Path(result_dir)
+    scores: list[AgentEvalScore] = []
+    for spec in specs:
+        result_path = root / spec.result_name
+        if not result_path.exists():
+            missing = {"status": "error", "error": f"missing result file: {result_path}"}
+            scores.append(score_result(spec, missing))
+            continue
+        scores.append(score_result(spec, json.loads(result_path.read_text(encoding="utf-8"))))
+    return scores
+
+
+def _steps(result: dict[str, Any]) -> list[dict[str, Any]]:
+    steps = result.get("steps")
+    return steps if isinstance(steps, list) else []
+
+
+def _action_names(result: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for step in _steps(result):
+        if not isinstance(step, dict):
+            continue
+        decision = step.get("decision")
+        if isinstance(decision, dict) and decision.get("action"):
+            names.add(str(decision["action"]))
+    return names
+
+
+def _current_url(result: dict[str, Any]) -> str:
+    final_session = result.get("final_session")
+    if isinstance(final_session, dict):
+        for key in ("current_url", "url", "start_url"):
+            if final_session.get(key):
+                return str(final_session[key])
+    for step in reversed(_steps(result)):
+        if not isinstance(step, dict):
+            continue
+        execution = step.get("execution")
+        after = execution.get("after") if isinstance(execution, dict) else None
+        if isinstance(after, dict) and after.get("url"):
+            return str(after["url"])
+        observation = step.get("observation")
+        if isinstance(observation, dict) and observation.get("url"):
+            return str(observation["url"])
+    return ""
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    return tuple(str(item) for item in value)
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    return str(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)

--- a/controller/app/agent_jobs.py
+++ b/controller/app/agent_jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from pathlib import Path
@@ -75,6 +76,29 @@ class AgentJobStore:
         async with self._lock:
             return await asyncio.to_thread(self._start_queued_sync, job_id)
 
+    async def append_checkpoint(self, job_id: str, checkpoint: AgentJobCheckpoint) -> AgentJobRecord:
+        async with self._lock:
+            return await asyncio.to_thread(self._append_checkpoint_sync, job_id, checkpoint)
+
+    async def finish(
+        self,
+        job_id: str,
+        *,
+        status: AgentJobStatus,
+        result: dict | None,
+        error: str | None,
+    ) -> AgentJobRecord:
+        async with self._lock:
+            return await asyncio.to_thread(self._finish_sync, job_id, status, result, error)
+
+    async def finish_cancelled(self, job_id: str, *, user_cancelled: bool) -> AgentJobRecord:
+        async with self._lock:
+            return await asyncio.to_thread(self._finish_cancelled_sync, job_id, user_cancelled)
+
+    async def request_cancel(self, job_id: str) -> tuple[AgentJobRecord, bool]:
+        async with self._lock:
+            return await asyncio.to_thread(self._request_cancel_sync, job_id)
+
     async def discard(self, job_id: str) -> tuple[AgentJobRecord, bool]:
         async with self._lock:
             return await asyncio.to_thread(self._discard_sync, job_id)
@@ -121,10 +145,68 @@ class AgentJobStore:
         self._write_sync(record)
         return record
 
+    def _append_checkpoint_sync(self, job_id: str, checkpoint: AgentJobCheckpoint) -> AgentJobRecord:
+        record = self._get_sync(job_id)
+        record.checkpoints.append(checkpoint)
+        record.updated_at = utc_now()
+        self._write_sync(record)
+        return record
+
+    def _finish_sync(
+        self,
+        job_id: str,
+        status: AgentJobStatus,
+        result: dict | None,
+        error: str | None,
+    ) -> AgentJobRecord:
+        record = self._get_sync(job_id)
+        if record.status == "cancelling":
+            record.status = "cancelled"
+            record.error = "agent_job_cancelled"
+            record.result = None
+        elif record.status not in {"cancelled", "discarded"}:
+            record.status = status
+            record.error = error
+            record.result = result
+        record.updated_at = utc_now()
+        self._write_sync(record)
+        return record
+
+    def _finish_cancelled_sync(self, job_id: str, user_cancelled: bool) -> AgentJobRecord:
+        record = self._get_sync(job_id)
+        if user_cancelled:
+            record.status = "cancelled"
+            record.error = "agent_job_cancelled"
+        else:
+            record.status = "interrupted"
+            record.error = "agent_job_interrupted"
+        record.result = None
+        record.updated_at = utc_now()
+        self._write_sync(record)
+        return record
+
+    def _request_cancel_sync(self, job_id: str) -> tuple[AgentJobRecord, bool]:
+        record = self._get_sync(job_id)
+        if record.status == "queued":
+            record.status = "cancelled"
+            record.error = "agent_job_cancelled"
+            record.updated_at = utc_now()
+            self._write_sync(record)
+            return record, True
+        if record.status == "running":
+            record.status = "cancelling"
+            record.error = "agent_job_cancellation_requested"
+            record.updated_at = utc_now()
+            self._write_sync(record)
+            return record, True
+        if record.status in {"cancelling", "cancelled"}:
+            return record, False
+        raise ValueError("Only queued or running jobs can be cancelled")
+
     def _discard_sync(self, job_id: str) -> tuple[AgentJobRecord, bool]:
         record = self._get_sync(job_id)
-        if record.status == "running":
-            raise ValueError("Running jobs cannot be discarded")
+        if record.status in {"running", "cancelling"}:
+            raise ValueError("Running jobs must be cancelled before they can be discarded")
         if record.status != "discarded":
             record.status = "discarded"
             record.error = "agent_job_discarded"
@@ -157,6 +239,8 @@ class AgentJobQueue:
         self._workers: list[asyncio.Task] = []
         self._started = False
         self.audit = audit_store
+        self._running_tasks: dict[str, asyncio.Task[None]] = {}
+        self._cancellation_reasons: dict[str, str] = {}
 
     async def startup(self) -> None:
         await self.store.startup()
@@ -229,6 +313,31 @@ class AgentJobQueue:
             await self._audit("agent_job_discarded", "discarded", record)
         return self._public_record(record)
 
+    async def cancel_job(self, job_id: str) -> dict:
+        record, changed = await self.store.request_cancel(job_id)
+        if changed:
+            await self._audit("agent_job_cancel_requested", record.status, record)
+        if record.status == "cancelled":
+            if changed:
+                await self._audit("agent_job_cancelled", "cancelled", record)
+            return self._public_record(record)
+
+        task = self._running_tasks.get(job_id)
+        if task is None:
+            record = await self.store.finish_cancelled(job_id, user_cancelled=False)
+            await self._audit("agent_job_interrupted", "interrupted", record)
+            return self._public_record(record)
+
+        self._cancellation_reasons[job_id] = "user"
+        task.cancel()
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=5)
+        except asyncio.CancelledError:
+            pass
+        except asyncio.TimeoutError:
+            return self._public_record(await self.store.get(job_id))
+        return self._public_record(await self.store.get(job_id))
+
     async def _enqueue(
         self,
         session_id: str,
@@ -257,13 +366,24 @@ class AgentJobQueue:
     async def _worker_loop(self, worker_index: int) -> None:
         while True:
             job_id = await self.queue.get()
+            task: asyncio.Task[None] | None = None
             try:
-                await self._process_job(job_id)
+                task = asyncio.create_task(self._process_job(job_id), name=f"agent-job-{job_id}")
+                self._running_tasks[job_id] = task
+                await task
             except asyncio.CancelledError:
-                raise
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    if task is not None:
+                        task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await task
+                    raise
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.exception("agent job worker %s crashed on %s: %s", worker_index, job_id, exc)
             finally:
+                self._running_tasks.pop(job_id, None)
+                self._cancellation_reasons.pop(job_id, None)
                 self.queue.task_done()
 
     async def _process_job(self, job_id: str) -> None:
@@ -287,14 +407,12 @@ class AgentJobQueue:
                     provider_model=request.provider_model,
                     workflow_profile=request.workflow_profile,
                 )
-                record.checkpoints.append(self._checkpoint_from_step(1, result))
-                await self.store.update(record)
+                record = await self.store.append_checkpoint(record.id, self._checkpoint_from_step(1, result))
             else:
                 request = AgentRunRequest.model_validate(record.request)
 
                 async def checkpoint_step(step_index: int, step_result: AgentStepResult) -> None:
-                    record.checkpoints.append(self._checkpoint_from_step(step_index, step_result))
-                    await self.store.update(record)
+                    await self.store.append_checkpoint(record.id, self._checkpoint_from_step(step_index, step_result))
 
                 result = await self.orchestrator.run(
                     session_id=record.session_id,
@@ -309,14 +427,15 @@ class AgentJobQueue:
                     workflow_profile=request.workflow_profile,
                     on_step=checkpoint_step,
                 )
-            record.status = "completed"
-            record.result = result.model_dump()
-            record.error = None
+            record = await self.store.finish(record.id, status="completed", result=result.model_dump(), error=None)
+        except asyncio.CancelledError:
+            user_cancelled = self._cancellation_reasons.get(job_id) == "user"
+            record = await self.store.finish_cancelled(job_id, user_cancelled=user_cancelled)
+            event_type = "agent_job_cancelled" if user_cancelled else "agent_job_interrupted"
+            await self._audit(event_type, record.status, record)
+            raise
         except Exception:
-            record.status = "failed"
-            record.error = "agent_job_failed"
-            record.result = None
-        await self.store.update(record)
+            record = await self.store.finish(record.id, status="failed", result=None, error="agent_job_failed")
         await self._audit("agent_job_finished", record.status, record)
 
     async def _audit(self, event_type: str, status: str, record: AgentJobRecord) -> None:

--- a/controller/app/agent_jobs.py
+++ b/controller/app/agent_jobs.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from uuid import uuid4
 
 from .audit import get_current_operator
-from .models import AgentJobRecord, AgentJobStatus, AgentRunRequest, AgentStepRequest
+from .models import (
+    AgentJobCheckpoint,
+    AgentJobRecord,
+    AgentJobStatus,
+    AgentRunRequest,
+    AgentStepRequest,
+    AgentStepResult,
+)
 from .utils import utc_now
 
 logger = logging.getLogger(__name__)
@@ -34,7 +41,15 @@ class AgentJobStore:
         async with self._lock:
             return await asyncio.to_thread(self._get_sync, job_id)
 
-    async def create(self, *, session_id: str, kind: str, request: dict, operator=None) -> AgentJobRecord:
+    async def create(
+        self,
+        *,
+        session_id: str,
+        kind: str,
+        request: dict,
+        operator=None,
+        parent_job_id: str | None = None,
+    ) -> AgentJobRecord:
         async with self._lock:
             now = utc_now()
             record = AgentJobRecord(
@@ -45,6 +60,7 @@ class AgentJobStore:
                 created_at=now,
                 updated_at=now,
                 request=request,
+                parent_job_id=parent_job_id,
                 operator=operator,
             )
             await asyncio.to_thread(self._write_sync, record)
@@ -59,6 +75,7 @@ class AgentJobStore:
         for record in await self.list():
             if record.status == "running":
                 record.status = "interrupted"
+                record.error = "agent_job_interrupted_on_restart"
                 await self.update(record)
 
     def _list_sync(
@@ -142,10 +159,10 @@ class AgentJobQueue:
         session_id: str | None = None,
     ) -> list[dict]:
         records = await self.store.list(status=status, session_id=session_id)
-        return [record.model_dump() for record in records]
+        return [self._public_record(record) for record in records]
 
     async def get_job(self, job_id: str) -> dict:
-        return (await self.store.get(job_id)).model_dump()
+        return self._public_record(await self.store.get(job_id))
 
     async def enqueue_step(self, session_id: str, payload: AgentStepRequest) -> dict:
         return await self._enqueue(session_id, "agent_step", payload)
@@ -153,17 +170,44 @@ class AgentJobQueue:
     async def enqueue_run(self, session_id: str, payload: AgentRunRequest) -> dict:
         return await self._enqueue(session_id, "agent_run", payload)
 
+    async def resume_job(self, job_id: str, *, max_steps: int | None = None) -> dict:
+        source = await self.store.get(job_id)
+        if not self._is_resumable(source):
+            raise ValueError("Job is not resumable")
+        if source.kind != "agent_run":
+            raise ValueError("Only agent_run jobs can be resumed")
+
+        payload = AgentRunRequest.model_validate(source.request)
+        completed_steps = len(source.checkpoints)
+        remaining_steps = max(1, payload.max_steps - completed_steps)
+        payload.max_steps = max_steps or remaining_steps
+        payload.context_hints = self._merge_context_hints(
+            payload.context_hints,
+            self._resume_context(source),
+        )
+        resumed = await self._enqueue(
+            source.session_id,
+            "agent_run",
+            payload,
+            parent_job_id=source.id,
+        )
+        await self._audit("agent_job_resumed", "queued", await self.store.get(resumed["id"]))
+        return resumed
+
     async def _enqueue(
         self,
         session_id: str,
         kind: str,
         payload: AgentStepRequest | AgentRunRequest,
+        *,
+        parent_job_id: str | None = None,
     ) -> dict:
         record = await self.store.create(
             session_id=session_id,
             kind=kind,
             request=payload.model_dump(),
             operator=get_current_operator(),
+            parent_job_id=parent_job_id,
         )
         try:
             self.queue.put_nowait(record.id)
@@ -173,7 +217,7 @@ class AgentJobQueue:
             await self.store.update(record)
             raise RuntimeError("Job queue is at capacity. Try again later.")
         await self._audit("agent_job_enqueued", "queued", record)
-        return record.model_dump()
+        return self._public_record(record)
 
     async def _worker_loop(self, worker_index: int) -> None:
         while True:
@@ -208,9 +252,17 @@ class AgentJobQueue:
                     upload_approved=request.upload_approved,
                     approval_id=request.approval_id,
                     provider_model=request.provider_model,
+                    workflow_profile=request.workflow_profile,
                 )
+                record.checkpoints.append(self._checkpoint_from_step(1, result))
+                await self.store.update(record)
             else:
                 request = AgentRunRequest.model_validate(record.request)
+
+                async def checkpoint_step(step_index: int, step_result: AgentStepResult) -> None:
+                    record.checkpoints.append(self._checkpoint_from_step(step_index, step_result))
+                    await self.store.update(record)
+
                 result = await self.orchestrator.run(
                     session_id=record.session_id,
                     provider_name=request.provider,
@@ -221,6 +273,8 @@ class AgentJobQueue:
                     upload_approved=request.upload_approved,
                     approval_id=request.approval_id,
                     provider_model=request.provider_model,
+                    workflow_profile=request.workflow_profile,
+                    on_step=checkpoint_step,
                 )
             record.status = "completed"
             record.result = result.model_dump()
@@ -244,3 +298,73 @@ class AgentJobQueue:
             operator=record.operator,
             details={"kind": record.kind, "error": record.error},
         )
+
+    @classmethod
+    def _public_record(cls, record: AgentJobRecord) -> dict:
+        payload = record.model_dump()
+        payload["checkpoint_count"] = len(record.checkpoints)
+        payload["resumable"] = cls._is_resumable(record)
+        return payload
+
+    @staticmethod
+    def _is_resumable(record: AgentJobRecord) -> bool:
+        if record.kind != "agent_run":
+            return False
+        if record.status in {"interrupted", "failed"}:
+            return True
+        if record.status != "completed" or not isinstance(record.result, dict):
+            return False
+        return record.result.get("status") in {"max_steps_reached", "approval_required", "error"}
+
+    @classmethod
+    def _checkpoint_from_step(cls, step_index: int, result: AgentStepResult) -> AgentJobCheckpoint:
+        execution = result.execution if isinstance(result.execution, dict) else {}
+        after = execution.get("after") if isinstance(execution.get("after"), dict) else {}
+        observation = result.observation if isinstance(result.observation, dict) else {}
+        decision = result.decision if isinstance(result.decision, dict) else {}
+        return AgentJobCheckpoint(
+            step_index=step_index,
+            created_at=utc_now(),
+            status=result.status,
+            action=cls._truncate(decision.get("action"), 120),
+            reason=cls._truncate(decision.get("reason"), 300),
+            url=cls._truncate(after.get("url") or observation.get("url"), 2000),
+            title=cls._truncate(after.get("title") or observation.get("title"), 500),
+            error=cls._truncate(result.error, 500),
+        )
+
+    @classmethod
+    def _resume_context(cls, record: AgentJobRecord) -> str:
+        if not record.checkpoints:
+            return (
+                f"Resuming background agent job {record.id}. No completed step checkpoints were recorded; "
+                "continue from the current browser state and avoid repeating completed work when visible."
+            )
+        latest = record.checkpoints[-1]
+        step_lines = []
+        for checkpoint in record.checkpoints[-6:]:
+            action = checkpoint.action or "unknown"
+            location = checkpoint.url or checkpoint.title or "current page"
+            step_lines.append(f"{checkpoint.step_index}. {checkpoint.status} {action} at {location}")
+        return (
+            f"Resuming background agent job {record.id} after {len(record.checkpoints)} completed step(s). "
+            f"Latest checkpoint: status={latest.status}, action={latest.action or 'unknown'}, "
+            f"url={latest.url or 'unknown'}. Continue from the current browser state; do not repeat completed "
+            "actions unless the page state requires it.\nCompleted checkpoints:\n"
+            + "\n".join(step_lines)
+        )
+
+    @staticmethod
+    def _merge_context_hints(existing: str | None, resume_context: str) -> str:
+        if existing:
+            return f"{existing}\n\n{resume_context}"
+        return resume_context
+
+    @staticmethod
+    def _truncate(value: object, limit: int) -> str | None:
+        if value is None:
+            return None
+        text = str(value)
+        if len(text) <= limit:
+            return text
+        return f"{text[: limit - 3]}..."

--- a/controller/app/agent_jobs.py
+++ b/controller/app/agent_jobs.py
@@ -71,6 +71,14 @@ class AgentJobStore:
             record.updated_at = utc_now()
             await asyncio.to_thread(self._write_sync, record)
 
+    async def start_queued(self, job_id: str) -> AgentJobRecord | None:
+        async with self._lock:
+            return await asyncio.to_thread(self._start_queued_sync, job_id)
+
+    async def discard(self, job_id: str) -> tuple[AgentJobRecord, bool]:
+        async with self._lock:
+            return await asyncio.to_thread(self._discard_sync, job_id)
+
     async def mark_running_interrupted(self) -> None:
         for record in await self.list():
             if record.status == "running":
@@ -103,6 +111,27 @@ class AgentJobStore:
         if not path.exists():
             raise KeyError(job_id)
         return AgentJobRecord.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def _start_queued_sync(self, job_id: str) -> AgentJobRecord | None:
+        record = self._get_sync(job_id)
+        if record.status != "queued":
+            return None
+        record.status = "running"
+        record.updated_at = utc_now()
+        self._write_sync(record)
+        return record
+
+    def _discard_sync(self, job_id: str) -> tuple[AgentJobRecord, bool]:
+        record = self._get_sync(job_id)
+        if record.status == "running":
+            raise ValueError("Running jobs cannot be discarded")
+        if record.status != "discarded":
+            record.status = "discarded"
+            record.error = "agent_job_discarded"
+            record.updated_at = utc_now()
+            self._write_sync(record)
+            return record, True
+        return record, False
 
     def _write_sync(self, record: AgentJobRecord) -> None:
         path = self.root / f"{record.id}.json"
@@ -194,6 +223,12 @@ class AgentJobQueue:
         await self._audit("agent_job_resumed", "queued", await self.store.get(resumed["id"]))
         return resumed
 
+    async def discard_job(self, job_id: str) -> dict:
+        record, changed = await self.store.discard(job_id)
+        if changed:
+            await self._audit("agent_job_discarded", "discarded", record)
+        return self._public_record(record)
+
     async def _enqueue(
         self,
         session_id: str,
@@ -232,12 +267,10 @@ class AgentJobQueue:
                 self.queue.task_done()
 
     async def _process_job(self, job_id: str) -> None:
-        record = await self.store.get(job_id)
-        if record.status != "queued":
+        record = await self.store.start_queued(job_id)
+        if record is None:
             return
 
-        record.status = "running"
-        await self.store.update(record)
         await self._audit("agent_job_started", "running", record)
 
         try:

--- a/controller/app/artifacts.py
+++ b/controller/app/artifacts.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .utils import UTC
+
+
+class SessionArtifactService:
+    def __init__(self, artifact_root: str | Path) -> None:
+        self.artifact_root = Path(artifact_root)
+
+    def prepare_session_dir(self, session_id: str) -> Path:
+        artifact_dir = self.artifact_root / session_id
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        (artifact_dir / "downloads").mkdir(parents=True, exist_ok=True)
+        return artifact_dir
+
+    async def capture_screenshot(self, session: Any, label: str) -> dict[str, str]:
+        safe_label = self._safe_label(label)
+        filename = f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%S%f')}Z-{safe_label}.png"
+        path = session.artifact_dir / filename
+        await session.page.screenshot(path=str(path), full_page=False)
+        return {"path": str(path), "url": f"/artifacts/{session.id}/{filename}"}
+
+    @staticmethod
+    def trace_payload(session: Any) -> dict[str, Any]:
+        return {
+            "trace_path": str(session.trace_path),
+            "trace_url": f"/artifacts/{session.id}/{session.trace_path.name}",
+            "trace_exists": session.trace_path.exists(),
+            "trace_recording": session.trace_recording,
+        }
+
+    async def append_jsonl(self, path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(payload, ensure_ascii=False)
+        await asyncio.to_thread(self.append_text, path, line + "\n")
+
+    @staticmethod
+    def append_text(path: Path, text: str) -> None:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(text)
+
+    @staticmethod
+    def _safe_label(label: str) -> str:
+        safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", label).strip(".-")
+        return safe[:120] or "screenshot"

--- a/controller/app/browser_manager.py
+++ b/controller/app/browser_manager.py
@@ -48,6 +48,7 @@ from .browser_scripts import (
     apply_stealth,
 )
 from .config import Settings
+from .downloads import DownloadCaptureService
 from .memory_manager import MemoryManager
 from .models import (
     ApprovalKind,
@@ -162,6 +163,7 @@ class BrowserManager:
             max_events=self.settings.audit_max_events,
         )
         self.artifacts = SessionArtifactService(self.settings.artifact_root)
+        self.download_capture = DownloadCaptureService(self.artifacts)
         self.session_store = DurableSessionStore(
             file_root=self.settings.session_store_root,
             redis_url=self.settings.redis_url,
@@ -4648,43 +4650,13 @@ class BrowserManager:
             del items[: len(items) - limit]
 
     async def _handle_download(self, session: BrowserSession, download: Any) -> None:
-        suggested = Path(str(getattr(download, "suggested_filename", "") or f"download-{uuid4().hex}")).name
-        destination = session.artifact_dir / "downloads" / suggested
-        if destination.exists():
-            destination = destination.with_name(f"{destination.stem}-{uuid4().hex[:8]}{destination.suffix}")
-
-        failure: str | None = None
-        status = "completed"
-        try:
-            await download.save_as(str(destination))
-            if hasattr(download, "failure"):
-                failure = await download.failure()
-        except Exception:
-            failure = "download_save_failed"
-            status = "failed"
-
-        if failure:
-            status = "failed"
-
-        record = {
-            "id": uuid4().hex[:12],
-            "timestamp": utc_now(),
-            "status": status,
-            "filename": destination.name,
-            "suggested_filename": suggested,
-            "path": str(destination),
-            "url": f"/artifacts/{session.id}/downloads/{destination.name}",
-            "source_url": getattr(download, "url", None),
-            "failure": failure,
-        }
-        self._bounded_append(session.downloads, record, limit=100)
-        await self._append_jsonl(session.artifact_dir / "downloads.jsonl", record)
+        record = await self.download_capture.capture(session, download)
         await self.audit.append(
             event_type="download_captured",
-            status=status,
+            status=record["status"],
             action="download",
             session_id=session.id,
-            details={"filename": record["filename"], "url": record["url"], "failure": failure},
+            details={"filename": record["filename"], "url": record["url"], "failure": record["failure"]},
         )
         if session.id in self.sessions:
             try:

--- a/controller/app/browser_manager.py
+++ b/controller/app/browser_manager.py
@@ -28,6 +28,7 @@ except Exception:  # pragma: no cover - graceful fallback for non-login test run
 from . import events as _events
 from .action_errors import BrowserActionError
 from .approvals import ApprovalRequiredError, ApprovalStore
+from .artifacts import SessionArtifactService
 from .audit import AuditStore, get_current_operator
 from .auth_state import AuthStateManager
 from .browser_scripts import (
@@ -160,6 +161,7 @@ class BrowserManager:
             db_path=self.settings.state_db_path,
             max_events=self.settings.audit_max_events,
         )
+        self.artifacts = SessionArtifactService(self.settings.artifact_root)
         self.session_store = DurableSessionStore(
             file_root=self.settings.session_store_root,
             redis_url=self.settings.redis_url,
@@ -718,9 +720,7 @@ class BrowserManager:
             raise RuntimeError(message)
 
     def _prepare_session_dirs(self, session_id: str) -> tuple[Path, Path, Path]:
-        artifact_dir = Path(self.settings.artifact_root) / session_id
-        artifact_dir.mkdir(parents=True, exist_ok=True)
-        (artifact_dir / "downloads").mkdir(parents=True, exist_ok=True)
+        artifact_dir = self.artifacts.prepare_session_dir(session_id)
         auth_dir = self._session_auth_root(session_id)
         upload_dir = self._session_upload_root(session_id)
         auth_dir.mkdir(parents=True, exist_ok=True)
@@ -3833,18 +3833,10 @@ class BrowserManager:
         }
 
     async def _capture_screenshot(self, session: BrowserSession, label: str) -> dict[str, str]:
-        filename = f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%S%f')}Z-{label}.png"
-        path = session.artifact_dir / filename
-        await session.page.screenshot(path=str(path), full_page=False)
-        return {"path": str(path), "url": f"/artifacts/{session.id}/{filename}"}
+        return await self.artifacts.capture_screenshot(session, label)
 
     def _trace_payload(self, session: BrowserSession) -> dict[str, Any]:
-        return {
-            "trace_path": str(session.trace_path),
-            "trace_url": f"/artifacts/{session.id}/{session.trace_path.name}",
-            "trace_exists": session.trace_path.exists(),
-            "trace_recording": session.trace_recording,
-        }
+        return self.artifacts.trace_payload(session)
 
     async def _stop_trace_recording(self, session: BrowserSession) -> None:
         if not self.settings.enable_tracing or not session.trace_recording:
@@ -4701,14 +4693,11 @@ class BrowserManager:
                 logger.warning("failed to persist download metadata for session %s: %s", session.id, exc)
 
     async def _append_jsonl(self, path: Path, payload: dict[str, Any]) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(payload, ensure_ascii=False)
-        await asyncio.to_thread(self._append_text, path, line + "\n")
+        await self.artifacts.append_jsonl(path, payload)
 
     @staticmethod
     def _append_text(path: Path, text: str) -> None:
-        with path.open("a", encoding="utf-8") as handle:
-            handle.write(text)
+        SessionArtifactService.append_text(path, text)
 
     # ── Screenshot diff ──────────────────────────────────────────────────────
 

--- a/controller/app/downloads.py
+++ b/controller/app/downloads.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from .artifacts import SessionArtifactService
+from .utils import utc_now
+
+
+class DownloadCaptureService:
+    def __init__(self, artifacts: SessionArtifactService) -> None:
+        self.artifacts = artifacts
+
+    async def capture(self, session: Any, download: Any) -> dict[str, Any]:
+        suggested = Path(str(getattr(download, "suggested_filename", "") or f"download-{uuid4().hex}")).name
+        destination = session.artifact_dir / "downloads" / suggested
+        if destination.exists():
+            destination = destination.with_name(f"{destination.stem}-{uuid4().hex[:8]}{destination.suffix}")
+
+        failure: str | None = None
+        status = "completed"
+        try:
+            await download.save_as(str(destination))
+            if hasattr(download, "failure"):
+                failure = await download.failure()
+        except Exception:
+            failure = "download_save_failed"
+            status = "failed"
+
+        if failure:
+            status = "failed"
+
+        record = {
+            "id": uuid4().hex[:12],
+            "timestamp": utc_now(),
+            "status": status,
+            "filename": destination.name,
+            "suggested_filename": suggested,
+            "path": str(destination),
+            "url": f"/artifacts/{session.id}/downloads/{destination.name}",
+            "source_url": getattr(download, "url", None),
+            "failure": failure,
+        }
+        self._bounded_append(session.downloads, record, limit=100)
+        await self.artifacts.append_jsonl(session.artifact_dir / "downloads.jsonl", record)
+        return record
+
+    @staticmethod
+    def _bounded_append(items: list[Any], value: Any, limit: int) -> None:
+        items.append(value)
+        if len(items) > limit:
+            del items[: len(items) - limit]

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -30,6 +30,7 @@ from .maintenance import MaintenanceService
 from .mcp_transport import McpHttpTransport
 from .metrics import MetricsRecorder
 from .models import (
+    AgentResumeRequest,
     AgentRunRequest,
     AgentStepRequest,
     ApprovalDecisionRequest,
@@ -1025,6 +1026,7 @@ async def run_agent_step(session_id: str, payload: AgentStepRequest) -> dict:
             upload_approved=payload.upload_approved,
             approval_id=payload.approval_id,
             provider_model=payload.provider_model,
+            workflow_profile=payload.workflow_profile,
         )
         status_code = 200 if result.status != "error" else (result.error_code or 502)
         if status_code != 200:
@@ -1055,6 +1057,7 @@ async def run_agent_loop(session_id: str, payload: AgentRunRequest) -> dict:
             upload_approved=payload.upload_approved,
             approval_id=payload.approval_id,
             provider_model=payload.provider_model,
+            workflow_profile=payload.workflow_profile,
         )
         return result.model_dump()
     except KeyError:
@@ -1067,6 +1070,19 @@ async def run_agent_loop(session_id: str, payload: AgentRunRequest) -> dict:
 async def enqueue_agent_run(session_id: str, payload: AgentRunRequest) -> dict:
     await manager.get_session(session_id)
     return await job_queue.enqueue_run(session_id, payload)
+
+
+@app.post("/agent/jobs/{job_id}/resume", status_code=202)
+async def resume_agent_job(job_id: str, payload: AgentResumeRequest | None = None) -> dict:
+    request = payload or AgentResumeRequest()
+    try:
+        return await job_queue.resume_job(job_id, max_steps=request.max_steps)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Unknown job") from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="Service unavailable") from None
 
 
 @app.get("/mcp")

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -1095,6 +1095,16 @@ async def discard_agent_job(job_id: str) -> dict:
         raise HTTPException(status_code=400, detail=str(exc)) from None
 
 
+@app.post("/agent/jobs/{job_id}/cancel", status_code=202)
+async def cancel_agent_job(job_id: str) -> dict:
+    try:
+        return await job_queue.cancel_job(job_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Unknown job") from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
+
 @app.get("/mcp")
 async def get_mcp_transport(request: Request):
     return await mcp_transport.handle_get_request(request)

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -82,7 +82,7 @@ _log_level = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), loggi
 logging.basicConfig(level=_log_level)
 logger = logging.getLogger(__name__)
 
-_VERSION = "1.0.2"
+_VERSION = "1.0.3"
 
 _SAFE_PATH_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
@@ -1083,6 +1083,16 @@ async def resume_agent_job(job_id: str, payload: AgentResumeRequest | None = Non
         raise HTTPException(status_code=400, detail=str(exc)) from None
     except RuntimeError:
         raise HTTPException(status_code=503, detail="Service unavailable") from None
+
+
+@app.post("/agent/jobs/{job_id}/discard")
+async def discard_agent_job(job_id: str) -> dict:
+    try:
+        return await job_queue.discard_job(job_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Unknown job") from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
 
 
 @app.get("/mcp")

--- a/controller/app/mcp_transport.py
+++ b/controller/app/mcp_transport.py
@@ -357,6 +357,7 @@ class McpHttpTransport:
                     "autoBrowser": {
                         "workflowProfiles": ["fast", "governed"],
                         "resumableAgentJobs": True,
+                        "discardableAgentJobs": True,
                     }
                 },
             },

--- a/controller/app/mcp_transport.py
+++ b/controller/app/mcp_transport.py
@@ -353,6 +353,12 @@ class McpHttpTransport:
             "capabilities": {
                 "tools": {},
                 "resources": {"subscribe": False},
+                "experimental": {
+                    "autoBrowser": {
+                        "workflowProfiles": ["fast", "governed"],
+                        "resumableAgentJobs": True,
+                    }
+                },
             },
             "serverInfo": {
                 "name": self.server_name,

--- a/controller/app/mcp_transport.py
+++ b/controller/app/mcp_transport.py
@@ -358,6 +358,7 @@ class McpHttpTransport:
                         "workflowProfiles": ["fast", "governed"],
                         "resumableAgentJobs": True,
                         "discardableAgentJobs": True,
+                        "cancellableAgentJobs": True,
                     }
                 },
             },

--- a/controller/app/models.py
+++ b/controller/app/models.py
@@ -298,7 +298,7 @@ ApprovalKind = Literal["upload", "post", "payment", "account_change", "destructi
 ApprovalStatus = Literal["pending", "approved", "rejected", "executed"]
 SessionStatus = Literal["active", "closed", "interrupted", "failed"]
 AgentJobKind = Literal["agent_step", "agent_run"]
-AgentJobStatus = Literal["queued", "running", "completed", "failed", "interrupted"]
+AgentJobStatus = Literal["queued", "running", "completed", "failed", "interrupted", "discarded"]
 AgentStepStatus = Literal["acted", "done", "takeover", "approval_required", "error"]
 
 

--- a/controller/app/models.py
+++ b/controller/app/models.py
@@ -284,6 +284,7 @@ ActionName = Literal[
     "done",
 ]
 ProviderName = Literal["openai", "claude", "gemini"]
+WorkflowProfile = Literal["fast", "governed"]
 RiskCategory = Literal[
     "read",
     "write",
@@ -298,6 +299,7 @@ ApprovalStatus = Literal["pending", "approved", "rejected", "executed"]
 SessionStatus = Literal["active", "closed", "interrupted", "failed"]
 AgentJobKind = Literal["agent_step", "agent_run"]
 AgentJobStatus = Literal["queued", "running", "completed", "failed", "interrupted"]
+AgentStepStatus = Literal["acted", "done", "takeover", "approval_required", "error"]
 
 
 class BrowserActionDecision(StrictInputModel):
@@ -396,6 +398,10 @@ class AgentStepRequest(StrictInputModel):
     provider: ProviderName
     goal: str = Field(min_length=1, max_length=4000)
     provider_model: str | None = None
+    workflow_profile: WorkflowProfile = Field(
+        default="fast",
+        description="fast preserves direct execution; governed adds conservative review guidance and richer audit context.",
+    )
     observation_limit: int = Field(default=40, ge=1, le=100)
     context_hints: str | None = Field(default=None, max_length=4000)
     upload_approved: bool = False
@@ -404,6 +410,15 @@ class AgentStepRequest(StrictInputModel):
 
 class AgentRunRequest(AgentStepRequest):
     max_steps: int = Field(default=6, ge=1, le=20)
+
+
+class AgentResumeRequest(StrictInputModel):
+    max_steps: int | None = Field(
+        default=None,
+        ge=1,
+        le=20,
+        description="Override the number of steps to run when resuming a job.",
+    )
 
 
 class ProviderInfo(BaseModel):
@@ -427,7 +442,8 @@ class AgentStepResult(BaseModel):
     provider: ProviderName
     model: str
     goal: str
-    status: Literal["acted", "done", "takeover", "approval_required", "error"]
+    workflow_profile: WorkflowProfile = "fast"
+    status: AgentStepStatus
     observation: dict[str, Any]
     decision: dict[str, Any]
     execution: dict[str, Any] | None = None
@@ -441,6 +457,7 @@ class AgentRunResult(BaseModel):
     provider: ProviderName
     model: str
     goal: str
+    workflow_profile: WorkflowProfile = "fast"
     status: Literal["acted", "done", "takeover", "approval_required", "error", "max_steps_reached"]
     steps: list[AgentStepResult]
     final_session: dict[str, Any]
@@ -483,6 +500,17 @@ class WitnessRemoteState(BaseModel):
     last_delivered_at: str | None = None
 
 
+class AgentJobCheckpoint(BaseModel):
+    step_index: int = Field(ge=1)
+    created_at: str
+    status: AgentStepStatus
+    action: str | None = None
+    reason: str | None = None
+    url: str | None = None
+    title: str | None = None
+    error: str | None = None
+
+
 class SessionRecord(BaseModel):
     id: str
     name: str
@@ -513,6 +541,8 @@ class AgentJobRecord(BaseModel):
     created_at: str
     updated_at: str
     request: dict[str, Any]
+    parent_job_id: str | None = None
+    checkpoints: list[AgentJobCheckpoint] = Field(default_factory=list)
     operator: OperatorIdentity | None = None
     result: dict[str, Any] | None = None
     error: str | None = None

--- a/controller/app/models.py
+++ b/controller/app/models.py
@@ -298,7 +298,16 @@ ApprovalKind = Literal["upload", "post", "payment", "account_change", "destructi
 ApprovalStatus = Literal["pending", "approved", "rejected", "executed"]
 SessionStatus = Literal["active", "closed", "interrupted", "failed"]
 AgentJobKind = Literal["agent_step", "agent_run"]
-AgentJobStatus = Literal["queued", "running", "completed", "failed", "interrupted", "discarded"]
+AgentJobStatus = Literal[
+    "queued",
+    "running",
+    "cancelling",
+    "completed",
+    "failed",
+    "interrupted",
+    "cancelled",
+    "discarded",
+]
 AgentStepStatus = Literal["acted", "done", "takeover", "approval_required", "error"]
 
 

--- a/controller/app/orchestrator.py
+++ b/controller/app/orchestrator.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
 
 from .approvals import ApprovalRequiredError
 from .browser_manager import BrowserManager
-from .models import AgentRunResult, AgentStepResult, ProviderName
+from .models import AgentRunResult, AgentStepResult, ProviderName, WorkflowProfile
 from .provider_registry import ProviderRegistry
 from .providers.base import ProviderAPIError, ProviderDecision
 
@@ -30,6 +31,7 @@ class BrowserOrchestrator:
         upload_approved: bool = False,
         approval_id: str | None = None,
         provider_model: str | None = None,
+        workflow_profile: WorkflowProfile = "fast",
         previous_steps: list[AgentStepResult] | None = None,
     ) -> AgentStepResult:
         adapter = self.registry.get(provider_name)
@@ -37,6 +39,7 @@ class BrowserOrchestrator:
         session = await self.manager.get_session(session_id)
         memory_context = getattr(session, "metadata", {}).get("memory_context")
         effective_goal = f"{memory_context}\n\n---\nCurrent goal: {goal}" if memory_context else goal
+        effective_context_hints = self._context_hints_for_profile(context_hints, workflow_profile)
         observation = await self.manager.observe(session_id, limit=observation_limit)
         prompt_history = self._summarize_previous_steps(previous_steps or [])
 
@@ -44,7 +47,7 @@ class BrowserOrchestrator:
             provider_decision = await adapter.decide(
                 goal=effective_goal,
                 observation=observation,
-                context_hints=context_hints,
+                context_hints=effective_context_hints,
                 previous_steps=prompt_history,
                 model_override=provider_model,
             )
@@ -55,12 +58,14 @@ class BrowserOrchestrator:
                 provider_decision=provider_decision,
                 upload_approved=upload_approved,
                 approval_id=approval_id,
+                workflow_profile=workflow_profile,
             )
         except ApprovalRequiredError as exc:
             result = AgentStepResult(
                 provider=provider_name,
                 model=model_name,
                 goal=goal,
+                workflow_profile=workflow_profile,
                 status="approval_required",
                 observation=observation,
                 decision=provider_decision.decision.model_dump(),
@@ -82,6 +87,7 @@ class BrowserOrchestrator:
                 provider=provider_name,
                 model=model_name,
                 goal=goal,
+                workflow_profile=workflow_profile,
                 status="error",
                 observation=observation,
                 decision={},
@@ -107,6 +113,8 @@ class BrowserOrchestrator:
         upload_approved: bool = False,
         approval_id: str | None = None,
         provider_model: str | None = None,
+        workflow_profile: WorkflowProfile = "fast",
+        on_step: Callable[[int, AgentStepResult], Awaitable[None]] | None = None,
     ) -> AgentRunResult:
         steps: list[AgentStepResult] = []
         final_status = "max_steps_reached"
@@ -123,9 +131,12 @@ class BrowserOrchestrator:
                 upload_approved=upload_approved,
                 approval_id=approval_id,
                 provider_model=provider_model,
+                workflow_profile=workflow_profile,
                 previous_steps=steps,
             )
             steps.append(step_result)
+            if on_step is not None:
+                await on_step(index + 1, step_result)
             model_name = step_result.model
             if self._should_trigger_loop_takeover(steps):
                 takeover_reason = "Agent loop guard triggered after repeated low-progress actions"
@@ -135,6 +146,7 @@ class BrowserOrchestrator:
                         provider=provider_name,
                         model=model_name,
                         goal=goal,
+                        workflow_profile=workflow_profile,
                         status="takeover",
                         observation=step_result.observation,
                         decision={
@@ -161,6 +173,7 @@ class BrowserOrchestrator:
             provider=provider_name,
             model=model_name,
             goal=goal,
+            workflow_profile=workflow_profile,
             status=final_status,
             steps=steps,
             final_session=final_session,
@@ -177,6 +190,7 @@ class BrowserOrchestrator:
         provider_decision: ProviderDecision,
         upload_approved: bool,
         approval_id: str | None,
+        workflow_profile: WorkflowProfile,
     ) -> AgentStepResult:
         decision = provider_decision.decision
         execution: dict[str, Any] | None = None
@@ -214,6 +228,7 @@ class BrowserOrchestrator:
             provider=provider_decision.provider,
             model=provider_decision.model,
             goal=goal,
+            workflow_profile=workflow_profile,
             status=status,  # type: ignore[arg-type]
             observation=observation,
             decision=decision.model_dump(),
@@ -223,6 +238,20 @@ class BrowserOrchestrator:
             error=None,
             error_code=None,
         )
+
+    @staticmethod
+    def _context_hints_for_profile(context_hints: str | None, workflow_profile: WorkflowProfile) -> str | None:
+        if workflow_profile == "fast":
+            return context_hints
+        governed_hint = (
+            "Workflow profile: governed. Prefer inspect/read actions before mutating state. "
+            "Use normal write actions only when the target is unambiguous and confidence is high. "
+            "For login, MFA, posting, payment, account changes, destructive actions, sensitive data, "
+            "or uncertainty, request human takeover instead of proceeding."
+        )
+        if context_hints:
+            return f"{context_hints}\n\n{governed_hint}"
+        return governed_hint
 
     @staticmethod
     def _summarize_previous_steps(steps: list[AgentStepResult]) -> list[dict[str, Any]]:

--- a/controller/app/routes/extensions.py
+++ b/controller/app/routes/extensions.py
@@ -595,8 +595,8 @@ const asText = (value, fallback = '—') => {
 const statusBadge = (s) => {
   const map = {active:'green', running:'green', completed:'green', ok:'green',
                 failed:'red', error:'red', rejected:'red',
-                pending:'yellow', queued:'yellow', approval_required:'yellow',
-                interrupted:'gray', discarded:'gray', closed:'gray'};
+                pending:'yellow', queued:'yellow', cancelling:'yellow', approval_required:'yellow',
+                interrupted:'gray', cancelled:'gray', discarded:'gray', closed:'gray'};
   const label = asText(s, 'unknown');
   const span = document.createElement('span');
   span.className = `badge badge-${map[label] || 'gray'}`;
@@ -763,6 +763,12 @@ async function discardAgentJob(jobId) {
   if (result && result.id) loadAgentJobs();
 }
 
+async function cancelAgentJob(jobId) {
+  if (!confirm('Cancel running agent job ' + jobId + '?')) return;
+  const result = await apiPost('/agent/jobs/' + encodeURIComponent(jobId) + '/cancel');
+  if (result && result.id) loadAgentJobs();
+}
+
 async function loadAgentJobs() {
   const jobs = await api('/agent/jobs');
   const items = Array.isArray(jobs) ? jobs : [];
@@ -782,6 +788,13 @@ async function loadAgentJobs() {
 
     const actions = document.createElement('div');
     actions.className = 'btn-row';
+    if (job.status === 'running') {
+      actions.appendChild(jobActionButton(
+        'Cancel',
+        'btn btn-danger btn-sm',
+        () => cancelAgentJob(jobId)
+      ));
+    }
     if (job.resumable) {
       actions.appendChild(jobActionButton(
         'Resume',
@@ -789,7 +802,7 @@ async function loadAgentJobs() {
         () => resumeAgentJob(jobId)
       ));
     }
-    if (job.status !== 'running' && job.status !== 'discarded') {
+    if (!['running', 'cancelling', 'cancelled', 'discarded'].includes(job.status)) {
       actions.appendChild(jobActionButton(
         'Discard',
         'btn btn-danger btn-sm',

--- a/controller/app/routes/extensions.py
+++ b/controller/app/routes/extensions.py
@@ -433,6 +433,10 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
   .btn-primary { background: var(--accent); color: white; }
   .btn-danger { background: var(--red); color: white; }
   .btn-sm { padding: 3px 10px; font-size: 12px; }
+  .btn-row { display: flex; gap: 6px; flex-wrap: wrap; }
+  .timeline { display: flex; flex-direction: column; gap: 4px; max-width: 280px; }
+  .timeline-item { color: var(--muted); font-size: 12px; }
+  .timeline-item strong { color: var(--text); font-weight: 600; }
   .empty { padding: 32px; text-align: center; color: var(--muted); }
   .refresh-btn { background: none; border: 1px solid var(--border); color: var(--muted);
                  padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 12px; }
@@ -447,6 +451,7 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
 <nav>
   <a href="#sessions" class="active">Sessions</a>
   <a href="#workflows">Workflows</a>
+  <a href="#agent-jobs">Agent Jobs</a>
   <a href="#peers">Peers</a>
   <a href="#audit">Audit Log</a>
 </nav>
@@ -455,6 +460,7 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
   <div class="grid" id="stats">
     <div class="card"><h3>Active Sessions</h3><div class="value" id="stat-sessions">—</div></div>
     <div class="card"><h3>Workflow Runs</h3><div class="value" id="stat-workflows">—</div></div>
+    <div class="card"><h3>Agent Jobs</h3><div class="value" id="stat-agent-jobs">—</div></div>
     <div class="card"><h3>Mesh Peers</h3><div class="value" id="stat-peers">—</div></div>
     <div class="card"><h3>Audit Events</h3><div class="value" id="stat-audit">—</div></div>
   </div>
@@ -463,7 +469,7 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
   <div class="section" id="sessions">
     <div class="section-header">
       <h2>Sessions</h2>
-      <button class="refresh-btn" onclick="loadSessions()">↻ Refresh</button>
+      <button class="refresh-btn" id="refresh-sessions">↻ Refresh</button>
     </div>
     <table><thead><tr>
       <th>Session ID</th><th>Name</th><th>Status</th><th>Operator</th><th>URL</th><th>Actions</th>
@@ -474,18 +480,29 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
   <div class="section" id="workflows">
     <div class="section-header">
       <h2>Workflow Runs</h2>
-      <button class="refresh-btn" onclick="loadWorkflows()">↻ Refresh</button>
+      <button class="refresh-btn" id="refresh-workflows">↻ Refresh</button>
     </div>
     <table><thead><tr>
       <th>Run ID</th><th>Workflow</th><th>Status</th><th>Started</th><th>Duration</th>
     </tr></thead><tbody id="workflows-tbody"><tr><td colspan="5" class="empty">Loading...</td></tr></tbody></table>
   </div>
 
+  <!-- Agent Jobs -->
+  <div class="section" id="agent-jobs">
+    <div class="section-header">
+      <h2>Agent Jobs</h2>
+      <button class="refresh-btn" id="refresh-agent-jobs">↻ Refresh</button>
+    </div>
+    <table><thead><tr>
+      <th>Job ID</th><th>Kind</th><th>Status</th><th>Profile</th><th>Checkpoints</th><th>Timeline</th><th>Actions</th>
+    </tr></thead><tbody id="agent-jobs-tbody"><tr><td colspan="7" class="empty">Loading...</td></tr></tbody></table>
+  </div>
+
   <!-- Peers -->
   <div class="section" id="peers">
     <div class="section-header">
       <h2>Mesh Peers</h2>
-      <button class="refresh-btn" onclick="loadPeers()">↻ Refresh</button>
+      <button class="refresh-btn" id="refresh-peers">↻ Refresh</button>
     </div>
     <table><thead><tr>
       <th>Node ID</th><th>Display Name</th><th>Endpoint</th><th>Last Seen</th><th>Grants</th><th>Actions</th>
@@ -496,7 +513,7 @@ _DASHBOARD_HTML = """<!DOCTYPE html>
   <div class="section" id="audit">
     <div class="section-header">
       <h2>Audit Log</h2>
-      <button class="refresh-btn" onclick="loadAudit()">↻ Refresh</button>
+      <button class="refresh-btn" id="refresh-audit">↻ Refresh</button>
     </div>
     <table><thead><tr>
       <th>Time</th><th>Operator</th><th>Action</th><th>Session</th><th>Status</th>
@@ -541,8 +558,9 @@ const _authHeaders = () => {
   if (operatorName) headers['__OPERATOR_NAME_HEADER__'] = operatorName;
   return headers;
 };
-const api = (path) =>
-  fetch(path, {headers: _authHeaders()})
+const api = (path, options = {}) => {
+  const headers = {..._authHeaders(), ...(options.headers || {})};
+  return fetch(path, {...options, headers})
     .then(async r => {
       if (r.status === 401) {
         sessionStorage.removeItem('ab_token');
@@ -561,6 +579,15 @@ const api = (path) =>
       return r.json();
     })
     .catch(e => ({}));
+};
+const apiPost = (path, payload = null) => {
+  const options = {method: 'POST'};
+  if (payload !== null) {
+    options.headers = {'Content-Type': 'application/json'};
+    options.body = JSON.stringify(payload);
+  }
+  return api(path, options);
+};
 const asText = (value, fallback = '—') => {
   if (value === null || value === undefined || value === '') return fallback;
   return String(value);
@@ -568,8 +595,8 @@ const asText = (value, fallback = '—') => {
 const statusBadge = (s) => {
   const map = {active:'green', running:'green', completed:'green', ok:'green',
                 failed:'red', error:'red', rejected:'red',
-                pending:'yellow', approval_required:'yellow',
-                interrupted:'gray', closed:'gray'};
+                pending:'yellow', queued:'yellow', approval_required:'yellow',
+                interrupted:'gray', discarded:'gray', closed:'gray'};
   const label = asText(s, 'unknown');
   const span = document.createElement('span');
   span.className = `badge badge-${map[label] || 'gray'}`;
@@ -627,7 +654,7 @@ const safeHttpUrl = (value) => {
 };
 
 async function loadAll() {
-  await Promise.all([loadIdentity(), loadSessions(), loadWorkflows(), loadPeers(), loadAudit()]);
+  await Promise.all([loadIdentity(), loadSessions(), loadWorkflows(), loadAgentJobs(), loadPeers(), loadAudit()]);
 }
 
 async function loadIdentity() {
@@ -689,6 +716,92 @@ async function loadWorkflows() {
   });
 }
 
+const checkpointTimeline = (job) => {
+  const container = document.createElement('div');
+  container.className = 'timeline';
+  const checkpoints = Array.isArray(job.checkpoints) ? job.checkpoints.slice(-4) : [];
+  if (!checkpoints.length) {
+    const empty = document.createElement('span');
+    empty.className = 'timeline-item';
+    empty.textContent = 'No checkpoints';
+    container.appendChild(empty);
+    return container;
+  }
+  checkpoints.forEach(checkpoint => {
+    const item = document.createElement('span');
+    item.className = 'timeline-item';
+    const step = document.createElement('strong');
+    step.textContent = `#${checkpoint.step_index || '?'}`;
+    item.appendChild(step);
+    item.appendChild(document.createTextNode(` ${asText(checkpoint.status, 'unknown')}`));
+    if (checkpoint.action) item.appendChild(document.createTextNode(` · ${checkpoint.action}`));
+    if (checkpoint.title || checkpoint.url) {
+      item.appendChild(document.createTextNode(` · ${checkpoint.title || checkpoint.url}`));
+    }
+    container.appendChild(item);
+  });
+  return container;
+};
+
+const jobActionButton = (label, className, handler) => {
+  const button = document.createElement('button');
+  button.className = className;
+  button.type = 'button';
+  button.textContent = label;
+  button.addEventListener('click', handler);
+  return button;
+};
+
+async function resumeAgentJob(jobId) {
+  const result = await apiPost('/agent/jobs/' + encodeURIComponent(jobId) + '/resume', {});
+  if (result && result.id) loadAgentJobs();
+}
+
+async function discardAgentJob(jobId) {
+  if (!confirm('Discard agent job ' + jobId + '?')) return;
+  const result = await apiPost('/agent/jobs/' + encodeURIComponent(jobId) + '/discard');
+  if (result && result.id) loadAgentJobs();
+}
+
+async function loadAgentJobs() {
+  const jobs = await api('/agent/jobs');
+  const items = Array.isArray(jobs) ? jobs : [];
+  document.getElementById('stat-agent-jobs').textContent = items.length;
+  const tbody = document.getElementById('agent-jobs-tbody');
+  if (!items.length) { appendEmptyRow(tbody, 7, 'No agent jobs'); return; }
+  tbody.replaceChildren();
+  items.slice(0,50).forEach(job => {
+    const row = document.createElement('tr');
+    const jobId = asText(job.id, '');
+    appendCell(row, jobId ? `${jobId.slice(0, 12)}...` : '—', {className: 'mono'});
+    appendCell(row, job.kind);
+    appendNodeCell(row, statusBadge(job.status || 'unknown'));
+    appendCell(row, job.request && job.request.workflow_profile);
+    appendCell(row, job.checkpoint_count ?? (job.checkpoints || []).length);
+    appendNodeCell(row, checkpointTimeline(job));
+
+    const actions = document.createElement('div');
+    actions.className = 'btn-row';
+    if (job.resumable) {
+      actions.appendChild(jobActionButton(
+        'Resume',
+        'btn btn-primary btn-sm',
+        () => resumeAgentJob(jobId)
+      ));
+    }
+    if (job.status !== 'running' && job.status !== 'discarded') {
+      actions.appendChild(jobActionButton(
+        'Discard',
+        'btn btn-danger btn-sm',
+        () => discardAgentJob(jobId)
+      ));
+    }
+    if (!actions.childNodes.length) actions.textContent = '—';
+    appendNodeCell(row, actions);
+    tbody.appendChild(row);
+  });
+}
+
 async function loadPeers() {
   const d = await api('/mesh/peers');
   const peers = d.peers || [];
@@ -739,6 +852,12 @@ async function loadAudit() {
     tbody.appendChild(row);
   });
 }
+
+document.getElementById('refresh-sessions').addEventListener('click', loadSessions);
+document.getElementById('refresh-workflows').addEventListener('click', loadWorkflows);
+document.getElementById('refresh-agent-jobs').addEventListener('click', loadAgentJobs);
+document.getElementById('refresh-peers').addEventListener('click', loadPeers);
+document.getElementById('refresh-audit').addEventListener('click', loadAudit);
 
 // Auto-refresh every 15s
 loadAll();

--- a/controller/app/tool_gateway.py
+++ b/controller/app/tool_gateway.py
@@ -53,6 +53,7 @@ from .tool_inputs import (  # noqa: F401 — re-exported for backwards compat
     QueueAgentRunInput,
     QueueAgentStepInput,
     ReadinessCheckInput,
+    ResumeAgentJobInput,
     SaveAuthProfileInput,
     SaveAuthStateInput,
     SaveMemoryProfileInput,
@@ -306,6 +307,13 @@ class McpToolGateway:
                     description="Read one browser-agent job record.",
                     input_model=AgentJobIdInput,
                     handler=self._get_agent_job,
+                    profiles=("full",),
+                ),
+                ToolSpec(
+                    name="browser.resume_agent_job",
+                    description="Resume an interrupted, failed, or step-limited background agent run from checkpoints.",
+                    input_model=ResumeAgentJobInput,
+                    handler=self._resume_agent_job,
                     profiles=("full",),
                 ),
                 ToolSpec(
@@ -900,6 +908,9 @@ class McpToolGateway:
 
     async def _get_agent_job(self, payload: AgentJobIdInput) -> dict[str, Any]:
         return await self.job_queue.get_job(payload.job_id)
+
+    async def _resume_agent_job(self, payload: ResumeAgentJobInput) -> dict[str, Any]:
+        return await self.job_queue.resume_job(payload.job_id, max_steps=payload.max_steps)
 
     async def _queue_agent_step(self, payload: QueueAgentStepInput) -> dict[str, Any]:
         await self.manager.get_session(payload.session_id)

--- a/controller/app/tool_gateway.py
+++ b/controller/app/tool_gateway.py
@@ -324,6 +324,13 @@ class McpToolGateway:
                     profiles=("full",),
                 ),
                 ToolSpec(
+                    name="browser.cancel_agent_job",
+                    description="Cancel a queued or running background agent job.",
+                    input_model=AgentJobIdInput,
+                    handler=self._cancel_agent_job,
+                    profiles=("full",),
+                ),
+                ToolSpec(
                     name="browser.queue_agent_step",
                     description="Queue one agent step for background execution.",
                     input_model=QueueAgentStepInput,
@@ -921,6 +928,9 @@ class McpToolGateway:
 
     async def _discard_agent_job(self, payload: AgentJobIdInput) -> dict[str, Any]:
         return await self.job_queue.discard_job(payload.job_id)
+
+    async def _cancel_agent_job(self, payload: AgentJobIdInput) -> dict[str, Any]:
+        return await self.job_queue.cancel_job(payload.job_id)
 
     async def _queue_agent_step(self, payload: QueueAgentStepInput) -> dict[str, Any]:
         await self.manager.get_session(payload.session_id)

--- a/controller/app/tool_gateway.py
+++ b/controller/app/tool_gateway.py
@@ -317,6 +317,13 @@ class McpToolGateway:
                     profiles=("full",),
                 ),
                 ToolSpec(
+                    name="browser.discard_agent_job",
+                    description="Discard a queued or finished background agent job so operators can clear stale work.",
+                    input_model=AgentJobIdInput,
+                    handler=self._discard_agent_job,
+                    profiles=("full",),
+                ),
+                ToolSpec(
                     name="browser.queue_agent_step",
                     description="Queue one agent step for background execution.",
                     input_model=QueueAgentStepInput,
@@ -911,6 +918,9 @@ class McpToolGateway:
 
     async def _resume_agent_job(self, payload: ResumeAgentJobInput) -> dict[str, Any]:
         return await self.job_queue.resume_job(payload.job_id, max_steps=payload.max_steps)
+
+    async def _discard_agent_job(self, payload: AgentJobIdInput) -> dict[str, Any]:
+        return await self.job_queue.discard_job(payload.job_id)
 
     async def _queue_agent_step(self, payload: QueueAgentStepInput) -> dict[str, Any]:
         await self.manager.get_session(payload.session_id)

--- a/controller/app/tool_inputs.py
+++ b/controller/app/tool_inputs.py
@@ -62,6 +62,7 @@ __all__ = [
     "QueueAgentRunInput",
     "QueueAgentStepInput",
     "ReadinessCheckInput",
+    "ResumeAgentJobInput",
     "SaveMemoryProfileInput",
     "SaveAuthProfileInput",
     "SaveAuthStateInput",
@@ -197,6 +198,10 @@ class ReadinessCheckInput(StrictInputModel):
 
 class AgentJobIdInput(StrictInputModel):
     job_id: str = Field(min_length=1, max_length=120)
+
+
+class ResumeAgentJobInput(AgentJobIdInput):
+    max_steps: int | None = Field(default=None, ge=1, le=20)
 
 
 class QueueAgentStepInput(SessionIdInput):

--- a/controller/app/ui/index.html
+++ b/controller/app/ui/index.html
@@ -66,7 +66,7 @@
 <header>
   <div class="status-dot" id="conn-dot"></div>
   <h1>auto-browser</h1>
-  <span class="ver">v1.0.2</span>
+  <span class="ver">v1.0.3</span>
   <span id="conn-label" style="font-size:12px;color:var(--muted);margin-left:4px">idle</span>
   <div style="flex:1"></div>
   <span style="font-size:12px;color:var(--muted)">Operator Dashboard</span>

--- a/controller/app/webhooks.py
+++ b/controller/app/webhooks.py
@@ -58,7 +58,7 @@ async def dispatch_approval_event(
         body.update(extra)
 
     raw = json.dumps(body, separators=(",", ":")).encode()
-    headers: dict[str, str] = {"Content-Type": "application/json", "User-Agent": "auto-browser/1.0.2"}
+    headers: dict[str, str] = {"Content-Type": "application/json", "User-Agent": "auto-browser/1.0.3"}
     if webhook_secret:
         headers["X-Webhook-Signature"] = _sign(raw, webhook_secret)
 

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.0.2"
+version = "1.0.3"
 description = "Controller API for auto-browser"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]

--- a/controller/tests/test_agent_eval.py
+++ b/controller/tests/test_agent_eval.py
@@ -5,7 +5,15 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from app.agent_eval import build_matrix, load_cases, score_from_result_dir, score_result, summarize_scores
+from app.agent_eval import (
+    build_matrix,
+    load_cases,
+    plan_payload,
+    render_markdown_report,
+    score_from_result_dir,
+    score_result,
+    summarize_scores,
+)
 
 
 class AgentEvalTests(unittest.TestCase):
@@ -52,6 +60,9 @@ class AgentEvalTests(unittest.TestCase):
             self.assertTrue(score.success)
             self.assertEqual(score.score, 1.0)
             self.assertEqual(summary["openai/fast"]["successes"], 1)
+            self.assertEqual(plan_payload(matrix)["runs"][0]["result_file"], "case-1__openai__fast.json")
+            self.assertIn("| case-1 | openai | fast | PASS | 1.0000 | - |", render_markdown_report(matrix, scores=[score]))
+            self.assertIn("Planned runs: 2", render_markdown_report(matrix))
 
     def test_score_from_result_dir_marks_missing_results_failed(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/controller/tests/test_agent_eval.py
+++ b/controller/tests/test_agent_eval.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.agent_eval import build_matrix, load_cases, score_from_result_dir, score_result, summarize_scores
+
+
+class AgentEvalTests(unittest.TestCase):
+    def test_load_matrix_and_score_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            cases_path = Path(tempdir) / "cases.json"
+            cases_path.write_text(
+                json.dumps(
+                    {
+                        "cases": [
+                            {
+                                "id": "case-1",
+                                "goal": "finish",
+                                "providers": ["openai"],
+                                "workflow_profiles": ["fast", "governed"],
+                                "expected_statuses": ["done"],
+                                "expect_url_contains": ["example.com"],
+                                "expect_actions": ["done"],
+                                "min_step_count": 1,
+                                "max_step_count": 2,
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            cases = load_cases(cases_path)
+            matrix = build_matrix(cases)
+            result = {
+                "status": "done",
+                "steps": [
+                    {
+                        "decision": {"action": "done"},
+                        "observation": {"url": "https://example.com"},
+                    }
+                ],
+                "final_session": {"current_url": "https://example.com"},
+            }
+            score = score_result(matrix[0], result)
+            summary = summarize_scores([score])
+
+            self.assertEqual([spec.workflow_profile for spec in matrix], ["fast", "governed"])
+            self.assertTrue(score.success)
+            self.assertEqual(score.score, 1.0)
+            self.assertEqual(summary["openai/fast"]["successes"], 1)
+
+    def test_score_from_result_dir_marks_missing_results_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            cases_path = Path(tempdir) / "cases.json"
+            cases_path.write_text(
+                json.dumps({"cases": [{"id": "missing-case", "goal": "finish", "providers": ["openai"]}]}),
+                encoding="utf-8",
+            )
+
+            matrix = build_matrix(load_cases(cases_path), workflow_profiles=("fast",))
+            scores = score_from_result_dir(matrix, tempdir)
+
+            self.assertFalse(scores[0].success)
+            self.assertIn("missing result file", scores[0].criteria[-1].detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_agent_http.py
+++ b/controller/tests/test_agent_http.py
@@ -162,6 +162,16 @@ class AgentHttpTests(unittest.TestCase):
         self.assertEqual(response.json()["status"], "discarded")
         discard_job.assert_awaited_once_with("job-1")
 
+    def test_cancel_agent_job_endpoint_marks_job_cancelled(self) -> None:
+        cancel_job = AsyncMock(return_value={"id": "job-1", "status": "cancelled", "resumable": False})
+
+        with patch.object(main_module.job_queue, "cancel_job", cancel_job):
+            response = self.client.post("/agent/jobs/job-1/cancel")
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["status"], "cancelled")
+        cancel_job.assert_awaited_once_with("job-1")
+
     def test_agent_step_surfaces_provider_failure_status_code(self) -> None:
         step = AsyncMock(
             return_value=AgentStepResult(

--- a/controller/tests/test_agent_http.py
+++ b/controller/tests/test_agent_http.py
@@ -109,6 +109,7 @@ class AgentHttpTests(unittest.TestCase):
                 provider="openai",
                 model="gpt-4.1-mini",
                 goal="Inspect the page",
+                workflow_profile="governed",
                 status="done",
                 observation={"url": "https://example.com", "title": "Example Domain"},
                 decision={"action": "done", "reason": "Already on the target page", "risk_category": "read"},
@@ -125,6 +126,7 @@ class AgentHttpTests(unittest.TestCase):
                     "goal": "Inspect the page",
                     "observation_limit": 12,
                     "provider_model": "gpt-4.1-mini",
+                    "workflow_profile": "governed",
                 },
             )
 
@@ -132,11 +134,23 @@ class AgentHttpTests(unittest.TestCase):
         body = response.json()
         self.assertEqual(body["status"], "done")
         self.assertEqual(body["usage"], {"transport": "fake-provider"})
+        self.assertEqual(body["workflow_profile"], "governed")
         self.assertEqual(body["decision"]["action"], "done")
         self.assertEqual(step.await_args.kwargs["session_id"], "session-1")
         self.assertEqual(step.await_args.kwargs["provider_name"], "openai")
         self.assertEqual(step.await_args.kwargs["provider_model"], "gpt-4.1-mini")
         self.assertEqual(step.await_args.kwargs["observation_limit"], 12)
+        self.assertEqual(step.await_args.kwargs["workflow_profile"], "governed")
+
+    def test_resume_agent_job_endpoint_returns_queued_job(self) -> None:
+        resume_job = AsyncMock(return_value={"id": "job-2", "parent_job_id": "job-1", "status": "queued"})
+
+        with patch.object(main_module.job_queue, "resume_job", resume_job):
+            response = self.client.post("/agent/jobs/job-1/resume", json={"max_steps": 4})
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["parent_job_id"], "job-1")
+        resume_job.assert_awaited_once_with("job-1", max_steps=4)
 
     def test_agent_step_surfaces_provider_failure_status_code(self) -> None:
         step = AsyncMock(

--- a/controller/tests/test_agent_http.py
+++ b/controller/tests/test_agent_http.py
@@ -152,6 +152,16 @@ class AgentHttpTests(unittest.TestCase):
         self.assertEqual(response.json()["parent_job_id"], "job-1")
         resume_job.assert_awaited_once_with("job-1", max_steps=4)
 
+    def test_discard_agent_job_endpoint_marks_job_discarded(self) -> None:
+        discard_job = AsyncMock(return_value={"id": "job-1", "status": "discarded", "resumable": False})
+
+        with patch.object(main_module.job_queue, "discard_job", discard_job):
+            response = self.client.post("/agent/jobs/job-1/discard")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "discarded")
+        discard_job.assert_awaited_once_with("job-1")
+
     def test_agent_step_surfaces_provider_failure_status_code(self) -> None:
         step = AsyncMock(
             return_value=AgentStepResult(

--- a/controller/tests/test_agent_jobs.py
+++ b/controller/tests/test_agent_jobs.py
@@ -149,11 +149,90 @@ class AgentJobQueueTests(unittest.IsolatedAsyncioTestCase):
         record.status = "running"
         await self.queue.store.update(record)
 
-        with self.assertRaisesRegex(ValueError, "Running jobs cannot be discarded"):
+        with self.assertRaisesRegex(ValueError, "Running jobs must be cancelled"):
             await self.queue.discard_job(record.id)
 
         stored = await self.queue.get_job(record.id)
         self.assertEqual(stored["status"], "running")
+
+    async def test_cancel_queued_job_marks_it_cancelled(self) -> None:
+        record = await self.queue.store.create(
+            session_id="session-5",
+            kind="agent_run",
+            request=AgentRunRequest(provider="openai", goal="cancel queued").model_dump(),
+        )
+
+        cancelled = await self.queue.cancel_job(record.id)
+        listed = await self.queue.list_jobs(status="cancelled")
+
+        self.assertEqual(cancelled["status"], "cancelled")
+        self.assertEqual(cancelled["error"], "agent_job_cancelled")
+        self.assertFalse(cancelled["resumable"])
+        self.assertEqual([item["id"] for item in listed], [record.id])
+
+    async def test_cancel_running_job_stops_worker_task(self) -> None:
+        class SlowOrchestrator:
+            def __init__(self) -> None:
+                self.started = asyncio.Event()
+                self.cancelled = asyncio.Event()
+
+            async def run(self, **kwargs):
+                self.started.set()
+                try:
+                    await asyncio.sleep(60)
+                finally:
+                    self.cancelled.set()
+
+        await self.queue.shutdown()
+        slow_orchestrator = SlowOrchestrator()
+        self.queue = AgentJobQueue(
+            orchestrator=slow_orchestrator,
+            store_root=Path(self.tempdir.name),
+            worker_count=1,
+        )
+        await self.queue.startup()
+
+        job = await self.queue.enqueue_run(
+            "session-6",
+            AgentRunRequest(provider="openai", goal="cancel active work"),
+        )
+        await asyncio.wait_for(slow_orchestrator.started.wait(), timeout=2)
+
+        cancelled = await self.queue.cancel_job(job["id"])
+
+        self.assertEqual(cancelled["status"], "cancelled")
+        self.assertEqual(cancelled["error"], "agent_job_cancelled")
+        self.assertTrue(slow_orchestrator.cancelled.is_set())
+
+    async def test_shutdown_interrupts_running_job(self) -> None:
+        class SlowOrchestrator:
+            def __init__(self) -> None:
+                self.started = asyncio.Event()
+
+            async def run(self, **kwargs):
+                self.started.set()
+                await asyncio.sleep(60)
+
+        await self.queue.shutdown()
+        slow_orchestrator = SlowOrchestrator()
+        self.queue = AgentJobQueue(
+            orchestrator=slow_orchestrator,
+            store_root=Path(self.tempdir.name),
+            worker_count=1,
+        )
+        await self.queue.startup()
+
+        job = await self.queue.enqueue_run(
+            "session-7",
+            AgentRunRequest(provider="openai", goal="interrupt active work"),
+        )
+        await asyncio.wait_for(slow_orchestrator.started.wait(), timeout=2)
+        await self.queue.shutdown()
+
+        interrupted = await self.queue.get_job(job["id"])
+        self.assertEqual(interrupted["status"], "interrupted")
+        self.assertEqual(interrupted["error"], "agent_job_interrupted")
+        self.assertTrue(interrupted["resumable"])
 
     async def test_running_jobs_become_interrupted_on_restart(self) -> None:
         await self.queue.store.create(

--- a/controller/tests/test_agent_jobs.py
+++ b/controller/tests/test_agent_jobs.py
@@ -125,6 +125,36 @@ class AgentJobQueueTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Resuming background agent job", resumed_record["request"]["context_hints"])
         self.assertIn("https://example.com/3", resumed_record["request"]["context_hints"])
 
+    async def test_discard_queued_job_marks_it_discarded(self) -> None:
+        record = await self.queue.store.create(
+            session_id="session-3",
+            kind="agent_run",
+            request=AgentRunRequest(provider="openai", goal="stale work").model_dump(),
+        )
+
+        discarded = await self.queue.discard_job(record.id)
+        listed = await self.queue.list_jobs(status="discarded")
+
+        self.assertEqual(discarded["status"], "discarded")
+        self.assertEqual(discarded["error"], "agent_job_discarded")
+        self.assertFalse(discarded["resumable"])
+        self.assertEqual([item["id"] for item in listed], [record.id])
+
+    async def test_discard_running_job_is_rejected(self) -> None:
+        record = await self.queue.store.create(
+            session_id="session-4",
+            kind="agent_run",
+            request=AgentRunRequest(provider="openai", goal="active work").model_dump(),
+        )
+        record.status = "running"
+        await self.queue.store.update(record)
+
+        with self.assertRaisesRegex(ValueError, "Running jobs cannot be discarded"):
+            await self.queue.discard_job(record.id)
+
+        stored = await self.queue.get_job(record.id)
+        self.assertEqual(stored["status"], "running")
+
     async def test_running_jobs_become_interrupted_on_restart(self) -> None:
         await self.queue.store.create(
             session_id="session-2",

--- a/controller/tests/test_agent_jobs.py
+++ b/controller/tests/test_agent_jobs.py
@@ -10,12 +10,16 @@ from app.models import AgentRunRequest, AgentRunResult, AgentStepRequest, AgentS
 
 
 class FakeOrchestrator:
+    def __init__(self) -> None:
+        self.run_calls: list[dict] = []
+
     async def step(self, **kwargs):
         await asyncio.sleep(0.01)
         return AgentStepResult(
             provider=kwargs["provider_name"],
             model="test-model",
             goal=kwargs["goal"],
+            workflow_profile=kwargs.get("workflow_profile", "fast"),
             status="done",
             observation={"url": "https://example.com"},
             decision={"action": "done", "reason": "done"},
@@ -27,13 +31,34 @@ class FakeOrchestrator:
         )
 
     async def run(self, **kwargs):
+        self.run_calls.append(kwargs)
         await asyncio.sleep(0.01)
+        steps = []
+        for step_index in range(1, kwargs["max_steps"] + 1):
+            step = AgentStepResult(
+                provider=kwargs["provider_name"],
+                model="test-model",
+                goal=kwargs["goal"],
+                workflow_profile=kwargs.get("workflow_profile", "fast"),
+                status="acted",
+                observation={"url": f"https://example.com/{step_index}", "title": f"Step {step_index}"},
+                decision={"action": "click", "reason": f"step {step_index}"},
+                execution={"after": {"url": f"https://example.com/{step_index}", "title": f"Step {step_index}"}},
+                usage=None,
+                raw_text=None,
+                error=None,
+                error_code=None,
+            )
+            steps.append(step)
+            if kwargs.get("on_step"):
+                await kwargs["on_step"](step_index, step)
         return AgentRunResult(
             provider=kwargs["provider_name"],
             model="test-model",
             goal=kwargs["goal"],
-            status="done",
-            steps=[],
+            workflow_profile=kwargs.get("workflow_profile", "fast"),
+            status="max_steps_reached",
+            steps=steps,
             final_session={"id": kwargs["session_id"], "status": "active"},
         )
 
@@ -41,8 +66,9 @@ class FakeOrchestrator:
 class AgentJobQueueTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
+        self.orchestrator = FakeOrchestrator()
         self.queue = AgentJobQueue(
-            orchestrator=FakeOrchestrator(),
+            orchestrator=self.orchestrator,
             store_root=Path(self.tempdir.name),
             worker_count=1,
         )
@@ -68,6 +94,36 @@ class AgentJobQueueTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(stored["result"]["status"], "done")
         self.assertEqual(stored["kind"], "agent_step")
+        self.assertEqual(stored["checkpoint_count"], 1)
+        self.assertFalse(stored["resumable"])
+
+    async def test_agent_run_records_checkpoints_and_resume_queues_remaining_steps(self) -> None:
+        job = await self.queue.enqueue_run(
+            "session-2",
+            AgentRunRequest(provider="openai", goal="run it", max_steps=3, workflow_profile="governed"),
+        )
+
+        for _ in range(50):
+            stored = await self.queue.get_job(job["id"])
+            if stored["status"] == "completed":
+                break
+            await asyncio.sleep(0.02)
+        else:
+            self.fail("run job did not complete")
+
+        self.assertEqual(stored["checkpoint_count"], 3)
+        self.assertTrue(stored["resumable"])
+        self.assertEqual(stored["checkpoints"][-1]["url"], "https://example.com/3")
+        self.assertEqual(stored["result"]["workflow_profile"], "governed")
+
+        resumed = await self.queue.resume_job(job["id"])
+        resumed_record = await self.queue.get_job(resumed["id"])
+
+        self.assertEqual(resumed_record["parent_job_id"], job["id"])
+        self.assertEqual(resumed_record["request"]["workflow_profile"], "governed")
+        self.assertEqual(resumed_record["request"]["max_steps"], 1)
+        self.assertIn("Resuming background agent job", resumed_record["request"]["context_hints"])
+        self.assertIn("https://example.com/3", resumed_record["request"]["context_hints"])
 
     async def test_running_jobs_become_interrupted_on_restart(self) -> None:
         await self.queue.store.create(
@@ -90,3 +146,4 @@ class AgentJobQueueTests(unittest.IsolatedAsyncioTestCase):
 
         updated = await self.queue.get_job(record.id)
         self.assertEqual(updated["status"], "interrupted")
+        self.assertTrue(updated["resumable"])

--- a/controller/tests/test_artifacts.py
+++ b/controller/tests/test_artifacts.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.artifacts import SessionArtifactService
+
+
+class FakePage:
+    async def screenshot(self, *, path: str, full_page: bool) -> None:
+        self.path = path
+        self.full_page = full_page
+        Path(path).write_bytes(b"png")
+
+
+class SessionArtifactServiceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_prepare_capture_trace_and_append_jsonl(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            service = SessionArtifactService(tempdir)
+            artifact_dir = service.prepare_session_dir("session-1")
+            trace_path = artifact_dir / "trace.zip"
+            trace_path.write_bytes(b"trace")
+            page = FakePage()
+            session = SimpleNamespace(
+                id="session-1",
+                artifact_dir=artifact_dir,
+                page=page,
+                trace_path=trace_path,
+                trace_recording=False,
+            )
+
+            screenshot = await service.capture_screenshot(session, "../bad label")
+            trace = service.trace_payload(session)
+            await service.append_jsonl(artifact_dir / "events.jsonl", {"status": "ok"})
+
+            self.assertTrue((artifact_dir / "downloads").is_dir())
+            self.assertIn("-bad-label.png", screenshot["path"])
+            self.assertTrue(Path(screenshot["path"]).exists())
+            self.assertFalse(page.full_page)
+            self.assertEqual(trace["trace_url"], "/artifacts/session-1/trace.zip")
+            self.assertTrue(trace["trace_exists"])
+            lines = (artifact_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+            self.assertEqual(json.loads(lines[0]), {"status": "ok"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_dashboard_security.py
+++ b/controller/tests/test_dashboard_security.py
@@ -9,6 +9,9 @@ class DashboardSecurityTests(unittest.TestCase):
     def test_dashboard_dynamic_tables_do_not_use_inner_html(self) -> None:
         self.assertIn("appendCell(row, s.name)", _DASHBOARD_HTML)
         self.assertIn("document.getElementById('stat-sessions').textContent", _DASHBOARD_HTML)
+        self.assertIn("agent-jobs-tbody", _DASHBOARD_HTML)
+        self.assertIn("resumeAgentJob", _DASHBOARD_HTML)
+        self.assertIn("discardAgentJob", _DASHBOARD_HTML)
         self.assertNotIn("innerHTML", _DASHBOARD_HTML)
         self.assertNotIn("onclick=\"removePeer", _DASHBOARD_HTML)
 

--- a/controller/tests/test_dashboard_security.py
+++ b/controller/tests/test_dashboard_security.py
@@ -12,6 +12,7 @@ class DashboardSecurityTests(unittest.TestCase):
         self.assertIn("agent-jobs-tbody", _DASHBOARD_HTML)
         self.assertIn("resumeAgentJob", _DASHBOARD_HTML)
         self.assertIn("discardAgentJob", _DASHBOARD_HTML)
+        self.assertIn("cancelAgentJob", _DASHBOARD_HTML)
         self.assertNotIn("innerHTML", _DASHBOARD_HTML)
         self.assertNotIn("onclick=\"removePeer", _DASHBOARD_HTML)
 

--- a/controller/tests/test_downloads.py
+++ b/controller/tests/test_downloads.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.artifacts import SessionArtifactService
+from app.downloads import DownloadCaptureService
+
+
+class FakeDownload:
+    def __init__(self, filename: str, *, url: str = "https://example.com/report.csv", failure: str | None = None):
+        self.suggested_filename = filename
+        self.url = url
+        self._failure = failure
+
+    async def save_as(self, path: str) -> None:
+        Path(path).write_text("downloaded", encoding="utf-8")
+
+    async def failure(self) -> str | None:
+        return self._failure
+
+
+class DownloadCaptureServiceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_capture_saves_file_and_jsonl_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifacts = SessionArtifactService(tempdir)
+            artifact_dir = artifacts.prepare_session_dir("session-1")
+            service = DownloadCaptureService(artifacts)
+            session = SimpleNamespace(id="session-1", artifact_dir=artifact_dir, downloads=[])
+
+            first = await service.capture(session, FakeDownload("../report.csv"))
+            second = await service.capture(session, FakeDownload("report.csv", failure="network"))
+
+            self.assertEqual(first["filename"], "report.csv")
+            self.assertTrue(Path(first["path"]).is_file())
+            self.assertEqual(second["status"], "failed")
+            self.assertNotEqual(first["filename"], second["filename"])
+            self.assertEqual(len(session.downloads), 2)
+
+            records = [
+                json.loads(line)
+                for line in (artifact_dir / "downloads.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual([record["filename"] for record in records], [first["filename"], second["filename"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_input_validation.py
+++ b/controller/tests/test_input_validation.py
@@ -12,6 +12,7 @@ from app.browser_manager import BrowserManager
 from app.config import Settings
 from app.cron_service import CronService
 from app.models import (
+    AgentRunRequest,
     BrowserActionDecision,
     ClickRequest,
     CreateSessionRequest,
@@ -96,6 +97,15 @@ class RequestValidationTests(unittest.TestCase):
 
         self.assertEqual(payload.preset, "rich")
         self.assertEqual(payload.limit, 120)
+
+    def test_agent_run_request_accepts_governed_workflow_profile(self) -> None:
+        payload = AgentRunRequest(provider="openai", goal="check the inbox", workflow_profile="governed")
+
+        self.assertEqual(payload.workflow_profile, "governed")
+
+    def test_agent_run_request_rejects_unknown_workflow_profile(self) -> None:
+        with self.assertRaises(ValidationError):
+            AgentRunRequest(provider="openai", goal="check the inbox", workflow_profile="unsafe")
 
     def test_get_network_log_uppercases_method(self) -> None:
         payload = GetNetworkLogInput(session_id="session-1", method="post")

--- a/controller/tests/test_mcp_transport.py
+++ b/controller/tests/test_mcp_transport.py
@@ -91,6 +91,7 @@ class McpTransportTests(unittest.TestCase):
         )
         self.assertTrue(result["capabilities"]["experimental"]["autoBrowser"]["resumableAgentJobs"])
         self.assertTrue(result["capabilities"]["experimental"]["autoBrowser"]["discardableAgentJobs"])
+        self.assertTrue(result["capabilities"]["experimental"]["autoBrowser"]["cancellableAgentJobs"])
         return session_id, protocol_version
 
     def test_initialize_requires_initialized_notification_before_tool_calls(self) -> None:

--- a/controller/tests/test_mcp_transport.py
+++ b/controller/tests/test_mcp_transport.py
@@ -83,7 +83,13 @@ class McpTransportTests(unittest.TestCase):
         session_id = response.headers[MCP_SESSION_HEADER]
         protocol_version = response.headers[MCP_PROTOCOL_HEADER]
         self.assertEqual(protocol_version, "2025-11-25")
-        self.assertEqual(response.json()["result"]["serverInfo"]["name"], "auto-browser")
+        result = response.json()["result"]
+        self.assertEqual(result["serverInfo"]["name"], "auto-browser")
+        self.assertEqual(
+            result["capabilities"]["experimental"]["autoBrowser"]["workflowProfiles"],
+            ["fast", "governed"],
+        )
+        self.assertTrue(result["capabilities"]["experimental"]["autoBrowser"]["resumableAgentJobs"])
         return session_id, protocol_version
 
     def test_initialize_requires_initialized_notification_before_tool_calls(self) -> None:

--- a/controller/tests/test_mcp_transport.py
+++ b/controller/tests/test_mcp_transport.py
@@ -90,6 +90,7 @@ class McpTransportTests(unittest.TestCase):
             ["fast", "governed"],
         )
         self.assertTrue(result["capabilities"]["experimental"]["autoBrowser"]["resumableAgentJobs"])
+        self.assertTrue(result["capabilities"]["experimental"]["autoBrowser"]["discardableAgentJobs"])
         return session_id, protocol_version
 
     def test_initialize_requires_initialized_notification_before_tool_calls(self) -> None:

--- a/controller/tests/test_orchestrator.py
+++ b/controller/tests/test_orchestrator.py
@@ -121,6 +121,43 @@ class BrowserOrchestratorLoopGuardTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("[Memory: checkout]", adapter.last_goal)
         self.assertIn("Current goal: Click the buy button", adapter.last_goal)
 
+    async def test_governed_workflow_profile_adds_conservative_context(self) -> None:
+        class ContextAwareAdapter:
+            default_model = "test-model"
+
+            def __init__(self) -> None:
+                self.last_context_hints = ""
+
+            async def decide(self, **kwargs):
+                self.last_context_hints = kwargs["context_hints"]
+                return ProviderDecision(
+                    provider="openai",
+                    model="test-model",
+                    decision=BrowserActionDecision(
+                        action="done",
+                        reason="Enough context",
+                        risk_category="read",
+                    ),
+                    usage={"provider": "fake"},
+                    raw_text='{"action":"done"}',
+                )
+
+        adapter = ContextAwareAdapter()
+        orchestrator = BrowserOrchestrator(self.manager, StaticRegistry(adapter))
+
+        result = await orchestrator.step(
+            session_id="session-1",
+            provider_name="openai",
+            goal="Inspect the account page",
+            context_hints="Stay on the current account.",
+            workflow_profile="governed",
+        )
+
+        self.assertEqual(result.workflow_profile, "governed")
+        self.assertIn("Stay on the current account.", adapter.last_context_hints)
+        self.assertIn("Workflow profile: governed", adapter.last_context_hints)
+        self.assertIn("request human takeover", adapter.last_context_hints)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/controller/tests/test_tool_gateway.py
+++ b/controller/tests/test_tool_gateway.py
@@ -104,6 +104,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
             get_job=AsyncMock(return_value={"id": "job-1", "status": "completed"}),
             resume_job=AsyncMock(return_value={"id": "job-2", "parent_job_id": "job-1", "status": "queued"}),
             discard_job=AsyncMock(return_value={"id": "job-1", "status": "discarded"}),
+            cancel_job=AsyncMock(return_value={"id": "job-1", "status": "cancelled"}),
             enqueue_step=AsyncMock(return_value={"id": "job-1", "kind": "agent_step"}),
             enqueue_run=AsyncMock(return_value={"id": "job-2", "kind": "agent_run"}),
         )
@@ -162,6 +163,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("browser.find_by_vision", names)
         self.assertEqual(len(names), len(tools))
         self.assertNotIn("browser.discard_agent_job", names)
+        self.assertNotIn("browser.cancel_agent_job", names)
 
     async def test_full_profile_keeps_internal_tools_available(self) -> None:
         names = {tool["name"] for tool in self.full_gateway.list_tools()}
@@ -169,6 +171,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("browser.list_agent_jobs", names)
         self.assertIn("browser.resume_agent_job", names)
         self.assertIn("browser.discard_agent_job", names)
+        self.assertIn("browser.cancel_agent_job", names)
         self.assertIn("browser.list_providers", names)
         self.assertIn("browser.delete_memory_profile", names)
         self.assertIn("browser.readiness_check", names)
@@ -194,6 +197,15 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(response.isError)
         self.assertEqual(response.structuredContent["status"], "discarded")
         self.job_queue.discard_job.assert_awaited_once_with("job-1")
+
+    async def test_cancel_agent_job_tool_forwards_arguments(self) -> None:
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(name="browser.cancel_agent_job", arguments={"job_id": "job-1"})
+        )
+
+        self.assertFalse(response.isError)
+        self.assertEqual(response.structuredContent["status"], "cancelled")
+        self.job_queue.cancel_job.assert_awaited_once_with("job-1")
 
     async def test_vision_tool_is_listed_when_targeter_is_available(self) -> None:
         names = {tool["name"] for tool in self.vision_gateway.list_tools()}

--- a/controller/tests/test_tool_gateway.py
+++ b/controller/tests/test_tool_gateway.py
@@ -102,6 +102,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.job_queue = SimpleNamespace(
             list_jobs=AsyncMock(return_value=[]),
             get_job=AsyncMock(return_value={"id": "job-1", "status": "completed"}),
+            resume_job=AsyncMock(return_value={"id": "job-2", "parent_job_id": "job-1", "status": "queued"}),
             enqueue_step=AsyncMock(return_value={"id": "job-1", "kind": "agent_step"}),
             enqueue_run=AsyncMock(return_value={"id": "job-2", "kind": "agent_run"}),
         )
@@ -144,6 +145,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("browser.execute_action", names)
         self.assertIn("browser.save_auth_profile", names)
         self.assertNotIn("browser.list_agent_jobs", names)
+        self.assertNotIn("browser.resume_agent_job", names)
         self.assertNotIn("browser.list_providers", names)
         self.assertNotIn("browser.get_remote_access", names)
         self.assertNotIn("browser.list_approvals", names)
@@ -163,6 +165,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         names = {tool["name"] for tool in self.full_gateway.list_tools()}
 
         self.assertIn("browser.list_agent_jobs", names)
+        self.assertIn("browser.resume_agent_job", names)
         self.assertIn("browser.list_providers", names)
         self.assertIn("browser.delete_memory_profile", names)
         self.assertIn("browser.readiness_check", names)
@@ -170,6 +173,15 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("social.post", names)
         self.assertIn("social.dm", names)
         self.assertNotIn("browser.find_by_vision", names)
+
+    async def test_resume_agent_job_tool_forwards_arguments(self) -> None:
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(name="browser.resume_agent_job", arguments={"job_id": "job-1", "max_steps": 2})
+        )
+
+        self.assertFalse(response.isError)
+        self.assertEqual(response.structuredContent["parent_job_id"], "job-1")
+        self.job_queue.resume_job.assert_awaited_once_with("job-1", max_steps=2)
 
     async def test_vision_tool_is_listed_when_targeter_is_available(self) -> None:
         names = {tool["name"] for tool in self.vision_gateway.list_tools()}

--- a/controller/tests/test_tool_gateway.py
+++ b/controller/tests/test_tool_gateway.py
@@ -103,6 +103,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
             list_jobs=AsyncMock(return_value=[]),
             get_job=AsyncMock(return_value={"id": "job-1", "status": "completed"}),
             resume_job=AsyncMock(return_value={"id": "job-2", "parent_job_id": "job-1", "status": "queued"}),
+            discard_job=AsyncMock(return_value={"id": "job-1", "status": "discarded"}),
             enqueue_step=AsyncMock(return_value={"id": "job-1", "kind": "agent_step"}),
             enqueue_run=AsyncMock(return_value={"id": "job-2", "kind": "agent_run"}),
         )
@@ -160,12 +161,14 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("social.search", names)
         self.assertNotIn("browser.find_by_vision", names)
         self.assertEqual(len(names), len(tools))
+        self.assertNotIn("browser.discard_agent_job", names)
 
     async def test_full_profile_keeps_internal_tools_available(self) -> None:
         names = {tool["name"] for tool in self.full_gateway.list_tools()}
 
         self.assertIn("browser.list_agent_jobs", names)
         self.assertIn("browser.resume_agent_job", names)
+        self.assertIn("browser.discard_agent_job", names)
         self.assertIn("browser.list_providers", names)
         self.assertIn("browser.delete_memory_profile", names)
         self.assertIn("browser.readiness_check", names)
@@ -182,6 +185,15 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(response.isError)
         self.assertEqual(response.structuredContent["parent_job_id"], "job-1")
         self.job_queue.resume_job.assert_awaited_once_with("job-1", max_steps=2)
+
+    async def test_discard_agent_job_tool_forwards_arguments(self) -> None:
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(name="browser.discard_agent_job", arguments={"job_id": "job-1"})
+        )
+
+        self.assertFalse(response.isError)
+        self.assertEqual(response.structuredContent["status"], "discarded")
+        self.job_queue.discard_job.assert_awaited_once_with("job-1")
 
     async def test_vision_tool_is_listed_when_targeter_is_available(self) -> None:
         names = {tool["name"] for tool in self.vision_gateway.list_tools()}

--- a/docs/agent-evals.md
+++ b/docs/agent-evals.md
@@ -11,9 +11,11 @@ Examples:
 
 ```powershell
 python scripts\agent_eval.py --json
+python scripts\agent_eval.py --report-file .\eval-report.md
 python scripts\agent_eval.py --results-dir .\eval-results
 python scripts\agent_eval.py --execute --base-url http://127.0.0.1:8000 --operator-id local-eval
 ```
 
 Saved result files are named `<case_id>__<provider>__<workflow_profile>.json`. The harness scores result status,
 final URL, observed actions, step counts, and provider errors, then aggregates each provider/profile pair.
+CI validates the eval matrix in plan mode so malformed cases cannot slip into a release branch.

--- a/docs/agent-evals.md
+++ b/docs/agent-evals.md
@@ -1,0 +1,19 @@
+# Agent Evals
+
+`scripts/agent_eval.py` runs a repeatable matrix of browser-agent cases across providers and workflow profiles.
+It has two modes:
+
+- Plan mode: prints the provider/profile matrix from `evals/agent_cases.json`.
+- Scoring mode: reads saved result JSON files and scores success criteria without starting a browser.
+- Execute mode: runs the cases against a live controller with `--execute --base-url`.
+
+Examples:
+
+```powershell
+python scripts\agent_eval.py --json
+python scripts\agent_eval.py --results-dir .\eval-results
+python scripts\agent_eval.py --execute --base-url http://127.0.0.1:8000 --operator-id local-eval
+```
+
+Saved result files are named `<case_id>__<provider>__<workflow_profile>.json`. The harness scores result status,
+final URL, observed actions, step counts, and provider errors, then aggregates each provider/profile pair.

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -38,7 +38,7 @@ Auto Browser is an open-source MCP-native control plane for authorized browser w
 
 ## Current release tag
 
-Use `v1.0.2` for current public release references.
+Use `v1.0.3` for current public release references.
 
 ## Suggested launch timing
 
@@ -62,7 +62,7 @@ See `docs/good-first-issues.md`.
 - [ ] embed GIF in README (above the fold, before quickstart)
 - [ ] verify no secrets in git history for this branch
 - [ ] prepare first 3 “good first issue” tickets (see `docs/good-first-issues.md`)
-- [ ] create GitHub release `v1.0.2` with changelog
+- [ ] create GitHub release `v1.0.3` with changelog
 - [ ] add GitHub topics: `mcp`, `browser-automation`, `playwright`, `llm`, `claude`, `ai-agent`, `self-hosted`, `local-first`, `fastapi`, `docker`
 
 ### Day 1 launch (same day, in order)

--- a/docs/llm-adapters.md
+++ b/docs/llm-adapters.md
@@ -40,6 +40,7 @@ The controller now includes:
 - provider discovery endpoint: `GET /agent/providers`
 - step endpoint: `POST /sessions/{session_id}/agent/step`
 - run endpoint: `POST /sessions/{session_id}/agent/run`
+- background job resume endpoint: `POST /agent/jobs/{job_id}/resume`
 
 ## How a step works
 
@@ -85,10 +86,34 @@ Uses the Gemini `generateContent` API with:
 {
   "provider": "claude",
   "goal": "Fill the search field with `playwright mcp` and stop before submitting.",
+  "workflow_profile": "governed",
   "max_steps": 4,
   "observation_limit": 25
 }
 ```
+
+`workflow_profile` defaults to `fast`. Use `governed` when an operator wants the
+agent to inspect first, avoid ambiguous writes, and request human takeover around
+sensitive account/payment/posting/destructive work.
+
+## Background jobs and resume
+
+Queued agent runs persist a compact checkpoint after every completed step. A
+checkpoint stores status, action, reason, URL/title, and error summary without
+raw provider text. If the controller restarts while a job is running, startup
+marks that job `interrupted` and leaves its checkpoints in the job record.
+
+Resume through REST:
+
+```bash
+curl -X POST http://localhost:8000/agent/jobs/<job_id>/resume \
+  -H "Content-Type: application/json" \
+  -d '{"max_steps": 4}'
+```
+
+The MCP full profile exposes the same behavior as `browser.resume_agent_job`.
+Resume creates a new child job with `parent_job_id` set to the original job and
+injects the checkpoint summary into `context_hints`.
 
 ## Safety behavior
 
@@ -119,6 +144,4 @@ If a provider still proposes a sensitive side effect, the controller does not tr
 ## Next production upgrades
 
 - switch OpenAI from Chat Completions to Responses API if you want one modern multimodal path everywhere
-- move provider calls into a queue/worker tier
-- add retry / loop detection policies
 - add streaming/SSE on top of the current REST + MCP surfaces when clients need server-pushed events

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -109,6 +109,10 @@ If you really want the whole surface:
 MCP_TOOL_PROFILE=full
 ```
 
+In the full profile, `browser.queue_agent_run` accepts `workflow_profile`
+(`fast` or `governed`) and `browser.resume_agent_job` resumes interrupted,
+failed, or step-limited background runs from persisted checkpoints.
+
 ## Raw tool-call example
 
 If you want to see the shape of the tool surface without wiring up a full MCP client yet:

--- a/evals/agent_cases.json
+++ b/evals/agent_cases.json
@@ -1,0 +1,31 @@
+{
+  "cases": [
+    {
+      "id": "example-domain-read",
+      "name": "Read a simple public page",
+      "start_url": "https://example.com",
+      "goal": "Confirm the page is Example Domain and finish without changing anything.",
+      "providers": ["openai", "claude"],
+      "workflow_profiles": ["fast", "governed"],
+      "max_steps": 4,
+      "expected_statuses": ["done"],
+      "expect_url_contains": ["example.com"],
+      "expect_actions": ["done"],
+      "min_step_count": 1,
+      "max_step_count": 4
+    },
+    {
+      "id": "wikipedia-search-read",
+      "name": "Navigate and extract a public fact",
+      "start_url": "https://www.wikipedia.org",
+      "goal": "Search for Playwright browser automation and stop on a relevant article or search result page.",
+      "providers": ["openai", "claude"],
+      "workflow_profiles": ["fast", "governed"],
+      "max_steps": 8,
+      "expected_statuses": ["done", "max_steps_reached"],
+      "expect_url_contains": ["wikipedia.org"],
+      "min_step_count": 1,
+      "max_step_count": 8
+    }
+  ]
+}

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.0.2"
+version = "1.0.3"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 license = { text = "MIT" }
 requires-python = ">=3.11"

--- a/scripts/agent_eval.py
+++ b/scripts/agent_eval.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROLLER = ROOT / "controller"
+if str(CONTROLLER) not in sys.path:
+    sys.path.insert(0, str(CONTROLLER))
+
+from app.agent_eval import (  # noqa: E402
+    ControllerEvalClient,
+    build_matrix,
+    load_cases,
+    score_from_result_dir,
+    score_result,
+    summarize_scores,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run or score repeatable auto-browser agent evaluations.")
+    parser.add_argument("--cases", default=str(ROOT / "evals" / "agent_cases.json"))
+    parser.add_argument("--providers", default="", help="Comma-separated provider override, e.g. openai,claude.")
+    parser.add_argument("--profiles", default="", help="Comma-separated workflow profile override, e.g. fast,governed.")
+    parser.add_argument(
+        "--results-dir",
+        default="",
+        help="Directory containing <case>__<provider>__<profile>.json files.",
+    )
+    parser.add_argument("--execute", action="store_true", help="Execute cases against a running controller.")
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000", help="Controller base URL for --execute.")
+    parser.add_argument("--bearer-token", default="")
+    parser.add_argument("--operator-id", default="")
+    parser.add_argument("--operator-name", default="")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    args = parser.parse_args()
+
+    cases = load_cases(args.cases)
+    matrix = build_matrix(
+        cases,
+        providers=_csv(args.providers),
+        workflow_profiles=_csv(args.profiles),
+    )
+
+    if args.execute:
+        client = ControllerEvalClient(
+            args.base_url,
+            bearer_token=args.bearer_token or None,
+            operator_id=args.operator_id or None,
+            operator_name=args.operator_name or None,
+        )
+        scores = []
+        for spec in matrix:
+            result = client.run_spec(spec)
+            scores.append(score_result(spec, result))
+        return _emit_scores(scores, json_output=args.json)
+
+    if args.results_dir:
+        scores = score_from_result_dir(matrix, args.results_dir)
+        return _emit_scores(scores, json_output=args.json)
+
+    plan = {
+        "cases": len(cases),
+        "runs": [
+            {
+                "case_id": spec.case.id,
+                "provider": spec.provider,
+                "workflow_profile": spec.workflow_profile,
+                "result_file": spec.result_name,
+            }
+            for spec in matrix
+        ],
+    }
+    if args.json:
+        print(json.dumps(plan, indent=2))
+    else:
+        print(f"Planned {len(matrix)} agent eval run(s) from {len(cases)} case(s).")
+        for run in plan["runs"]:
+            print(f"- {run['case_id']} provider={run['provider']} profile={run['workflow_profile']}")
+    return 0
+
+
+def _emit_scores(scores, *, json_output: bool) -> int:
+    payload = {
+        "summary": summarize_scores(scores),
+        "scores": [score.to_dict() for score in scores],
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2))
+    else:
+        for key, summary in payload["summary"].items():
+            print(
+                f"{key}: {summary['successes']}/{summary['runs']} success, "
+                f"avg={summary['average_score']:.4f}"
+            )
+        for score in payload["scores"]:
+            status = "PASS" if score["success"] else "FAIL"
+            print(f"- {status} {score['case_id']} {score['provider']}/{score['workflow_profile']}")
+    return 0 if all(score.success for score in scores) else 1
+
+
+def _csv(value: str):
+    items = tuple(item.strip() for item in value.split(",") if item.strip())
+    return items or None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_eval.py
+++ b/scripts/agent_eval.py
@@ -15,6 +15,8 @@ from app.agent_eval import (  # noqa: E402
     ControllerEvalClient,
     build_matrix,
     load_cases,
+    plan_payload,
+    render_markdown_report,
     score_from_result_dir,
     score_result,
     summarize_scores,
@@ -37,6 +39,7 @@ def main() -> int:
     parser.add_argument("--operator-id", default="")
     parser.add_argument("--operator-name", default="")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument("--report-file", default="", help="Write a Markdown report to this path.")
     args = parser.parse_args()
 
     cases = load_cases(args.cases)
@@ -57,24 +60,16 @@ def main() -> int:
         for spec in matrix:
             result = client.run_spec(spec)
             scores.append(score_result(spec, result))
+        _write_report(args.report_file, render_markdown_report(matrix, scores=scores))
         return _emit_scores(scores, json_output=args.json)
 
     if args.results_dir:
         scores = score_from_result_dir(matrix, args.results_dir)
+        _write_report(args.report_file, render_markdown_report(matrix, scores=scores))
         return _emit_scores(scores, json_output=args.json)
 
-    plan = {
-        "cases": len(cases),
-        "runs": [
-            {
-                "case_id": spec.case.id,
-                "provider": spec.provider,
-                "workflow_profile": spec.workflow_profile,
-                "result_file": spec.result_name,
-            }
-            for spec in matrix
-        ],
-    }
+    plan = plan_payload(matrix)
+    _write_report(args.report_file, render_markdown_report(matrix))
     if args.json:
         print(json.dumps(plan, indent=2))
     else:
@@ -106,6 +101,14 @@ def _emit_scores(scores, *, json_output: bool) -> int:
 def _csv(value: str):
     items = tuple(item.strip() for item in value.split(",") if item.strip())
     return items or None
+
+
+def _write_report(path: str, content: str) -> None:
+    if not path:
+        return
+    report_path = Path(path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(content, encoding="utf-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This prepares the `v1.0.3` auto-browser reliability release.

- adds durable agent-job cancellation across queue state, REST, MCP, tool gateway, and dashboard controls
- hardens worker shutdown so running jobs are persisted as interrupted instead of racing detached cancellation
- adds Markdown reporting for the agent eval matrix and validates that matrix in CI
- extracts download capture from BrowserManager into a focused service with coverage
- adds the browser-node lockfile so Node audit is reproducible
- updates README, ROADMAP, and CHANGELOG for the 1.0.3 release line

## Validation

- `python -m ruff check controller/app controller/tests scripts integrations/langchain/auto_browser_langchain --select E9,F,I --no-cache`
- `python -m compileall -q controller/app controller/tests scripts integrations/langchain/auto_browser_langchain`
- controller tests: `380 passed, 2 skipped, 26 subtests passed`
- client tests: `3 passed`
- `python scripts/agent_eval.py --json --report-file ./.pytest-tmp-controller/agent-evals.md`
- `node --check browser-node/server.mjs`
- `npm audit --omit=dev`: 0 vulnerabilities
- `pip-audit -r controller/requirements.txt`: no known vulnerabilities
- built wheels for controller, client, and langchain integration at `1.0.3`
- GitHub main before PR: latest CI/CodeQL successful, open CodeQL alerts 0, open Dependabot alerts 0
