### PR TITLE
feat(providers): drive Auto Browser with any OpenAI-compatible model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,34 @@ GEMINI_CLI_PATH=gemini
 GEMINI_CLI_MODEL=
 CLI_HOME=/data/cli-home
 
+# ---------------------------------------------------------------------------
+# OpenAI-compatible providers (one generic adapter -> effectively every model)
+# Set an API key to enable a provider. base_url has a sensible default; set the
+# model where marked. Vision (screenshots) is on for all except DeepSeek (text).
+# ---------------------------------------------------------------------------
+# OpenRouter: one key proxies ~every frontier model (Claude, GPT, Gemini, Grok,
+# DeepSeek, Llama, Mistral, Qwen, ...). Pick the model, e.g. anthropic/claude-3.7-sonnet.
+OPENROUTER_API_KEY=
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_MODEL=
+# xAI (Grok)
+XAI_API_KEY=
+XAI_BASE_URL=https://api.x.ai/v1
+XAI_MODEL=grok-4
+# DeepSeek (text-only; driven from the DOM/accessibility outline)
+DEEPSEEK_API_KEY=
+DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+DEEPSEEK_MODEL=deepseek-chat
+# MiniMax
+MINIMAX_API_KEY=
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+MINIMAX_MODEL=MiniMax-M3
+# Any other OpenAI-compatible endpoint: self-hosted Ollama / vLLM / LM Studio,
+# Azure OpenAI, Together, Groq, Fireworks, ... Set base URL + model.
+OPENAI_COMPATIBLE_API_KEY=
+OPENAI_COMPATIBLE_BASE_URL=
+OPENAI_COMPATIBLE_MODEL=
+
 # Optional: when using docker-compose.host-subscriptions.yml, point this at the
 # host home that already contains your signed-in CLI state.
 CLI_HOST_HOME=/home/youruser

--- a/README.md
+++ b/README.md
@@ -222,13 +222,30 @@ For deployment details, hosted Witness notes, CLI auth modes, and reverse-SSH gu
 ```mermaid
 flowchart LR
     User[Human operator] -->|watch / takeover| noVNC[noVNC]
-    LLM[OpenAI / Claude / Gemini] -->|shared tools| Controller[Controller API]
+    LLM[Any model: OpenAI / Claude / Gemini / OpenRouter / Grok / DeepSeek / MiniMax / local] -->|shared tools| Controller[Controller API]
     Controller -->|Playwright protocol| Browser[Browser node]
     noVNC --> Browser
     Browser --> Artifacts[(screenshots / traces / auth state)]
     Controller --> Artifacts
     Controller --> Policy[Allowlist + approval gates]
 ```
+
+### Model providers
+
+First-class adapters for **OpenAI**, **Claude**, and **Gemini** (API or CLI). Beyond those,
+a single generic **OpenAI-compatible** adapter drives any model reachable over an OpenAI
+`/chat/completions` endpoint — set an API key to enable it:
+
+| Provider | Reaches |
+|----------|---------|
+| `openrouter` | one key → ~every frontier model (Claude, GPT, Gemini, Grok, DeepSeek, Llama, Mistral, Qwen, …) |
+| `xai` | Grok |
+| `deepseek` | DeepSeek (text-only; driven from the DOM/accessibility outline) |
+| `minimax` | MiniMax |
+| `openai_compatible` | any custom base URL — self-hosted Ollama / vLLM / LM Studio, Azure OpenAI, Together, Groq, Fireworks, … |
+
+Vision (screenshots) is used for every provider except text-only ones. See `.env.example` for
+the `*_API_KEY` / `*_BASE_URL` / `*_MODEL` settings.
 
 Core components:
 

--- a/controller/app/config.py
+++ b/controller/app/config.py
@@ -234,6 +234,29 @@ class Settings(BaseSettings):
     gemini_cli_model: str | None = Field(None, alias="GEMINI_CLI_MODEL")
     cli_home: str | None = Field("/data/cli-home", alias="CLI_HOME")
 
+    # OpenAI-compatible providers, all served by one generic adapter. Set the API key
+    # (and, for openrouter/openai_compatible, a model) to enable each. base_url defaults
+    # are stable; model defaults are current-but-overridable.
+    openrouter_api_key: str | None = Field(None, alias="OPENROUTER_API_KEY")
+    openrouter_base_url: str = Field("https://openrouter.ai/api/v1", alias="OPENROUTER_BASE_URL")
+    openrouter_model: str = Field("", alias="OPENROUTER_MODEL")
+
+    xai_api_key: str | None = Field(None, alias="XAI_API_KEY")
+    xai_base_url: str = Field("https://api.x.ai/v1", alias="XAI_BASE_URL")
+    xai_model: str = Field("grok-4", alias="XAI_MODEL")
+
+    deepseek_api_key: str | None = Field(None, alias="DEEPSEEK_API_KEY")
+    deepseek_base_url: str = Field("https://api.deepseek.com/v1", alias="DEEPSEEK_BASE_URL")
+    deepseek_model: str = Field("deepseek-chat", alias="DEEPSEEK_MODEL")
+
+    minimax_api_key: str | None = Field(None, alias="MINIMAX_API_KEY")
+    minimax_base_url: str = Field("https://api.minimax.io/v1", alias="MINIMAX_BASE_URL")
+    minimax_model: str = Field("MiniMax-M3", alias="MINIMAX_MODEL")
+
+    openai_compatible_api_key: str | None = Field(None, alias="OPENAI_COMPATIBLE_API_KEY")
+    openai_compatible_base_url: str = Field("", alias="OPENAI_COMPATIBLE_BASE_URL")
+    openai_compatible_model: str = Field("", alias="OPENAI_COMPATIBLE_MODEL")
+
     model_request_timeout_seconds: float = Field(60.0, alias="MODEL_REQUEST_TIMEOUT_SECONDS")
     model_max_retries: int = Field(2, alias="MODEL_MAX_RETRIES")
     model_retry_backoff_seconds: float = Field(1.0, alias="MODEL_RETRY_BACKOFF_SECONDS")

--- a/controller/app/models.py
+++ b/controller/app/models.py
@@ -275,7 +275,19 @@ ActionName = Literal[
     "request_human_takeover",
     "done",
 ]
-ProviderName = Literal["openai", "claude", "gemini"]
+ProviderName = Literal[
+    "openai",
+    "claude",
+    "gemini",
+    # OpenAI-compatible providers (one generic adapter): OpenRouter proxies ~every
+    # frontier model; the rest are popular direct endpoints; openai_compatible is a
+    # custom base URL for anything else (Ollama / vLLM / Azure / Together / Groq / ...).
+    "openrouter",
+    "xai",
+    "deepseek",
+    "minimax",
+    "openai_compatible",
+]
 WorkflowProfile = Literal["fast", "governed"]
 RiskCategory = Literal[
     "read",

--- a/controller/app/provider_registry.py
+++ b/controller/app/provider_registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .config import Settings
 from .models import ProviderInfo, ProviderName
 from .providers import ClaudeAdapter, GeminiAdapter, OpenAIAdapter
+from .providers.openai_compatible import build_openai_compatible_adapters
 
 
 class ProviderRegistry:
@@ -11,6 +12,10 @@ class ProviderRegistry:
             "openai": OpenAIAdapter(settings),
             "claude": ClaudeAdapter(settings),
             "gemini": GeminiAdapter(settings),
+            # OpenAI-compatible providers (openrouter, xai, deepseek, minimax,
+            # openai_compatible) — one generic adapter, so any model reachable over an
+            # OpenAI-style /chat/completions endpoint can drive the browser.
+            **build_openai_compatible_adapters(settings),
         }
 
     def get(self, name: ProviderName):

--- a/controller/app/providers/__init__.py
+++ b/controller/app/providers/__init__.py
@@ -2,10 +2,16 @@ from .base import ProviderDecision
 from .claude_adapter import ClaudeAdapter
 from .gemini_adapter import GeminiAdapter
 from .openai_adapter import OpenAIAdapter
+from .openai_compatible import (
+    OpenAICompatibleAdapter,
+    build_openai_compatible_adapters,
+)
 
 __all__ = [
     "ClaudeAdapter",
     "GeminiAdapter",
     "OpenAIAdapter",
+    "OpenAICompatibleAdapter",
     "ProviderDecision",
+    "build_openai_compatible_adapters",
 ]

--- a/controller/app/providers/openai_compatible.py
+++ b/controller/app/providers/openai_compatible.py
@@ -1,0 +1,244 @@
+"""Generic adapter for any OpenAI /chat/completions-compatible endpoint.
+
+A single parameterized adapter backs every provider that speaks the OpenAI
+chat-completions dialect, so Auto Browser is not limited to the three first-class
+providers. In particular this covers:
+
+- **OpenRouter** — one key proxies essentially every frontier model (Claude, GPT,
+  Gemini, Grok, DeepSeek, Llama, Mistral, Qwen, ...), so "all models" is one config away.
+- **xAI (Grok)**, **DeepSeek**, **MiniMax** — popular direct endpoints.
+- **openai_compatible** — a fully custom base URL for anything else: a self-hosted
+  Ollama / vLLM / LM Studio server, Azure OpenAI, Together, Groq, Fireworks, etc.
+
+Vision + function-calling, same request shape as the OpenAI adapter's API path, with a
+content-parsing fallback for endpoints that don't honor tool_choice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..config import Settings
+from ..models import BrowserActionDecision, ProviderName
+from .base import BaseProviderAdapter, ProviderDecision
+
+
+@dataclass(frozen=True)
+class OpenAICompatibleProfile:
+    """Static description of one OpenAI-compatible provider.
+
+    The three ``*_attr`` fields name the ``Settings`` attributes that hold this
+    provider's API key, base URL, and model, so one adapter class can serve many
+    providers by reading different config slots.
+    """
+
+    provider: str
+    label: str
+    api_key_attr: str
+    base_url_attr: str
+    model_attr: str
+    env_var: str
+    supports_vision: bool = True
+
+
+# base_url defaults are stable; model defaults are current-but-overridable via env.
+# Empty model/base_url means "the operator must set it" (surfaced by readiness below).
+OPENAI_COMPATIBLE_PROFILES: tuple[OpenAICompatibleProfile, ...] = (
+    OpenAICompatibleProfile(
+        provider="openrouter",
+        label="OpenRouter",
+        api_key_attr="openrouter_api_key",
+        base_url_attr="openrouter_base_url",
+        model_attr="openrouter_model",
+        env_var="OPENROUTER_API_KEY",
+        supports_vision=True,
+    ),
+    OpenAICompatibleProfile(
+        provider="xai",
+        label="xAI Grok",
+        api_key_attr="xai_api_key",
+        base_url_attr="xai_base_url",
+        model_attr="xai_model",
+        env_var="XAI_API_KEY",
+        supports_vision=True,
+    ),
+    OpenAICompatibleProfile(
+        provider="deepseek",
+        label="DeepSeek",
+        api_key_attr="deepseek_api_key",
+        base_url_attr="deepseek_base_url",
+        model_attr="deepseek_model",
+        env_var="DEEPSEEK_API_KEY",
+        # deepseek-chat is text-only; drive it from the DOM/accessibility outline.
+        supports_vision=False,
+    ),
+    OpenAICompatibleProfile(
+        provider="minimax",
+        label="MiniMax",
+        api_key_attr="minimax_api_key",
+        base_url_attr="minimax_base_url",
+        model_attr="minimax_model",
+        env_var="MINIMAX_API_KEY",
+        supports_vision=True,
+    ),
+    OpenAICompatibleProfile(
+        provider="openai_compatible",
+        label="OpenAI-compatible",
+        api_key_attr="openai_compatible_api_key",
+        base_url_attr="openai_compatible_base_url",
+        model_attr="openai_compatible_model",
+        env_var="OPENAI_COMPATIBLE_API_KEY",
+        supports_vision=True,
+    ),
+)
+
+
+class OpenAICompatibleAdapter(BaseProviderAdapter):
+    """Adapter for a single OpenAI-compatible endpoint described by a profile."""
+
+    def __init__(self, settings: Settings, profile: OpenAICompatibleProfile):
+        super().__init__(settings)
+        # Instance attribute overrides the class-level ``provider`` annotation so one
+        # class can present as many providers.
+        self.provider = profile.provider  # type: ignore[assignment]
+        self.profile = profile
+
+    def _cfg(self, attr: str) -> Any:
+        return getattr(self.settings, attr)
+
+    @property
+    def supported_auth_modes(self) -> tuple[str, ...]:
+        return ("api",)
+
+    @property
+    def auth_mode(self) -> str:
+        return "api"
+
+    @property
+    def default_model(self) -> str:
+        return self._cfg(self.profile.model_attr) or ""
+
+    @property
+    def configured(self) -> bool:
+        ready, _ = self._readiness()
+        return ready
+
+    @property
+    def missing_detail(self) -> str:
+        return self.readiness_detail
+
+    @property
+    def readiness_detail(self) -> str:
+        _, detail = self._readiness()
+        return detail
+
+    def _readiness(self) -> tuple[bool, str]:
+        api_key = self._cfg(self.profile.api_key_attr)
+        base_url = self._cfg(self.profile.base_url_attr)
+        model = self._cfg(self.profile.model_attr)
+        missing = []
+        if not api_key:
+            missing.append(self.profile.env_var)
+        if not base_url:
+            missing.append(self.profile.env_var.replace("_API_KEY", "_BASE_URL"))
+        if not model:
+            missing.append(self.profile.env_var.replace("_API_KEY", "_MODEL"))
+        if missing:
+            return False, f"{self.profile.label} not configured; set: {', '.join(missing)}"
+        return True, f"ready via {self.profile.env_var}"
+
+    async def _decide(
+        self,
+        *,
+        goal: str,
+        observation: dict[str, Any],
+        context_hints: str | None,
+        previous_steps: list[dict[str, Any]],
+        model_override: str | None,
+    ) -> ProviderDecision:
+        model = model_override or self.default_model
+        content: list[dict[str, Any]] = [
+            {
+                "type": "text",
+                "text": self.build_text_prompt(
+                    goal=goal,
+                    observation=observation,
+                    context_hints=context_hints,
+                    previous_steps=previous_steps,
+                ),
+            }
+        ]
+        if self.profile.supports_vision:
+            mime_type, image_b64 = self.encode_image(observation["screenshot_path"])
+            content.append(
+                {"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{image_b64}"}}
+            )
+
+        payload = {
+            "model": model,
+            "temperature": 0,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are the Auto Browser planner. Pick exactly one next action. "
+                        "Use the provided function tool for your answer, or if you cannot "
+                        "call tools, reply with only the matching JSON object."
+                    ),
+                },
+                {"role": "user", "content": content},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "browser_action",
+                        "description": "Select the single best next browser action.",
+                        "parameters": self.action_schema,
+                        "strict": True,
+                    },
+                }
+            ],
+            "tool_choice": {"type": "function", "function": {"name": "browser_action"}},
+        }
+
+        base_url = str(self._cfg(self.profile.base_url_attr)).rstrip("/")
+        response = await self._post_json(
+            url=f"{base_url}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {self._cfg(self.profile.api_key_attr)}",
+                "Content-Type": "application/json",
+            },
+            payload=payload,
+        )
+
+        message = response["choices"][0].get("message", {})
+        tool_calls = message.get("tool_calls") or []
+        if tool_calls:
+            raw_text = tool_calls[0]["function"]["arguments"]
+            decision = BrowserActionDecision.model_validate_json(raw_text)
+        else:
+            # Some OpenAI-compatible endpoints ignore tool_choice; parse the content.
+            raw_text = str(message.get("content") or "").strip()
+            if not raw_text:
+                raise RuntimeError(
+                    f"{self.profile.label} returned neither a browser_action tool call nor content"
+                )
+            decision = self.parse_decision_text(raw_text)
+
+        return ProviderDecision(
+            provider=self.provider,
+            model=response.get("model", model),
+            decision=decision,
+            usage=response.get("usage"),
+            raw_text=raw_text,
+        )
+
+
+def build_openai_compatible_adapters(settings: Settings) -> dict[ProviderName, OpenAICompatibleAdapter]:
+    """One adapter per profile, keyed by provider name for the registry."""
+    return {
+        profile.provider: OpenAICompatibleAdapter(settings, profile)  # type: ignore[misc]
+        for profile in OPENAI_COMPATIBLE_PROFILES
+    }

--- a/controller/tests/test_openai_compatible_provider.py
+++ b/controller/tests/test_openai_compatible_provider.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app.config import Settings
+from app.provider_registry import ProviderRegistry
+from app.providers.openai_compatible import (
+    OPENAI_COMPATIBLE_PROFILES,
+    OpenAICompatibleAdapter,
+)
+
+# Smallest valid PNG so encode_image() has a real file to read for vision providers.
+_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    "0000000a49444154789c6300010000050001a5f645400000000049454e44ae426082"
+)
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class FakeAsyncClient:
+    def __init__(self, response: FakeResponse):
+        self.response = response
+        self.calls: list[dict] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return None
+
+    async def post(self, url, headers=None, json=None):
+        self.calls.append({"url": url, "headers": headers, "json": json})
+        return self.response
+
+
+def _settings(**overrides) -> Settings:
+    settings = Settings(_env_file=None)
+    for key, value in overrides.items():
+        setattr(settings, key, value)
+    return settings
+
+
+def _tool_call_response(arguments: dict) -> FakeResponse:
+    return FakeResponse(
+        {
+            "model": "test-model",
+            "choices": [
+                {"message": {"tool_calls": [{"function": {"name": "browser_action", "arguments": json.dumps(arguments)}}]}}
+            ],
+            "usage": {"total_tokens": 5},
+        }
+    )
+
+
+def _content_response(text: str) -> FakeResponse:
+    return FakeResponse({"model": "test-model", "choices": [{"message": {"content": text}}]})
+
+
+class OpenAICompatibleProviderTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.image = Path(self.tempdir.name) / "shot.png"
+        self.image.write_bytes(_PNG)
+
+    def _observation(self) -> dict:
+        return {"screenshot_path": str(self.image), "url": "https://example.com", "title": "Example"}
+
+    def _adapter(self, provider: str, **cfg) -> OpenAICompatibleAdapter:
+        profile = next(p for p in OPENAI_COMPATIBLE_PROFILES if p.provider == provider)
+        return OpenAICompatibleAdapter(_settings(**cfg), profile)
+
+    def test_registry_registers_all_openai_compatible_providers(self):
+        registry = ProviderRegistry(_settings())
+        for name in ("openrouter", "xai", "deepseek", "minimax", "openai_compatible"):
+            self.assertIn(name, registry.providers)
+            self.assertEqual(registry.providers[name].provider, name)
+
+    def test_not_configured_without_api_key(self):
+        adapter = self._adapter("openrouter")
+        self.assertFalse(adapter.configured)
+        self.assertIn("OPENROUTER_API_KEY", adapter.readiness_detail)
+
+    def test_configured_with_key_and_defaulted_base_and_model(self):
+        adapter = self._adapter("xai", xai_api_key="k")
+        self.assertTrue(adapter.configured)
+        self.assertEqual(adapter.default_model, "grok-4")
+
+    def test_custom_endpoint_reports_missing_base_url_and_model(self):
+        adapter = self._adapter("openai_compatible", openai_compatible_api_key="k")
+        self.assertFalse(adapter.configured)
+        detail = adapter.readiness_detail
+        self.assertIn("OPENAI_COMPATIBLE_BASE_URL", detail)
+        self.assertIn("OPENAI_COMPATIBLE_MODEL", detail)
+
+    async def test_decide_via_tool_call_sends_vision(self):
+        adapter = self._adapter("minimax", minimax_api_key="k")
+        fake = FakeAsyncClient(_tool_call_response({"action": "done", "reason": "complete"}))
+        with patch("app.providers.base.httpx.AsyncClient", return_value=fake):
+            decision = await adapter.decide(goal="g", observation=self._observation())
+        self.assertEqual(decision.decision.action, "done")
+        self.assertEqual(decision.provider, "minimax")
+        sent = fake.calls[0]["json"]
+        self.assertEqual(sent["model"], "MiniMax-M3")
+        self.assertIn("image_url", [c["type"] for c in sent["messages"][1]["content"]])
+        self.assertEqual(fake.calls[0]["url"], "https://api.minimax.io/v1/chat/completions")
+
+    async def test_decide_falls_back_to_content_when_no_tool_call(self):
+        adapter = self._adapter(
+            "openrouter", openrouter_api_key="k", openrouter_model="anthropic/claude-3.7-sonnet"
+        )
+        fake = FakeAsyncClient(_content_response(json.dumps({"action": "done", "reason": "ok"})))
+        with patch("app.providers.base.httpx.AsyncClient", return_value=fake):
+            decision = await adapter.decide(goal="g", observation=self._observation())
+        self.assertEqual(decision.decision.action, "done")
+
+    async def test_text_only_provider_omits_image(self):
+        adapter = self._adapter("deepseek", deepseek_api_key="k")
+        fake = FakeAsyncClient(_tool_call_response({"action": "done", "reason": "x"}))
+        with patch("app.providers.base.httpx.AsyncClient", return_value=fake):
+            await adapter.decide(goal="g", observation=self._observation())
+        content_types = [c["type"] for c in fake.calls[0]["json"]["messages"][1]["content"]]
+        self.assertNotIn("image_url", content_types)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
Auto Browser was limited to three first-class providers (OpenAI, Claude, Gemini). Goal: **any AI model should be able to drive the browser**.

## What
A single generic `OpenAICompatibleAdapter` for any OpenAI `/chat/completions`-compatible endpoint, selected by a small profile (which config slots to read). New providers:

| Provider | Reaches |
|---|---|
| `openrouter` | one key → ~every frontier model (Claude, GPT, Gemini, Grok, DeepSeek, Llama, Mistral, Qwen, …) |
| `xai` | Grok |
| `deepseek` | DeepSeek (text-only → DOM/accessibility outline) |
| `minimax` | MiniMax |
| `openai_compatible` | any custom base URL: self-hosted Ollama / vLLM / LM Studio, Azure, Together, Groq, Fireworks, … |

- Vision + function-calling, with a **content-parsing fallback** for endpoints that ignore `tool_choice` (more robust than a bespoke adapter).
- One parameterized class → no per-provider file to maintain.
- Extends `ProviderName`, registers the providers, documents `*_API_KEY`/`*_BASE_URL`/`*_MODEL` in `.env.example`, updates the README.
- **7-case test suite**; full provider/registry suites green locally (93 passed).

## Supersedes #77
MiniMax is now one of the generic profiles, so the bespoke MiniMax adapter in #77 is redundant. Closing #77 with credit.