### PR TITLE
docs(mcp): resources & subscription examples (closes #34)

### DIFF
--- a/controller/tests/test_mcp_resources_doc.py
+++ b/controller/tests/test_mcp_resources_doc.py
@@ -1,0 +1,44 @@
+"""Guard: the MCP resources example doc stays in sync with the transport.
+
+If a resource URI scheme or subscription method changes in code, this test
+fails so the documented example (examples/mcp-resources.md) is updated too.
+No browser/network — inspects the module source and the doc text.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_DOC = _REPO / "examples" / "mcp-resources.md"
+_TRANSPORT = _REPO / "controller" / "app" / "mcp_transport.py"
+
+
+class McpResourcesDocTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.doc = _DOC.read_text(encoding="utf-8")
+        self.transport = _TRANSPORT.read_text(encoding="utf-8")
+
+    def test_documented_resource_schemes_exist_in_code(self) -> None:
+        for suffix in ("screenshot", "dom", "console", "network"):
+            self.assertIn(f'browser://{{session_id}}/{suffix}', self.transport, suffix)
+            self.assertIn(f"browser://<session-id>/{suffix}", self.doc, suffix)
+        self.assertIn('"browser://sessions"', self.transport)
+        self.assertIn("browser://sessions", self.doc)
+
+    def test_documented_methods_exist_in_code(self) -> None:
+        for method in ("resources/list", "resources/read", "resources/subscribe",
+                       "resources/unsubscribe", "notifications/resources/updated"):
+            self.assertIn(method, self.transport, method)
+            self.assertIn(method, self.doc, method)
+
+    def test_documented_error_codes_match(self) -> None:
+        # subscribe: unknown uri -> -32002, bad params -> -32602
+        self.assertIn("-32002", self.transport)
+        self.assertIn("-32002", self.doc)
+        self.assertIn("-32602", self.doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ More walkthroughs:
 - `login-and-save-profile.md`
 - `fill-a-form.md`
 - `extract-feed-posts.md`
+- `mcp-resources.md` — MCP resources & subscription notifications
 - `claude_desktop_config.json`
 
 ## 1. Create a session

--- a/examples/mcp-resources.md
+++ b/examples/mcp-resources.md
@@ -1,0 +1,90 @@
+# MCP resources & subscriptions
+
+Auto Browser's MCP endpoint exposes live browser state as **resources** and lets
+a client **subscribe** to change notifications. This walkthrough shows the raw
+JSON-RPC for each — pair it with the tool examples in
+[`claude-desktop-setup.md`](./claude-desktop-setup.md).
+
+All calls go to the MCP transport (default `POST /mcp`) with an
+`MCP-Session-Id` header once a session is established. Bearer auth applies if
+`API_BEARER_TOKEN` is set.
+
+## Resource catalog
+
+`resources/list` returns the subscribable resources. `browser://sessions` is
+always present; the per-session resources appear once a browser session exists.
+
+```jsonc
+// --> request
+{ "jsonrpc": "2.0", "id": 1, "method": "resources/list" }
+
+// <-- result
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resources": [
+      { "uri": "browser://sessions",            "name": "Active Sessions", "mimeType": "application/json" },
+      { "uri": "browser://<session-id>/screenshot", "name": "Screenshot […]", "mimeType": "image/png" },
+      { "uri": "browser://<session-id>/dom",     "name": "DOM […]",        "mimeType": "text/html" },
+      { "uri": "browser://<session-id>/console", "name": "Console […]",    "mimeType": "application/json" },
+      { "uri": "browser://<session-id>/network", "name": "Network Log […]","mimeType": "application/json" }
+    ]
+  }
+}
+```
+
+| URI | mimeType | Content |
+|-----|----------|---------|
+| `browser://sessions` | `application/json` | All active sessions |
+| `browser://<id>/screenshot` | `image/png` | Latest screenshot for the session |
+| `browser://<id>/dom` | `text/html` | Current page HTML |
+| `browser://<id>/console` | `application/json` | Recent console messages |
+| `browser://<id>/network` | `application/json` | Recent network requests/responses |
+
+## Reading a resource
+
+```jsonc
+// --> request
+{ "jsonrpc": "2.0", "id": 2, "method": "resources/read",
+  "params": { "uri": "browser://sessions" } }
+
+// <-- result: { "contents": [ { "uri": "...", "mimeType": "application/json", "text": "[…]" } ] }
+```
+
+## Subscribing to changes
+
+Subscribe to a resource URI to receive a `notifications/resources/updated`
+message whenever that resource changes (e.g. the page DOM updates or a new
+network request lands). Subscribing to an unknown URI returns error `-32002`;
+a missing/empty URI returns `-32602`.
+
+```jsonc
+// --> subscribe
+{ "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+  "params": { "uri": "browser://<session-id>/dom" } }
+
+// <-- result: {}   (subscription recorded)
+
+// <-- later, pushed by the server when the DOM changes:
+{ "jsonrpc": "2.0", "method": "notifications/resources/updated",
+  "params": { "uri": "browser://<session-id>/dom" } }
+```
+
+Unsubscribe when you're done:
+
+```jsonc
+{ "jsonrpc": "2.0", "id": 4, "method": "resources/unsubscribe",
+  "params": { "uri": "browser://<session-id>/dom" } }
+```
+
+Subscriptions are tracked per MCP session and persist across reconnects for the
+lifetime of that session. Closing the MCP session drops its subscriptions.
+
+## Typical flow
+
+1. Create a browser session (via the `browser.create_session` tool).
+2. `resources/list` to discover the per-session URIs.
+3. `resources/subscribe` to `.../dom` and/or `.../network`.
+4. Drive the page with tools; react to `notifications/resources/updated`.
+5. `resources/read` the updated URI to pull the new content.


### PR DESCRIPTION
Closes #34.

Adds `examples/mcp-resources.md` documenting the MCP **resource** catalog (`browser://sessions` + per-session `screenshot`/`dom`/`console`/`network`), `resources/read`, and the **subscription** flow (`resources/subscribe`/`unsubscribe` + `notifications/resources/updated`) with concrete JSON-RPC and error codes. Linked from `examples/README.md`.

A sync test (`test_mcp_resources_doc.py`) asserts the documented URIs, methods, and error codes match `mcp_transport.py`, so the example can't drift out of date.

Note: complements the in-flight external draft #48 (which extends the transport itself); this PR is docs + a drift guard only.