### PR TITLE
ci: guard playwright pin parity + cap fastapi <0.137

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: python -m pip install 'ruff==0.15.12'
       - name: Ruff check
         run: make lint
+      - name: Check Playwright pins matched (controller <-> browser-node)
+        run: python scripts/check_playwright_pins.py
       - name: Validate agent eval matrix
         run: python scripts/agent_eval.py --mock --json --report-file /tmp/agent-evals.md
       - name: Validate fixture eval matrix

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -1,4 +1,7 @@
-fastapi==0.136.3
+# Cap <0.137: 0.137 changed router internals so include_router silently mounts
+# nothing (every route vanishes, only FastAPI's default doc routes survive).
+# Revisit behind a route-presence smoke test. See closed PR #82.
+fastapi>=0.136.3,<0.137
 starlette==1.3.1
 uvicorn[standard]==0.50.1
 playwright==1.61.0

--- a/scripts/check_playwright_pins.py
+++ b/scripts/check_playwright_pins.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Fail if the Playwright pins in the controller and browser-node drift apart.
+
+The controller (Python, controller/requirements.txt) and the browser-node
+(Node, browser-node/package.json) run Playwright over the same CDP protocol.
+A version mismatch between them has broken CI before (#76), so this guard makes
+the matched-pair invariant machine-enforced instead of tribal knowledge: any
+single-side bump (e.g. a Dependabot PR touching only one) fails here until the
+other side is bumped to match.
+
+Exit 0 when the pins match, 1 (with a diff) when they don't.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REQUIREMENTS = REPO_ROOT / "controller" / "requirements.txt"
+PACKAGE_JSON = REPO_ROOT / "browser-node" / "package.json"
+
+# Strip a leading npm range operator (^, ~, >=, <=, >, <, =) so "^1.61.0" and
+# "1.61.0" compare equal. The pins are expected to be exact, but tolerate ranges.
+_RANGE_PREFIX = re.compile(r"^[\^~=><]+")
+
+
+def _controller_pin() -> str:
+    for raw in REQUIREMENTS.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        # Matches "playwright==1.61.0" and "playwright[extra]==1.61.0".
+        match = re.match(r"^playwright(?:\[[^\]]*\])?==([^\s;]+)", line)
+        if match:
+            return match.group(1)
+    raise SystemExit(f"could not find a pinned 'playwright==' in {REQUIREMENTS}")
+
+
+def _browser_node_pin() -> str:
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    for section in ("dependencies", "devDependencies", "optionalDependencies"):
+        version = data.get(section, {}).get("playwright")
+        if version:
+            return _RANGE_PREFIX.sub("", version.strip())
+    raise SystemExit(f"could not find a 'playwright' dependency in {PACKAGE_JSON}")
+
+
+def main() -> int:
+    controller = _controller_pin()
+    browser_node = _browser_node_pin()
+    if controller == browser_node:
+        print(f"OK: playwright pinned to {controller} in both controller and browser-node.")
+        return 0
+
+    print(
+        "ERROR: Playwright version mismatch between controller and browser-node.\n"
+        f"  controller/requirements.txt : playwright=={controller}\n"
+        f"  browser-node/package.json   : playwright  {browser_node}\n"
+        "\nThey must move as a matched pair (they share the CDP protocol). Bump both\n"
+        "to the same version. See scripts/check_playwright_pins.py for why.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Dependency-safety hardening prompted by the current Dependabot queue (closes the gap behind the just-closed #82 and #83).

## Matched-pair Playwright guard
`scripts/check_playwright_pins.py` + a lint-job CI step fail the build when the controller (`requirements.txt`) and browser-node (`package.json`) Playwright pins diverge. They share the CDP protocol and must move together; a single-side bump broke CI before (#76) and Dependabot proposed another (#83). Now machine-enforced — a single-side bump can't merge.

## fastapi <0.137 cap
0.137 changed router internals so `include_router` silently mounts nothing (all routes vanish; only FastAPI's default doc routes survive). The controller relies on `include_router` + `app.mount`. Caps the pin so the #82-class bump can't land; revisit behind a route-presence smoke test.

Both changes verified locally (guard passes matched, fails on simulated mismatch; ruff clean).