### PR TITLE
Add MCP resource examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Client setup guides:
 - [`examples/cursor-mcp-setup.md`](./examples/cursor-mcp-setup.md)
 - [`examples/claude_desktop_config.json`](./examples/claude_desktop_config.json)
 
+For resource listing, resource reads, and subscription-style update examples,
+see [`docs/mcp-clients.md#resources-and-subscriptions`](./docs/mcp-clients.md#resources-and-subscriptions).
+
 ## Convergence Harness
 
 Auto Browser ships a Stage 0 convergence harness for Agent Skill Induction. It runs a structured task contract, records tamper-checked traces, verifies completion, and writes a staged skill candidate with signed provenance. Generated skills are staged only — promotion stays explicit and reviewed.

--- a/controller/app/mcp_transport.py
+++ b/controller/app/mcp_transport.py
@@ -262,6 +262,15 @@ class McpHttpTransport:
         ]
         if self.manager is None:
             return resources
+        if callable(getattr(self.manager, "list_audit_events", None)):
+            resources.append(
+                {
+                    "uri": "browser://audit/events",
+                    "name": "Recent Audit Events",
+                    "description": "Recent browser audit events across sessions",
+                    "mimeType": "application/json",
+                }
+            )
 
         for session_id in list(self.manager.sessions.keys()):
             resources += [
@@ -302,6 +311,15 @@ class McpHttpTransport:
                 "uri": uri,
                 "mimeType": "application/json",
                 "text": json.dumps(sessions, ensure_ascii=False),
+            }
+        if uri == "browser://audit/events":
+            if self.manager is None or not callable(getattr(self.manager, "list_audit_events", None)):
+                return None
+            events = await self.manager.list_audit_events(limit=100)
+            return {
+                "uri": uri,
+                "mimeType": "application/json",
+                "text": json.dumps(events, ensure_ascii=False),
             }
 
         # Parse browser://{session_id}/{resource}

--- a/controller/tests/test_mcp_transport.py
+++ b/controller/tests/test_mcp_transport.py
@@ -20,6 +20,15 @@ class McpTransportTests(unittest.TestCase):
         self.manager = SimpleNamespace(
             sessions={"session-1": object()},
             list_sessions=AsyncMock(return_value=[{"id": "session-1", "status": "active"}]),
+            list_audit_events=AsyncMock(
+                return_value=[
+                    {
+                        "event_type": "browser_action",
+                        "session_id": "session-1",
+                        "action": "click",
+                    }
+                ]
+            ),
         )
         self.gateway = SimpleNamespace(
             list_tools=lambda: [
@@ -320,6 +329,41 @@ class McpTransportTests(unittest.TestCase):
         body = read_response.json()
         self.assertEqual(body["error"]["code"], -32002)
         self.assertIn("Resource not found", body["error"]["message"])
+
+    def test_resources_list_and_read_audit_events_work_after_initialization(self) -> None:
+        session_id, protocol_version = self._initialize()
+        self.client.post(
+            "/mcp",
+            headers={MCP_SESSION_HEADER: session_id, MCP_PROTOCOL_HEADER: protocol_version},
+            json={"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        )
+
+        list_response = self.client.post(
+            "/mcp",
+            headers={MCP_SESSION_HEADER: session_id, MCP_PROTOCOL_HEADER: protocol_version},
+            json={"jsonrpc": "2.0", "id": 13, "method": "resources/list", "params": {}},
+        )
+        self.assertEqual(list_response.status_code, 200)
+        resource_uris = {item["uri"] for item in list_response.json()["result"]["resources"]}
+        self.assertIn("browser://audit/events", resource_uris)
+
+        read_response = self.client.post(
+            "/mcp",
+            headers={MCP_SESSION_HEADER: session_id, MCP_PROTOCOL_HEADER: protocol_version},
+            json={
+                "jsonrpc": "2.0",
+                "id": 14,
+                "method": "resources/read",
+                "params": {"uri": "browser://audit/events"},
+            },
+        )
+
+        self.assertEqual(read_response.status_code, 200)
+        contents = read_response.json()["result"]["contents"]
+        self.assertEqual(contents[0]["uri"], "browser://audit/events")
+        self.assertEqual(contents[0]["mimeType"], "application/json")
+        self.assertEqual(json.loads(contents[0]["text"])[0]["event_type"], "browser_action")
+        self.manager.list_audit_events.assert_awaited_once_with(limit=100)
 
     def test_resources_subscribe_and_unsubscribe_track_session_state(self) -> None:
         session_id, protocol_version = self._initialize()

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -88,6 +88,85 @@ The best MCP demo is:
 
 That shows why MCP + browser state reuse is more valuable than a plain “open page and click things” demo.
 
+## Resources and subscriptions
+
+MCP clients can inspect browser state through resources as well as one-shot
+tools. Start with a normal MCP initialization, keep the returned
+`MCP-Session-Id` and `MCP-Protocol-Version` headers, then send
+`notifications/initialized`.
+
+Minimal resource listing over the HTTP transport:
+
+```bash
+curl -s http://127.0.0.1:8000/mcp \
+  -X POST \
+  -H 'accept: application/json, text/event-stream' \
+  -H 'content-type: application/json' \
+  -H "MCP-Session-Id: $MCP_SESSION_ID" \
+  -H "MCP-Protocol-Version: $MCP_PROTOCOL_VERSION" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 20,
+    "method": "resources/list",
+    "params": {}
+  }' | jq
+```
+
+The default resource set includes:
+
+- `browser://sessions` for active browser sessions
+- `browser://audit/events` for recent audit events
+- `browser://<session-id>/dom`, `browser://<session-id>/screenshot`,
+  `browser://<session-id>/console`, and `browser://<session-id>/network` once a
+  session exists
+
+Read a resource by URI:
+
+```bash
+curl -s http://127.0.0.1:8000/mcp \
+  -X POST \
+  -H 'accept: application/json, text/event-stream' \
+  -H 'content-type: application/json' \
+  -H "MCP-Session-Id: $MCP_SESSION_ID" \
+  -H "MCP-Protocol-Version: $MCP_PROTOCOL_VERSION" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 21,
+    "method": "resources/read",
+    "params": {
+      "uri": "browser://audit/events"
+    }
+  }' | jq
+```
+
+Clients that support resource updates can subscribe, then keep the MCP event
+stream open with `GET /mcp`:
+
+```bash
+curl -s http://127.0.0.1:8000/mcp \
+  -X POST \
+  -H 'accept: application/json, text/event-stream' \
+  -H 'content-type: application/json' \
+  -H "MCP-Session-Id: $MCP_SESSION_ID" \
+  -H "MCP-Protocol-Version: $MCP_PROTOCOL_VERSION" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 22,
+    "method": "resources/subscribe",
+    "params": {
+      "uri": "browser://sessions"
+    }
+  }' | jq
+
+curl -N http://127.0.0.1:8000/mcp \
+  -H 'accept: text/event-stream' \
+  -H "MCP-Session-Id: $MCP_SESSION_ID" \
+  -H "MCP-Protocol-Version: $MCP_PROTOCOL_VERSION"
+```
+
+When a subscribed resource changes, the stream emits a JSON-RPC notification
+named `notifications/resources/updated` with the updated `uri`.
+
 ## Curated vs full MCP tool profile
 
 The default MCP tool profile is `curated`.


### PR DESCRIPTION
## Summary

- add a `browser://audit/events` MCP resource for reading recent audit events
- document resource listing, resource reads, and subscription-style update examples
- link the resource examples from the README MCP client section

## Validation

- [x] `python -m pytest tests/test_mcp_transport.py -q`
- [x] `ruff check controller/app controller/tests scripts/*.py --select E9,F,I`
- [x] `git diff --check`
- [x] `python scripts/release_audit.py --skip-doctor`
- [ ] `make doctor` (not run locally; `make` is unavailable in this Windows environment, and the direct release audit doctor step hits a Windows bash/CRLF `pipefail` parsing issue)
- [x] docs updated for MCP resource examples

## Risk

- Low operator-facing risk: adds a read-only audit resource and docs examples.
- No migration or env var impact.