### PR TITLE
fix: align playwright versions between controller and browser-node

### DIFF
--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-browser-browser-node",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.61.0"
       }
     },
     "node_modules/fsevents": {
@@ -26,12 +26,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "playwright": "1.61.1"
+    "playwright": "1.61.0"
   }
 }

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.136.3
 starlette==1.3.1
 uvicorn[standard]==0.49.0
-playwright==1.60.0
+playwright==1.61.0
 pydantic-settings==2.10.1
 httpx==0.28.1
 redis==8.0.1


### PR DESCRIPTION
## Summary
- `controller/requirements.txt` pinned `playwright==1.60.0` (pip) while `browser-node/package.json` pinned `playwright==1.61.1` (npm)
- Playwright's websocket protocol enforces an exact client/server version match, so the controller can never connect to the browser node's Playwright server as shipped
- Every `docker compose up --build` run crash-loops the controller on startup with:
  ```
  RuntimeError: Unable to connect to browser node via Playwright server. Checked ws endpoint file ... and direct endpoint <not configured>.
  ```
  with the underlying cause visible when connecting manually:
  ```
  playwright._impl._errors.Error: BrowserType.connect: WebSocket error: ... 428 Precondition Required
  Playwright version mismatch:
    - server version: v1.61
    - client version: v1.60
  ```
- Pinned both sides to `1.61.0` (the closest version available on both PyPI and npm at time of writing) and regenerated `browser-node/package-lock.json` to match

## Test plan
- [x] `docker compose build controller browser-node`
- [x] `docker compose up -d` — both containers reach `healthy`/running state without crash-looping
- [x] `curl http://127.0.0.1:8000/docs` → 200
- [x] `curl http://127.0.0.1:8000/dashboard` → 200
- [x] `curl http://127.0.0.1:6080/vnc.html` → 200
- [ ] CI on this PR