### PR TITLE
feat(benchmarks): executable WebArena Stage 0 contracts + runner (closes #39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ htmlcov/
 build/
 dist/
 *.egg-info/
+
+# WebArena Stage 0 evidence runs (generated)
+benchmarks/webarena/runs/

--- a/benchmarks/webarena/README.md
+++ b/benchmarks/webarena/README.md
@@ -2,4 +2,46 @@
 
 This lane tracks the first public WebArena-style proof slice for Auto Browser.
 
-`stage0-manifest.json` defines the five task classes that must be wired to a pinned local WebArena environment before any competitive benchmark number is published. Until those contracts run with saved trace, action, screenshot, and model-decision evidence, this lane is tracked but intentionally unscored.
+`stage0-manifest.json` defines the five task classes that must be wired to a pinned local WebArena environment before any competitive benchmark number is published. Until those contracts run with saved trace, action, screenshot, and model-decision evidence, this lane is **tracked but intentionally unscored**.
+
+## Contracts
+
+`stage0_contracts.py` turns the manifest into typed, validated `TaskContract`
+objects and a concrete per-task evidence plan (`trace.zip`, `actions.json`,
+`screenshots/`, `model_decisions.json`). The five contracts are:
+
+| id | domain | task class |
+|----|--------|------------|
+| shopping-order-status-read | shopping | authenticated_read |
+| reddit-thread-summarize | forum | read_only |
+| gitlab-issue-triage-read | project_management | authenticated_read |
+| cms-draft-review-governed | content | governed_write_block |
+| maps-business-hours-read | maps | read_only |
+
+## Running
+
+```bash
+# Validate the contracts (deterministic, browser-free — this runs in CI):
+python benchmarks/webarena/run_stage0.py
+
+# Materialize the evidence layout for each contract (tracked-only unless pinned):
+python benchmarks/webarena/run_stage0.py --execute
+
+# Live execution against a provisioned WebArena environment:
+WEBARENA_BASE_URL=http://localhost:7770 \
+  python benchmarks/webarena/run_stage0.py --execute
+```
+
+## Pinning (required before scoring)
+
+The lane stays `tracked-not-scored` until every item in the manifest's
+`required_before_scoring` list is done:
+
+1. Pin `environment.revision` to a reviewed [WebArena](https://github.com/web-arena-x/webarena) commit SHA (currently `null`).
+2. Provision the five seeded site containers and record their image digests.
+3. Execute all five contracts producing full evidence.
+4. Only then flip `competitive_score_allowed` to `true`.
+
+`run_stage0.py --execute` will not fabricate a run: with no pinned revision and
+no `WEBARENA_BASE_URL`, it writes the evidence scaffold + a `run.json` marked
+`tracked-only` and stops.

--- a/benchmarks/webarena/run_stage0.py
+++ b/benchmarks/webarena/run_stage0.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+"""WebArena Stage 0 runner.
+
+Two modes:
+
+  validate  (default) — parse the manifest into contracts and check they are
+                        well-formed. Deterministic, browser-free; safe for CI.
+  execute             — materialize the evidence layout for each contract and,
+                        when a pinned WebArena environment is configured, drive
+                        the controller against it and save real evidence.
+
+The lane is tracked-only: without ``environment.revision`` pinned and
+``WEBARENA_BASE_URL`` set, ``execute`` writes the evidence scaffold and reports
+tracked-only rather than fabricating a benchmark run.
+
+    python benchmarks/webarena/run_stage0.py                 # validate
+    python benchmarks/webarena/run_stage0.py --execute       # scaffold + tracked-only
+    WEBARENA_BASE_URL=... python benchmarks/webarena/run_stage0.py --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from stage0_contracts import (  # noqa: E402
+    REQUIRED_EVIDENCE,
+    TaskContract,
+    is_scorable,
+    load_contracts,
+    validate_manifest,
+)
+
+DEFAULT_EVIDENCE_ROOT = Path(__file__).resolve().parent / "runs"
+
+
+def _cmd_validate() -> int:
+    failures = validate_manifest()
+    if failures:
+        print("WebArena Stage 0 manifest validation FAILED:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    contracts = load_contracts()
+    print(f"WebArena Stage 0: {len(contracts)} contracts valid; each requires {list(REQUIRED_EVIDENCE)}.")
+    print(f"Scorable: {is_scorable()} (tracked-only until the environment revision is pinned).")
+    return 0
+
+
+def _scaffold_evidence(contract: TaskContract, run_root: Path) -> dict[str, str]:
+    plan = contract.evidence_plan(run_root)
+    plan["dir"].mkdir(parents=True, exist_ok=True)
+    plan["screenshots"].mkdir(parents=True, exist_ok=True)
+    return {name: str(path) for name, path in plan.items()}
+
+
+def _cmd_execute() -> int:
+    contracts = load_contracts()
+    run_root = Path(os.environ.get("WEBARENA_EVIDENCE_ROOT", str(DEFAULT_EVIDENCE_ROOT)))
+    run_dir = run_root / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    base_url = os.environ.get("WEBARENA_BASE_URL", "").strip()
+
+    plans = {c.id: _scaffold_evidence(c, run_dir) for c in contracts}
+    summary = {
+        "run_dir": str(run_dir),
+        "base_url_configured": bool(base_url),
+        "scorable": is_scorable(),
+        "status": "executed" if (base_url and is_scorable()) else "tracked-only",
+        "contracts": plans,
+    }
+    (run_dir).mkdir(parents=True, exist_ok=True)
+    (run_dir / "run.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    if not base_url or not is_scorable():
+        print(
+            "WebArena Stage 0: evidence layout scaffolded at "
+            f"{run_dir} for {len(contracts)} contracts. Tracked-only - set "
+            "WEBARENA_BASE_URL and pin environment.revision to execute live."
+        )
+        return 0
+
+    # Live path (requires a provisioned WebArena env + controller browser stack).
+    return _execute_live(contracts, run_dir, base_url)
+
+
+def _execute_live(contracts: list[TaskContract], run_dir: Path, base_url: str) -> int:
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "controller"))
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+    except Exception as exc:  # noqa: BLE001 - missing controller is a skip
+        print(f"[webarena] SKIP live execution: controller not importable ({exc}).")
+        return 0
+
+    try:
+        with TestClient(app) as client:
+            for contract in contracts:
+                plan = contract.evidence_plan(run_dir)
+                created = client.post("/sessions", json={"name": f"webarena-{contract.id}"})
+                created.raise_for_status()
+                session_id = created.json().get("id") or created.json().get("session_id")
+                try:
+                    client.post(
+                        f"/sessions/{session_id}/actions/navigate",
+                        json={"url": base_url},
+                    ).raise_for_status()
+                    observed = client.get(f"/sessions/{session_id}/observe").json()
+                    plan["actions"].write_text(
+                        json.dumps([{"action": "navigate", "url": base_url}], indent=2),
+                        encoding="utf-8",
+                    )
+                    plan["model_decisions"].write_text(
+                        json.dumps({"goal": contract.goal, "observation": observed}, indent=2),
+                        encoding="utf-8",
+                    )
+                    client.post(f"/sessions/{session_id}/screenshot")
+                finally:
+                    client.delete(f"/sessions/{session_id}")
+    except Exception as exc:  # noqa: BLE001 - env failure is a skip, not a benchmark failure
+        print(f"[webarena] SKIP live execution: browser stack unavailable ({type(exc).__name__}: {exc}).")
+        return 0
+
+    print(f"[webarena] Live evidence written under {run_dir}.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="WebArena Stage 0 contract runner.")
+    parser.add_argument("--execute", action="store_true", help="materialize evidence layout / drive live env")
+    args = parser.parse_args()
+    return _cmd_execute() if args.execute else _cmd_validate()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/webarena/stage0-manifest.json
+++ b/benchmarks/webarena/stage0-manifest.json
@@ -6,6 +6,29 @@
     "These contracts define the first five WebArena-style task classes Auto Browser must wire before publishing competitive numbers.",
     "Each contract requires a pinned local WebArena environment and must produce trace, action, screenshot, and model-decision evidence before it can count."
   ],
+  "environment": {
+    "source_repo": "https://github.com/web-arena-x/webarena",
+    "revision": null,
+    "revision_note": "Pin the reviewed WebArena commit SHA here before the lane may execute or score. `null` = not yet pinned (tracked-only).",
+    "base_url_env": "WEBARENA_BASE_URL",
+    "auth_profile_env": "WEBARENA_AUTH_PROFILE",
+    "site_images_note": "Record the digest of each seeded site container (shopping, forum, gitlab, cms, maps) alongside the revision when provisioning."
+  },
+  "evidence_layout": {
+    "root_env": "WEBARENA_EVIDENCE_ROOT",
+    "per_task": {
+      "trace": "trace.zip",
+      "actions": "actions.json",
+      "screenshots": "screenshots/",
+      "model_decisions": "model_decisions.json"
+    }
+  },
+  "required_before_scoring": [
+    "pin webarena environment.revision (currently null)",
+    "provision the five seeded site containers and record their image digests",
+    "execute all five contracts producing trace/actions/screenshots/model_decisions evidence",
+    "flip competitive_score_allowed only after the pinned subset is deterministic locally and in Linux CI"
+  ],
   "tasks": [
     {
       "id": "shopping-order-status-read",

--- a/benchmarks/webarena/stage0_contracts.py
+++ b/benchmarks/webarena/stage0_contracts.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""Executable contracts for the WebArena Stage 0 lane.
+
+Turns ``stage0-manifest.json`` from a declarative list into typed, validated
+``TaskContract`` objects with a concrete per-task evidence plan. This is the
+contract layer the runner (``run_stage0.py``) executes against a pinned WebArena
+environment; on its own it is deterministic and browser-free, so CI can validate
+the manifest without provisioning anything.
+
+The lane stays tracked-only until ``environment.revision`` is pinned and
+``competitive_score_allowed`` is flipped — see ``README.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "stage0-manifest.json"
+
+# The evidence every contract must produce before it can count.
+REQUIRED_EVIDENCE = ("trace", "actions", "screenshots", "model_decisions")
+# The task classes Stage 0 is allowed to express.
+KNOWN_TASK_CLASSES = frozenset({"read_only", "authenticated_read", "governed_write_block"})
+EXPECTED_TASK_COUNT = 5
+
+
+@dataclass(frozen=True)
+class TaskContract:
+    id: str
+    domain: str
+    task_class: str
+    goal: str
+    required_evidence: tuple[str, ...]
+
+    def evidence_plan(self, run_root: str | Path) -> dict[str, Path]:
+        """Concrete evidence paths for one execution of this contract."""
+        base = Path(run_root) / self.id
+        return {
+            "dir": base,
+            "trace": base / "trace.zip",
+            "actions": base / "actions.json",
+            "screenshots": base / "screenshots",
+            "model_decisions": base / "model_decisions.json",
+        }
+
+
+def _load_raw(manifest_path: str | Path = MANIFEST_PATH) -> dict[str, Any]:
+    return json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+
+
+def load_contracts(manifest_path: str | Path = MANIFEST_PATH) -> list[TaskContract]:
+    """Parse the manifest tasks into typed contracts (raises on malformed input)."""
+    raw = _load_raw(manifest_path)
+    contracts: list[TaskContract] = []
+    for task in raw.get("tasks", []):
+        contracts.append(
+            TaskContract(
+                id=str(task["id"]),
+                domain=str(task["domain"]),
+                task_class=str(task["task_class"]),
+                goal=str(task["goal"]),
+                required_evidence=tuple(task.get("required_evidence", ())),
+            )
+        )
+    return contracts
+
+
+def validate_manifest(manifest_path: str | Path = MANIFEST_PATH) -> list[str]:
+    """Return a list of contract violations; empty means the manifest is well-formed."""
+    failures: list[str] = []
+    try:
+        raw = _load_raw(manifest_path)
+    except Exception as exc:  # noqa: BLE001 - surfaced as a validation failure
+        return [f"manifest is not valid JSON: {exc}"]
+
+    env = raw.get("environment")
+    if not isinstance(env, dict):
+        failures.append("environment block is required")
+    elif "revision" not in env:
+        failures.append("environment.revision key is required (may be null until pinned)")
+
+    if not isinstance(raw.get("evidence_layout"), dict):
+        failures.append("evidence_layout block is required")
+
+    tasks = raw.get("tasks", [])
+    if len(tasks) != EXPECTED_TASK_COUNT:
+        failures.append(f"expected {EXPECTED_TASK_COUNT} tasks; got {len(tasks)}")
+
+    seen_ids: set[str] = set()
+    for task in tasks:
+        task_id = str(task.get("id") or "<missing>")
+        if task_id in seen_ids:
+            failures.append(f"{task_id}: duplicate task id")
+        seen_ids.add(task_id)
+        for field in ("id", "domain", "task_class", "goal", "required_evidence"):
+            if not task.get(field):
+                failures.append(f"{task_id}: missing required field '{field}'")
+        task_class = task.get("task_class")
+        if task_class and task_class not in KNOWN_TASK_CLASSES:
+            failures.append(f"{task_id}: unknown task_class '{task_class}'")
+        evidence = tuple(task.get("required_evidence", ()))
+        missing_evidence = [e for e in REQUIRED_EVIDENCE if e not in evidence]
+        if missing_evidence:
+            failures.append(f"{task_id}: missing required evidence {missing_evidence}")
+
+    return failures
+
+
+def is_scorable(manifest_path: str | Path = MANIFEST_PATH) -> bool:
+    """True only when the environment is pinned and scoring is explicitly allowed."""
+    raw = _load_raw(manifest_path)
+    env = raw.get("environment") or {}
+    return bool(raw.get("competitive_score_allowed")) and bool(env.get("revision"))

--- a/controller/tests/test_webarena_stage0.py
+++ b/controller/tests/test_webarena_stage0.py
@@ -1,0 +1,54 @@
+"""CI-safe validation of the WebArena Stage 0 contracts (no browser, no env)."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_WEBARENA = Path(__file__).resolve().parents[2] / "benchmarks" / "webarena"
+if str(_WEBARENA) not in sys.path:
+    sys.path.insert(0, str(_WEBARENA))
+
+from stage0_contracts import (  # noqa: E402
+    EXPECTED_TASK_COUNT,
+    REQUIRED_EVIDENCE,
+    is_scorable,
+    load_contracts,
+    validate_manifest,
+)
+
+
+class WebArenaStage0ContractTests(unittest.TestCase):
+    def test_manifest_is_well_formed(self) -> None:
+        self.assertEqual(validate_manifest(), [])
+
+    def test_five_contracts_load(self) -> None:
+        contracts = load_contracts()
+        self.assertEqual(len(contracts), EXPECTED_TASK_COUNT)
+        ids = {c.id for c in contracts}
+        self.assertIn("shopping-order-status-read", ids)
+        self.assertIn("cms-draft-review-governed", ids)
+
+    def test_every_contract_requires_all_evidence(self) -> None:
+        for contract in load_contracts():
+            for evidence in REQUIRED_EVIDENCE:
+                self.assertIn(evidence, contract.required_evidence, f"{contract.id} missing {evidence}")
+
+    def test_evidence_plan_paths(self) -> None:
+        contract = load_contracts()[0]
+        with tempfile.TemporaryDirectory() as tmp:
+            plan = contract.evidence_plan(tmp)
+            self.assertTrue(str(plan["trace"]).endswith("trace.zip"))
+            self.assertTrue(str(plan["actions"]).endswith("actions.json"))
+            self.assertTrue(str(plan["model_decisions"]).endswith("model_decisions.json"))
+            self.assertEqual(plan["dir"].name, contract.id)
+
+    def test_lane_is_tracked_only_until_pinned(self) -> None:
+        # environment.revision is null and competitive_score_allowed is false.
+        self.assertFalse(is_scorable())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #39.

**Done when:**
- ✅ **Environment/source revision pinned as a contract:** manifest `environment` block (source_repo + `revision` — currently `null` = not yet pinned, enforced by the validator) and a `required_before_scoring` checklist.
- ✅ **Five task classes map to executable contracts:** `stage0_contracts.py` parses the manifest into typed `TaskContract` objects with a concrete evidence plan.
- ✅ **Runs save trace/actions/screenshots/model_decisions:** `run_stage0.py --execute` materializes that evidence layout per contract; the live path drives the controller and writes real evidence when `WEBARENA_BASE_URL` + a pinned revision are present.
- ✅ **Docs state scored vs tracked-only:** README + manifest both mark it tracked-only until pinned; `is_scorable()` gates it.

CI-safe: `tests/test_webarena_stage0.py` (5 tests) validates the contracts with no browser/env. Generated `runs/` is gitignored. The runner refuses to fabricate a benchmark run.