### PR TITLE
release: ship auto-browser 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-07-01
+
+### Added
+- **Operator dashboard: run replay view.** Open a completed agent run by job id to see its action order, approvals, final status, and screenshot artifacts, reusing the existing `/agent/jobs` and `/approvals` endpoints. All untrusted run data renders via text nodes and safe cell helpers (never `innerHTML`).
+- **Operator dashboard: auth profile setup wizard.** A four-step flow — name a profile and start a login session, complete login by hand in the takeover window, save the captured auth state as a named profile, and reopen a session from any saved profile.
+- **Local fixture server + optional live execution** (`scripts/fixture_server.py`, `scripts/fixture_live.py`): serve `evals/fixtures/` over loopback and drive the real controller (create session → navigate → observe) against a fixture. Opt-in; requires Playwright browsers and never runs in default CI.
+- **WebArena Stage 0 executable contracts** (`benchmarks/webarena/`): typed `TaskContract`s parsed from the manifest, an environment-revision pin (null until a reviewed SHA is set), and a runner with `validate`/`execute` modes that materializes the trace/actions/screenshots/model_decisions evidence layout. Lane stays tracked-only until pinned.
+- **Verifier lane adapter** (`benchmarks/adapters/verifier_adapter.py`): maps an `AgentRunResult` into the CUAVerifier and Online-Mind2Web evidence lanes. Never scores — `verifier_result` is always `None` and records are `scored: false`.
+- **Closed-tab recovery fixture + regression** (`closed-tab-recovery`): the fixture-eval mandatory set and a controller test now cover closing the active tab and recovering to a usable, foregrounded tab.
+- **MCP resources & subscription examples** (`examples/mcp-resources.md`) with a doc-sync test that keeps the documented URIs, methods, and error codes aligned with `mcp_transport.py`.
+- **Live-free coverage** for the provider base layer (readiness checks, decision-parse ladder, error extraction), the stealth timing/fingerprint layer, and the mesh nonce replay cache. Controller coverage ratcheted upward while keeping the 80% gate green and avoiding live browser/network dependencies.
+- **Scheduled dependency audit** is provided by the existing `dependency-audit` CI job (pip-audit) plus GitHub Dependabot alerts.
+
+### Changed
+- **Startup warns when `API_BEARER_TOKEN` is unset in non-production.** Production already hard-fails; non-production now surfaces a runtime-policy warning so a reachable dev/staging instance is not silently served unauthenticated.
+- **Provider decision-parse ladder** narrows its fall-through handlers from bare `except Exception` to `(ValidationError, ValueError)`, so a genuine bug propagates instead of being masked as a parse miss.
+
+### Fixed
+- **Codespaces stack no longer double-binds ports.** `docker-compose.codespaces.yml` now tags its `ports` lists with `!override` so they replace the base `127.0.0.1` bindings instead of appending `0.0.0.0` on top (which failed with "address already in use" and broke the devcontainer `postStartCommand`).
+- **`GET /sessions` no longer 500s after the browser is closed from VNC** (external fix, thanks @gmother): session summary detects a disconnected page and marks the session `interrupted`/`live:false` instead of raising.
+
+### Security
+- Resolved all open Dependabot alerts by bumping pinned dependencies: `starlette` 1.0.1 → 1.3.1, `cryptography` 46.0.7 → 49.0.0, plus `redis` 8.0.1, `pyotp` 2.10.0, `prometheus-client` 0.25.0, and Playwright/GitHub Actions updates.
+
 ## [1.2.1] — 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,9 +30,15 @@ Works with:
 - **Safety rails built in.** Approvals, operator identity, PII scrubbing, Witness receipts, and policy presets are all part of the product surface.
 - **Governed skill induction.** Verified browser traces can become staged skill candidates with signed provenance, verifier adapters, and review-only graduation — agents that prove they can repeat themselves correctly, not just act once.
 
-## Release Highlights (v1.2.1)
+## Release Highlights (v1.3.0)
 
 - **On PyPI.** `pip install auto-browser-client` for the SDK, `pip install auto-browser-langchain` for the LangChain/LangGraph/CrewAI adapters, and `uvx auto-browser-mcp` to run the MCP stdio bridge with zero setup. Releases publish via PyPI trusted publishing (OIDC) on tag push.
+
+### Since v1.2.1
+- **Operator dashboard, expanded.** A run-replay view (action order, approvals, final status, screenshots from existing artifacts) and a four-step auth-profile setup wizard (name → guided login → save → reopen), both rendered with XSS-safe text nodes.
+- **Fixture proof layers.** A loopback fixture server and opt-in live runner drive the real controller against local fixtures; a new closed-tab-recovery fixture guards active-tab recovery.
+- **Benchmark scaffolding.** Executable WebArena Stage 0 contracts (pinned-environment gated, tracked-only) and an adapter mapping runs into the CUAVerifier / Online-Mind2Web evidence lanes — never scored until pinned.
+- **Security & hardening.** All Dependabot alerts resolved (starlette 1.3.1, cryptography 49, redis 8, …); a startup warning when `API_BEARER_TOKEN` is unset in non-production; the closed-browser `GET /sessions` 500 fixed; the Codespaces port double-bind fixed.
 
 ### Since v1.2.0
 - **Verifiable Witness receipts.** Receipts were always hash-chained at write time; now you can check the chain on demand. `GET /sessions/{id}/witness/verify` and the read-only `browser.verify_witness` MCP tool walk the full chain and report the first divergent receipt if the log was altered, reordered, or truncated.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This is the near-term direction for Auto Browser.
 
-## Now (current in v1.2.1)
+## Now (current in v1.3.0)
 
 - PyPI packages: `auto-browser-client` SDK, `auto-browser-langchain` adapters, `uvx auto-browser-mcp` stdio bridge
 - stable local-first browser control

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -2,4 +2,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.2.1"
+version = "1.3.0"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -30,7 +30,7 @@ _log_level = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), loggi
 logging.basicConfig(level=_log_level)
 logger = logging.getLogger(__name__)
 
-_VERSION = "1.2.1"
+_VERSION = "1.3.0"
 
 def _install_controller_host_middleware(application: FastAPI, allowed_hosts: list[str]) -> None:
     install_controller_host_middleware(application, allowed_hosts)

--- a/controller/app/webhooks.py
+++ b/controller/app/webhooks.py
@@ -99,7 +99,7 @@ async def dispatch_approval_event(
         body.update(extra)
 
     raw = json.dumps(body, separators=(",", ":")).encode()
-    headers: dict[str, str] = {"Content-Type": "application/json", "User-Agent": "auto-browser/1.2.1"}
+    headers: dict[str, str] = {"Content-Type": "application/json", "User-Agent": "auto-browser/1.3.0"}
     if webhook_secret:
         headers["X-Webhook-Signature"] = _sign(raw, webhook_secret)
 

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.2.1"
+version = "1.3.0"
 description = "Controller API for auto-browser"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]

--- a/controller/tests/test_events_webhooks.py
+++ b/controller/tests/test_events_webhooks.py
@@ -64,7 +64,7 @@ class WebhookTests(unittest.IsolatedAsyncioTestCase):
         first_call = client.post.await_args_list[0]
         self.assertEqual(first_call.args[0], "https://hooks.example.com/approval")
         self.assertIn("X-Webhook-Signature", first_call.kwargs["headers"])
-        self.assertEqual(first_call.kwargs["headers"]["User-Agent"], "auto-browser/1.2.1")
+        self.assertEqual(first_call.kwargs["headers"]["User-Agent"], "auto-browser/1.3.0")
         self.assertIn(b'"source":"test"', first_call.kwargs["content"])
         self.assertEqual(client.post.await_count, 2)
 

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.2.1"
+version = "1.3.0"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 # console script against that dependency.
 [project]
 name = "auto-browser-mcp"
-version = "1.2.1"
+version = "1.3.0"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["auto-browser-client>=1.2.1"]
+dependencies = ["auto-browser-client>=1.3.0"]
 keywords = ["auto-browser", "mcp", "mcp-server", "browser-automation"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Release PR for **v1.3.0**. Bumps all package versions 1.2.1 → 1.3.0 and records the CHANGELOG.

Highlights (full list in CHANGELOG):
- Dashboard **run replay view** (#37) + **auth profile wizard** (#35)
- **Fixture server + live runner** (#36), **closed-tab recovery** (#33)
- **WebArena Stage 0 contracts** (#39), **verifier lane adapter** (#40)
- **MCP resource examples** (#34), **coverage ratchet** (#38)
- Non-prod **auth warning**, parse-ladder except narrowing
- Fixes: Codespaces port double-bind (#61), closed-browser `GET /sessions` 500 (#59)
- Security: all Dependabot alerts cleared (starlette 1.3.1, cryptography 49, redis 8, …)

All 3 published packages report 1.3.0 (matches the tag verification in release.yml). 531 controller tests pass; lint clean.