### PR TITLE
feat: add MiniMax M3 provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,11 @@ GEMINI_CLI_PATH=gemini
 GEMINI_CLI_MODEL=
 CLI_HOME=/data/cli-home
 
+MINIMAX_API_KEY=
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+MINIMAX_MODEL=MiniMax-M3
+MINIMAX_AUTH_MODE=api
+
 # Optional: when using docker-compose.host-subscriptions.yml, point this at the
 # host home that already contains your signed-in CLI state.
 CLI_HOST_HOME=/home/youruser

--- a/controller/app/config.py
+++ b/controller/app/config.py
@@ -234,6 +234,11 @@ class Settings(BaseSettings):
     gemini_cli_model: str | None = Field(None, alias="GEMINI_CLI_MODEL")
     cli_home: str | None = Field("/data/cli-home", alias="CLI_HOME")
 
+    minimax_api_key: str | None = Field(None, alias="MINIMAX_API_KEY")
+    minimax_base_url: str = Field("https://api.minimax.io/v1", alias="MINIMAX_BASE_URL")
+    minimax_model: str = Field("MiniMax-M3", alias="MINIMAX_MODEL")
+    minimax_auth_mode: str = Field("api", alias="MINIMAX_AUTH_MODE")
+
     model_request_timeout_seconds: float = Field(60.0, alias="MODEL_REQUEST_TIMEOUT_SECONDS")
     model_max_retries: int = Field(2, alias="MODEL_MAX_RETRIES")
     model_retry_backoff_seconds: float = Field(1.0, alias="MODEL_RETRY_BACKOFF_SECONDS")

--- a/controller/app/models.py
+++ b/controller/app/models.py
@@ -275,7 +275,7 @@ ActionName = Literal[
     "request_human_takeover",
     "done",
 ]
-ProviderName = Literal["openai", "claude", "gemini"]
+ProviderName = Literal["openai", "claude", "gemini", "minimax"]
 WorkflowProfile = Literal["fast", "governed"]
 RiskCategory = Literal[
     "read",

--- a/controller/app/provider_registry.py
+++ b/controller/app/provider_registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .config import Settings
 from .models import ProviderInfo, ProviderName
-from .providers import ClaudeAdapter, GeminiAdapter, OpenAIAdapter
+from .providers import ClaudeAdapter, GeminiAdapter, MinimaxAdapter, OpenAIAdapter
 
 
 class ProviderRegistry:
@@ -11,6 +11,7 @@ class ProviderRegistry:
             "openai": OpenAIAdapter(settings),
             "claude": ClaudeAdapter(settings),
             "gemini": GeminiAdapter(settings),
+            "minimax": MinimaxAdapter(settings),
         }
 
     def get(self, name: ProviderName):

--- a/controller/app/providers/__init__.py
+++ b/controller/app/providers/__init__.py
@@ -1,11 +1,13 @@
 from .base import ProviderDecision
 from .claude_adapter import ClaudeAdapter
 from .gemini_adapter import GeminiAdapter
+from .minimax_adapter import MinimaxAdapter
 from .openai_adapter import OpenAIAdapter
 
 __all__ = [
     "ClaudeAdapter",
     "GeminiAdapter",
+    "MinimaxAdapter",
     "OpenAIAdapter",
     "ProviderDecision",
 ]

--- a/controller/app/providers/minimax_adapter.py
+++ b/controller/app/providers/minimax_adapter.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..models import BrowserActionDecision
+from .base import BaseProviderAdapter, ProviderDecision
+
+
+class MinimaxAdapter(BaseProviderAdapter):
+    provider = "minimax"
+
+    @property
+    def supported_auth_modes(self) -> tuple[str, ...]:
+        return ("api",)
+
+    @property
+    def default_model(self) -> str:
+        return self.settings.minimax_model
+
+    @property
+    def configured(self) -> bool:
+        ready, _ = self._readiness()
+        return ready
+
+    @property
+    def missing_detail(self) -> str:
+        return self.readiness_detail
+
+    @property
+    def readiness_detail(self) -> str:
+        _, detail = self._readiness()
+        return detail
+
+    @property
+    def auth_mode(self) -> str:
+        return self.normalize_auth_mode(self.settings.minimax_auth_mode)
+
+    def _readiness(self) -> tuple[bool, str]:
+        if not self.auth_mode_supported(self.auth_mode):
+            return False, self.invalid_auth_mode_detail(self.auth_mode)
+        return self.describe_api_readiness(api_key=self.settings.minimax_api_key, env_var="MINIMAX_API_KEY")
+
+    async def _decide(
+        self,
+        *,
+        goal: str,
+        observation: dict[str, Any],
+        context_hints: str | None,
+        previous_steps: list[dict[str, Any]],
+        model_override: str | None,
+    ) -> ProviderDecision:
+        model = model_override or self.settings.minimax_model
+        mime_type, image_b64 = self.encode_image(observation["screenshot_path"])
+        payload = {
+            "model": model,
+            "temperature": 0,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are the Auto Browser planner. Pick exactly one next action. "
+                        "Use the provided function tool for your answer."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": self.build_text_prompt(
+                                goal=goal,
+                                observation=observation,
+                                context_hints=context_hints,
+                                previous_steps=previous_steps,
+                            ),
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:{mime_type};base64,{image_b64}",
+                            },
+                        },
+                    ],
+                },
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "browser_action",
+                        "description": "Select the single best next browser action.",
+                        "parameters": self.action_schema,
+                        "strict": True,
+                    },
+                }
+            ],
+            "tool_choice": {"type": "function", "function": {"name": "browser_action"}},
+        }
+        response = await self._post_json(
+            url=f"{self.settings.minimax_base_url.rstrip('/')}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {self.settings.minimax_api_key}",
+                "Content-Type": "application/json",
+            },
+            payload=payload,
+        )
+        choice = response["choices"][0]
+        message = choice.get("message", {})
+        tool_calls = message.get("tool_calls") or []
+        if not tool_calls:
+            raise RuntimeError("MiniMax did not return a tool call for browser_action")
+        arguments = tool_calls[0]["function"]["arguments"]
+        decision = BrowserActionDecision.model_validate_json(arguments)
+        usage = response.get("usage")
+        return ProviderDecision(
+            provider=self.provider,
+            model=response.get("model", model),
+            decision=decision,
+            usage=usage,
+            raw_text=arguments,
+        )

--- a/controller/tests/test_minimax_provider.py
+++ b/controller/tests/test_minimax_provider.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+
+from app.config import Settings
+from app.provider_registry import ProviderRegistry
+from app.providers.minimax_adapter import MinimaxAdapter
+
+
+class FakeAsyncClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests: list[dict] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def post(self, url, headers=None, json=None):
+        self.requests.append({"url": url, "headers": headers, "json": json})
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class MinimaxAdapterTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        root = Path(self.tempdir.name)
+        self.screenshot_path = root / "screen.png"
+        self.screenshot_path.write_bytes(b"fake")
+        self.observation = {
+            "screenshot_path": str(self.screenshot_path),
+            "url": "https://example.com",
+            "title": "Example",
+            "interactables": [],
+        }
+
+    async def asyncTearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    async def test_api_mode_returns_tool_call_decision(self) -> None:
+        settings = Settings(_env_file=None, MINIMAX_API_KEY="test-key")
+        adapter = MinimaxAdapter(settings)
+
+        request = httpx.Request("POST", "https://api.minimax.io/v1/chat/completions")
+        responses = [
+            httpx.Response(
+                200,
+                request=request,
+                json={
+                    "model": "MiniMax-M3",
+                    "choices": [
+                        {
+                            "message": {
+                                "tool_calls": [
+                                    {
+                                        "function": {
+                                            "name": "browser_action",
+                                            "arguments": '{"action":"done","reason":"complete","risk_category":"read"}',
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "usage": {"total_tokens": 12},
+                },
+            )
+        ]
+        fake = FakeAsyncClient(responses)
+
+        with patch("app.providers.base.httpx.AsyncClient", return_value=fake):
+            result = await adapter._decide(
+                goal="Finish the task",
+                observation=self.observation,
+                context_hints=None,
+                previous_steps=[],
+                model_override=None,
+            )
+
+        self.assertEqual(result.provider, "minimax")
+        self.assertEqual(result.model, "MiniMax-M3")
+        self.assertEqual(result.decision.action, "done")
+        self.assertEqual(fake.requests[0]["url"], "https://api.minimax.io/v1/chat/completions")
+        self.assertEqual(fake.requests[0]["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(fake.requests[0]["json"]["model"], "MiniMax-M3")
+
+    def test_missing_api_key_is_not_configured(self) -> None:
+        adapter = MinimaxAdapter(Settings(_env_file=None))
+        self.assertFalse(adapter.configured)
+        self.assertIn("MINIMAX_API_KEY", adapter.readiness_detail)
+
+    def test_api_key_present_is_configured(self) -> None:
+        adapter = MinimaxAdapter(Settings(_env_file=None, MINIMAX_API_KEY="test-key"))
+        self.assertTrue(adapter.configured)
+        self.assertEqual(adapter.default_model, "MiniMax-M3")
+
+    def test_registry_exposes_minimax_provider(self) -> None:
+        infos = {item.provider: item for item in ProviderRegistry(Settings(_env_file=None)).list()}
+        self.assertIn("minimax", infos)
+        self.assertEqual(infos["minimax"].model, "MiniMax-M3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add MiniMax as a new LLM provider, compatible with the existing provider architecture.

## Changes
- Add `MinimaxAdapter` in `controller/app/providers/minimax_adapter.py`, mirroring the OpenAI-compatible API path of `openai_adapter.py` (tool-call function calling with an image_url screenshot).
- Register the provider in `provider_registry.py`, add `"minimax"` to `ProviderName` in `models.py`, and export it from `providers/__init__.py`.
- Add `MINIMAX_API_KEY` / `MINIMAX_BASE_URL` / `MINIMAX_MODEL` / `MINIMAX_AUTH_MODE` settings in `config.py` and `.env.example` (defaults to `MiniMax-M3`).
- Add unit tests in `controller/tests/test_minimax_provider.py`.

## Testing
- `python -m pytest tests/test_minimax_provider.py -v` — 4 passed
- Existing provider suite (`test_provider_*`, `test_tabs_and_providers`, `test_agent_http -k provider`) — passing, no regressions
- `ruff check controller/app controller/tests scripts/*.py --select E9,F,I` — clean