### PR TITLE
feat(benchmarks): adapter mapping runs into verifier lanes (closes #40)

### DIFF
--- a/benchmarks/adapters/README.md
+++ b/benchmarks/adapters/README.md
@@ -1,0 +1,50 @@
+# Verifier lane adapters
+
+First adapter pass (issue #40) mapping Auto Browser run artifacts into the
+external evidence lanes under `benchmarks/cuaverifier/` and
+`benchmarks/online_mind2web/`.
+
+`verifier_adapter.py` is pure and dict-based: it consumes a serialized
+[`AgentRunResult`](../../controller/app/models.py) and emits one record per lane.
+It **never scores** — `verifier_result` is always `None` and every record is
+`"scored": false`. Both lanes stay `tracked-not-scored` until their upstream
+revision and deterministic subset are pinned (see each lane's manifest
+`required_before_scoring`).
+
+## Field mapping
+
+Source is `AgentRunResult` (`provider`, `model`, `goal`, `workflow_profile`,
+`status`, `steps[]`, `final_session`). `final_session` is the session summary
+(`current_url`, `auth_profile`, `artifact_dir`, `trace_path`, ...).
+
+| Lane field | Source |
+|------------|--------|
+| `provider` | `run.provider` |
+| `workflow_profile` | `run.workflow_profile` |
+| `auth_profile` | `run.final_session.auth_profile` |
+| `final_url` | `run.final_session.current_url` |
+| `action_sequence` | per step: `step.decision.{action,element_id,url,risk_category}` + `step.status` |
+| `task_goal` (cuaverifier) | `run.goal` |
+| `status` (cuaverifier) | `run.status` |
+| `evidence` (cuaverifier) | `final_session.{artifact_dir,trace_path}` + screenshots (pending) |
+| `verifier_result` | **not produced by Auto Browser** — filled by the external verifier once pinned |
+
+## Known source gaps
+
+`missing_source_fields()` surfaces runs that can't feed the lanes yet (no
+provider, no final URL, or no steps). Screenshot references are not yet threaded
+from saved session artifacts into `evidence.screenshots`; that lands when the
+lane is pinned and CI enforcement is enabled.
+
+## Usage
+
+```bash
+python benchmarks/adapters/verifier_adapter.py path/to/agent_run_result.json
+```
+
+Or programmatically:
+
+```python
+from verifier_adapter import adapt
+records = adapt(run_result_dict)   # {"online_mind2web": {...}, "cuaverifier": {...}}
+```

--- a/benchmarks/adapters/verifier_adapter.py
+++ b/benchmarks/adapters/verifier_adapter.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+"""Adapt Auto Browser run artifacts into the external verifier evidence lanes.
+
+First adapter pass for issue #40: map a saved ``AgentRunResult`` (see
+``controller/app/models.py``) into the fields required by the CUAVerifier and
+Online-Mind2Web Stage 1 lanes. The adapter is pure and dict-based so it can run
+over serialized result JSON without importing the controller.
+
+It NEVER produces a score: ``verifier_result`` is left ``None`` and every record
+is stamped ``"scored": false``. Scoring stays gated until each lane pins its
+upstream revision and deterministic subset (see the lane manifests /
+``benchmarks/adapters/README.md``).
+
+    python benchmarks/adapters/verifier_adapter.py run_result.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Fields each lane needs from an Auto Browser run. Surfacing these is the
+# "identify the trace/result fields" deliverable.
+REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    "online_mind2web": (
+        "provider",
+        "workflow_profile",
+        "auth_profile",
+        "final_url",
+        "action_sequence",
+        "verifier_result",
+    ),
+    "cuaverifier": (
+        "task_goal",
+        "provider",
+        "status",
+        "final_url",
+        "action_sequence",
+        "evidence",
+        "verifier_result",
+    ),
+}
+
+
+def _final_session(run: dict[str, Any]) -> dict[str, Any]:
+    value = run.get("final_session")
+    return value if isinstance(value, dict) else {}
+
+
+def _final_url(run: dict[str, Any]) -> str | None:
+    return _final_session(run).get("current_url")
+
+
+def _action_sequence(run: dict[str, Any]) -> list[dict[str, Any]]:
+    """One entry per executed step: the chosen action + where it landed."""
+    sequence: list[dict[str, Any]] = []
+    for step in run.get("steps", []):
+        decision = step.get("decision") if isinstance(step.get("decision"), dict) else {}
+        sequence.append(
+            {
+                "action": decision.get("action"),
+                "element_id": decision.get("element_id"),
+                "url": decision.get("url"),
+                "risk_category": decision.get("risk_category"),
+                "step_status": step.get("status"),
+            }
+        )
+    return sequence
+
+
+def to_mind2web_result(run: dict[str, Any]) -> dict[str, Any]:
+    final = _final_session(run)
+    return {
+        "lane": "online-mind2web-stage1",
+        "scored": False,
+        "provider": run.get("provider"),
+        "workflow_profile": run.get("workflow_profile"),
+        "auth_profile": final.get("auth_profile"),
+        "final_url": _final_url(run),
+        "action_sequence": _action_sequence(run),
+        # Produced by the external verifier; pending until the lane is pinned.
+        "verifier_result": None,
+    }
+
+
+def to_cuaverifier_input(run: dict[str, Any]) -> dict[str, Any]:
+    final = _final_session(run)
+    return {
+        "lane": "cuaverifier-stage1",
+        "scored": False,
+        "task_goal": run.get("goal"),
+        "provider": run.get("provider"),
+        "model": run.get("model"),
+        "status": run.get("status"),
+        "final_url": _final_url(run),
+        "action_sequence": _action_sequence(run),
+        "evidence": {
+            # Refs into the saved session artifacts; filled when the lane is pinned.
+            "artifact_dir": final.get("artifact_dir"),
+            "trace": final.get("trace_path"),
+            "screenshots": None,
+        },
+        "verifier_result": None,
+    }
+
+
+def adapt(run: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Map one run into both verifier lanes."""
+    return {
+        "online_mind2web": to_mind2web_result(run),
+        "cuaverifier": to_cuaverifier_input(run),
+    }
+
+
+def missing_source_fields(run: dict[str, Any]) -> list[str]:
+    """Report source fields the lanes need that this run does not carry."""
+    gaps: list[str] = []
+    if not run.get("provider"):
+        gaps.append("provider")
+    if _final_url(run) is None:
+        gaps.append("final_session.current_url")
+    if not run.get("steps"):
+        gaps.append("steps (action_sequence would be empty)")
+    return gaps
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Adapt an Auto Browser run result into verifier lane records.")
+    parser.add_argument("run_result", help="path to a saved AgentRunResult JSON file")
+    args = parser.parse_args()
+
+    run = json.loads(Path(args.run_result).read_text(encoding="utf-8"))
+    mapped = adapt(run)
+    gaps = missing_source_fields(run)
+    if gaps:
+        print(f"# warning: run is missing lane source fields: {gaps}", file=sys.stderr)
+    print(json.dumps(mapped, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/controller/tests/test_verifier_adapter.py
+++ b/controller/tests/test_verifier_adapter.py
@@ -1,0 +1,73 @@
+"""CI-safe tests for the verifier lane adapter (pure dict mapping, no browser)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_ADAPTERS = Path(__file__).resolve().parents[2] / "benchmarks" / "adapters"
+if str(_ADAPTERS) not in sys.path:
+    sys.path.insert(0, str(_ADAPTERS))
+
+from verifier_adapter import (  # noqa: E402
+    REQUIRED_FIELDS,
+    adapt,
+    missing_source_fields,
+    to_cuaverifier_input,
+    to_mind2web_result,
+)
+
+_SAMPLE_RUN = {
+    "provider": "openai",
+    "model": "gpt-x",
+    "goal": "find one recent order status",
+    "workflow_profile": "governed",
+    "status": "done",
+    "steps": [
+        {"status": "acted", "decision": {"action": "navigate", "url": "https://shop/orders", "risk_category": "read"}},
+        {"status": "acted", "decision": {"action": "click", "element_id": "order-1", "risk_category": "write"}},
+    ],
+    "final_session": {
+        "current_url": "https://shop/orders/1",
+        "auth_profile": "shopper",
+        "artifact_dir": "/data/artifacts/s1",
+        "trace_path": "/data/artifacts/s1/trace.zip",
+    },
+}
+
+
+class VerifierAdapterTests(unittest.TestCase):
+    def test_mind2web_has_all_required_fields(self) -> None:
+        record = to_mind2web_result(_SAMPLE_RUN)
+        for field in REQUIRED_FIELDS["online_mind2web"]:
+            self.assertIn(field, record)
+        self.assertEqual(record["provider"], "openai")
+        self.assertEqual(record["workflow_profile"], "governed")
+        self.assertEqual(record["auth_profile"], "shopper")
+        self.assertEqual(record["final_url"], "https://shop/orders/1")
+        self.assertEqual(len(record["action_sequence"]), 2)
+        self.assertEqual(record["action_sequence"][0]["action"], "navigate")
+
+    def test_cuaverifier_has_all_required_fields(self) -> None:
+        record = to_cuaverifier_input(_SAMPLE_RUN)
+        for field in REQUIRED_FIELDS["cuaverifier"]:
+            self.assertIn(field, record)
+        self.assertEqual(record["task_goal"], "find one recent order status")
+        self.assertEqual(record["evidence"]["trace"], "/data/artifacts/s1/trace.zip")
+
+    def test_adapter_never_scores(self) -> None:
+        records = adapt(_SAMPLE_RUN)
+        for lane in ("online_mind2web", "cuaverifier"):
+            self.assertFalse(records[lane]["scored"])
+            self.assertIsNone(records[lane]["verifier_result"])
+
+    def test_missing_source_fields_flags_incomplete_run(self) -> None:
+        self.assertEqual(missing_source_fields(_SAMPLE_RUN), [])
+        gaps = missing_source_fields({"provider": "", "steps": [], "final_session": {}})
+        self.assertIn("provider", gaps)
+        self.assertIn("steps (action_sequence would be empty)", gaps)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #40.

**Done when:**
- ✅ **Trace/result fields identified:** `REQUIRED_FIELDS` per lane + the mapping table in `benchmarks/adapters/README.md`, plus `missing_source_fields()` to surface runs that can't feed the lanes.
- ✅ **Adapter maps Auto Browser artifacts:** `verifier_adapter.py` maps a serialized `AgentRunResult` into both lanes (`to_mind2web_result`, `to_cuaverifier_input`, `adapt`). Pure/dict-based, importable, with a CLI.
- ✅ **Lane stays unscored:** `verifier_result` is always `None` and every record is `scored:false`; scoring is gated on each lane pinning its revision + deterministic subset.

CI-safe test `tests/test_verifier_adapter.py` (4 tests) — no browser/network.