### PR TITLE
test(tabs): closed-tab recovery fixture + active-tab regression (closes #33)

### DIFF
--- a/controller/tests/test_tabs_and_providers.py
+++ b/controller/tests/test_tabs_and_providers.py
@@ -123,6 +123,22 @@ class BrowserTabManagementTests(unittest.IsolatedAsyncioTestCase):
         # Active page unchanged
         self.assertIs(self.session.page, original_page)
 
+    async def test_close_active_tab_recovers_to_a_usable_tab(self) -> None:
+        # Regression for closed-tab recovery: closing the ACTIVE tab must leave the
+        # session pointing at a live, usable tab — never at the page we just closed.
+        closed_page = self.session.page  # "Home", index 0, currently active
+
+        result = await self.manager.close_tab(self.session.id, 0)
+
+        self.assertTrue(closed_page.closed)
+        self.assertEqual(len(result["tabs"]), 1)
+        # The active page must have moved to the surviving tab, and be usable.
+        self.assertIsNot(self.session.page, closed_page)
+        self.assertFalse(self.session.page.closed)
+        self.assertEqual(self.session.page.url, "https://example.com/export")
+        # The recovered tab is brought to the foreground.
+        self.assertEqual(self.session.page.front_calls, 1)
+
 
 class ProviderRegistryLoginCommandTests(unittest.TestCase):
     def test_cli_modes_expose_login_commands(self) -> None:

--- a/evals/fixture_cases.json
+++ b/evals/fixture_cases.json
@@ -48,6 +48,17 @@
       "headline": "multi-tab recovery",
       "required_text": ["Primary workspace", "Open support tab"],
       "required_fragments": ["target=\"_blank\"", "data-eval-action=\"activate-tab\""]
+    },
+    {
+      "id": "closed-tab-recovery",
+      "fixture": "closed_tab_recovery.html",
+      "headline": "closed tab recovery returns to the active tab",
+      "required_text": ["Primary workspace", "Close support tab", "Return to primary workspace"],
+      "required_fragments": [
+        "data-eval-action=\"close-tab\"",
+        "data-eval-action=\"activate-tab\"",
+        "data-eval-active-tab=\"primary\""
+      ]
     }
   ]
 }

--- a/evals/fixtures/closed_tab_recovery.html
+++ b/evals/fixtures/closed_tab_recovery.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Closed tab recovery fixture</title>
+  </head>
+  <body>
+    <main>
+      <h1>Primary workspace</h1>
+      <p>
+        Open the support tab, then close it and return here. The agent must not be
+        left stranded on the closed tab.
+      </p>
+
+      <!-- Opens a child/support tab. -->
+      <a
+        id="open-support-tab"
+        href="support_tab.html"
+        target="_blank"
+        rel="noopener"
+        data-eval-action="open-tab"
+        >Open support tab</a
+      >
+
+      <!-- Closes the support tab (the popup/child). -->
+      <button id="close-support-tab" type="button" data-eval-action="close-tab">
+        Close support tab
+      </button>
+
+      <!-- Returns focus to this primary workspace tab. -->
+      <button id="return-to-primary" type="button" data-eval-action="activate-tab">
+        Return to primary workspace
+      </button>
+
+      <p id="primary-marker" data-eval-active-tab="primary">
+        You are back on the primary workspace tab.
+      </p>
+    </main>
+  </body>
+</html>

--- a/scripts/fixture_eval.py
+++ b/scripts/fixture_eval.py
@@ -16,6 +16,7 @@ MANDATORY_CASES = {
     "approval-required-upload",
     "resume-after-failure",
     "multi-tab-recovery",
+    "closed-tab-recovery",
 }
 
 


### PR DESCRIPTION
Closes #33.

**Done when:**
- ✅ New fixture: `evals/fixtures/closed_tab_recovery.html` (open support tab → close it → return to the primary/active tab).
- ✅ `scripts/fixture_eval.py` includes it as a mandatory case (`closed-tab-recovery`); `fixture_eval` now validates 7 cases.
- ✅ Controller regression `test_close_active_tab_recovers_to_a_usable_tab`: closing the **active** tab must leave the session on a live, foregrounded tab — the test fails if the active tab is left unusable (pointing at the closed page).

No live browser/network deps.