### PR TITLE
refactor(providers): narrow parse-ladder excepts to real parse errors

### DIFF
--- a/controller/app/providers/base.py
+++ b/controller/app/providers/base.py
@@ -14,9 +14,16 @@ from shutil import which
 from typing import Any
 
 import httpx
+from pydantic import ValidationError
 
 from ..config import Settings
 from ..models import BROWSER_ACTION_SCHEMA, BrowserActionDecision, ProviderName
+
+# Parse strategies fall through on malformed input only. model_validate* raise
+# ValidationError; json.loads / raw_decode raise JSONDecodeError (a ValueError).
+# Narrowing to these lets a real bug (AttributeError, TypeError, ...) surface
+# instead of being silently swallowed as a parse miss.
+_PARSE_ERRORS = (ValidationError, ValueError)
 
 DEFAULT_PROVIDER_AUTH_MODES = {"api", "cli"}
 
@@ -440,12 +447,12 @@ class BaseProviderAdapter(ABC):
 
         try:
             return BrowserActionDecision.model_validate_json(text)
-        except Exception:
+        except _PARSE_ERRORS:
             pass
 
         try:
             payload = json.loads(text)
-        except Exception:
+        except _PARSE_ERRORS:
             payload = None
 
         if payload is not None:
@@ -459,7 +466,7 @@ class BaseProviderAdapter(ABC):
                 continue
             try:
                 candidate, _ = decoder.raw_decode(text[index:])
-            except Exception:
+            except _PARSE_ERRORS:
                 continue
             decision = self._find_decision_candidate(candidate)
             if decision is not None:
@@ -475,7 +482,7 @@ class BaseProviderAdapter(ABC):
         if isinstance(payload, dict):
             try:
                 return BrowserActionDecision.model_validate(payload)
-            except Exception:
+            except _PARSE_ERRORS:
                 pass
             for value in payload.values():
                 decision = BaseProviderAdapter._find_decision_candidate(value)

--- a/controller/tests/test_provider_base.py
+++ b/controller/tests/test_provider_base.py
@@ -161,6 +161,16 @@ class ProviderDecisionParsingTests(unittest.TestCase):
         self.assertIsNone(BaseProviderAdapter._find_decision_candidate({"nothing": "useful"}))
         self.assertIsNone(BaseProviderAdapter._find_decision_candidate(["a", "b"]))
 
+    def test_parse_ladder_does_not_swallow_unexpected_errors(self) -> None:
+        # A non-parse bug (not ValidationError/ValueError) must propagate rather
+        # than being masked as a parse miss by the narrowed except clauses. Here
+        # json.loads raises RuntimeError on the second strategy; it must surface.
+        from unittest.mock import patch
+
+        with patch("app.providers.base.json.loads", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                self.adapter.parse_decision_text("not a decision object at all")
+
 
 class ProviderErrorExtractionTests(unittest.TestCase):
     def test_safe_json(self) -> None:


### PR DESCRIPTION
Optimization-dive follow-up (L2 from the 2026-06-29 review).

The provider decision-parse ladder used bare `except Exception` at each fall-through, which could silently mask a real bug (AttributeError, TypeError) as a parse miss. Narrowed the four parse-strategy handlers to `(ValidationError, ValueError)` — exactly what `model_validate*` / `json.loads` / `raw_decode` raise on malformed input — so unexpected errors propagate.

- Regression test: a non-parse `RuntimeError` now surfaces instead of being swallowed.
- Clears the `S110` lint findings in `providers/base.py`.
- 18 provider-base tests pass; configured lint clean.