### PR TITLE
fix(codespaces): stop double-binding ports in compose override

### DIFF
--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -1,10 +1,16 @@
 # Use in Codespaces: docker compose -f docker-compose.yml -f docker-compose.codespaces.yml up
+#
+# `!override` replaces the base service's `ports` list instead of merging with it.
+# Without it, Compose appends these entries to the base 127.0.0.1 bindings, so both
+# 127.0.0.1:PORT and 0.0.0.0:PORT are published for the same container port and the
+# second bind fails with "address already in use" (breaks the devcontainer
+# postStartCommand). Requires Docker Compose v2.24.4+ (Codespaces ships newer).
 services:
   browser-node:
-    ports:
+    ports: !override
       - "0.0.0.0:${NOVNC_PORT:-6080}:6080"
       - "0.0.0.0:${VNC_PORT:-5900}:5900"
 
   controller:
-    ports:
+    ports: !override
       - "0.0.0.0:${API_PORT:-8000}:8000"


### PR DESCRIPTION
Closes #61.

## Problem
`docker compose -f docker-compose.yml -f docker-compose.codespaces.yml up` failed with `address already in use` on 8000/6080/5900. Because it is wired into the devcontainer `postStartCommand`, fresh Codespaces never finished starting.

## Root cause
Compose merges the `ports` list **additively**. The codespaces override re-published the same container ports on `0.0.0.0`, so both `127.0.0.1:PORT` (base) and `0.0.0.0:PORT` (override) were published for one container port -> second bind fails.

## Fix
Tag the override `ports` lists with `!override` (Compose v2.24.4+) so they **replace** the base bindings instead of appending.

## Verification
`docker compose ... config` now shows a single `host_ip: 0.0.0.0` mapping per port - no duplicate 127.0.0.1 binding.