### PR TITLE
fix(deps): prometheus-client 0.25.0 + de-brittle metrics test

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -9,7 +9,7 @@ cryptography==49.0.0
 Pillow==12.2.0
 pytesseract==0.3.13
 docker==7.1.0
-prometheus-client==0.22.1
+prometheus-client==0.25.0
 pyotp==2.10.0
 apscheduler==3.11.2
 tomli==2.3.0; python_version < "3.11"

--- a/controller/tests/test_metrics.py
+++ b/controller/tests/test_metrics.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import unittest
 
+from prometheus_client import CONTENT_TYPE_LATEST
+
 from app.metrics import MetricsRecorder
 
 
@@ -21,7 +23,7 @@ class MetricsRecorderTests(unittest.TestCase):
         self.assertIn("auto_browser_mcp_tool_duration_seconds", text)
         self.assertIn('tool="browser.observe"', text)
         self.assertIn("auto_browser_active_sessions", text)
-        self.assertEqual(content_type, "text/plain; version=0.0.4; charset=utf-8")
+        self.assertEqual(content_type, CONTENT_TYPE_LATEST)
 
     def test_disabled_recorder_suppresses_output(self) -> None:
         recorder = MetricsRecorder(enabled=False)
@@ -32,7 +34,7 @@ class MetricsRecorderTests(unittest.TestCase):
         payload, content_type = recorder.render()
 
         self.assertEqual(payload, b"")
-        self.assertEqual(content_type, "text/plain; version=0.0.4; charset=utf-8")
+        self.assertEqual(content_type, CONTENT_TYPE_LATEST)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Supersedes #52.

Dependabot #52 bumped prometheus-client 0.22.1 -> 0.25.0 but broke `test_metrics`: 0.25 changed the exposition format version (`0.0.4` -> `1.0.0`), so the hardcoded `text/plain; version=0.0.4` content-type assertion failed.

This PR bumps the pin **and** fixes the root brittleness by asserting against `prometheus_client.CONTENT_TYPE_LATEST` (version-agnostic). Verified locally on 0.25.0: metrics tests pass, ruff clean.