### PR TITLE
fix(auth): warn when API_BEARER_TOKEN unset in non-production

### DIFF
--- a/controller/app/runtime_policy.py
+++ b/controller/app/runtime_policy.py
@@ -133,6 +133,11 @@ def validate_runtime_policy(settings: Settings) -> RuntimePolicyReport:
     report = RuntimePolicyReport()
 
     if not settings.is_production:
+        if not settings.api_bearer_token:
+            report.warnings.append(
+                "API_BEARER_TOKEN is unset; the controller serves every route unauthenticated. "
+                "Set it before exposing this instance on a non-loopback address."
+            )
         return report
 
     if not settings.api_bearer_token:

--- a/controller/tests/test_runtime_policy.py
+++ b/controller/tests/test_runtime_policy.py
@@ -52,6 +52,26 @@ class RuntimePolicyTests(unittest.TestCase):
         self.assertTrue(report.ok)
         self.assertEqual(report.errors, [])
 
+    def test_development_warns_when_bearer_token_unset(self) -> None:
+        settings = Settings(_env_file=None, APP_ENV="development")
+
+        report = validate_runtime_policy(settings)
+
+        self.assertTrue(report.ok)
+        self.assertTrue(
+            any("API_BEARER_TOKEN is unset" in w for w in report.warnings),
+            report.warnings,
+        )
+
+    def test_development_no_bearer_warning_when_token_set(self) -> None:
+        settings = Settings(
+            _env_file=None, APP_ENV="development", API_BEARER_TOKEN="dev-token"
+        )
+
+        report = validate_runtime_policy(settings)
+
+        self.assertFalse(any("API_BEARER_TOKEN is unset" in w for w in report.warnings))
+
     def test_production_requires_security_basics(self) -> None:
         settings = Settings(
             _env_file=None,


### PR DESCRIPTION
Production already hard-fails without a bearer token, but non-production deploys returned early with no signal and served every route unauthenticated. Emit a runtime-policy warning in that path so a reachable dev/staging box is not silently open. Adds coverage for the warn/no-warn cases.

Verified: 13 runtime-policy tests pass, ruff clean.