### PR TITLE
fix(compose): wire APP_ENV and v1.4.0 providers into the controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **Compose deploy now wires `APP_ENV` and the v1.4.0 OpenAI-compatible providers into the controller.** `APP_ENV` was absent from `docker-compose.yml`, so `APP_ENV=production` in `.env` never reached the container — it always ran in `development`, silently skipping production hardening. And the new providers (`openrouter`, `xai`, `deepseek`, `minimax`, `openai_compatible`) weren't passed through, so they couldn't be configured through a standard compose deploy despite being supported in code. Both are now in the controller `environment:` block. Caught by smoke-testing the deploy end to end.
+
 ## [1.4.0] — 2026-07-09
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       browser-node:
         condition: service_healthy
     environment:
+      APP_ENV: ${APP_ENV:-development}
       API_BEARER_TOKEN: ${API_BEARER_TOKEN:-}
       CONTROLLER_ALLOWED_HOSTS: ${CONTROLLER_ALLOWED_HOSTS:-localhost,127.0.0.1,::1,testserver}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
@@ -104,6 +105,22 @@ services:
       GEMINI_CLI_PATH: ${GEMINI_CLI_PATH:-gemini}
       GEMINI_CLI_MODEL: ${GEMINI_CLI_MODEL:-}
       CLI_HOME: ${CLI_HOME:-/data/cli-home}
+      # OpenAI-compatible providers (v1.4.0): any model over an OpenAI /chat/completions endpoint.
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENROUTER_BASE_URL: ${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}
+      OPENROUTER_MODEL: ${OPENROUTER_MODEL:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
+      XAI_BASE_URL: ${XAI_BASE_URL:-https://api.x.ai/v1}
+      XAI_MODEL: ${XAI_MODEL:-grok-4}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-https://api.deepseek.com/v1}
+      DEEPSEEK_MODEL: ${DEEPSEEK_MODEL:-deepseek-chat}
+      MINIMAX_API_KEY: ${MINIMAX_API_KEY:-}
+      MINIMAX_BASE_URL: ${MINIMAX_BASE_URL:-https://api.minimax.io/v1}
+      MINIMAX_MODEL: ${MINIMAX_MODEL:-MiniMax-M3}
+      OPENAI_COMPATIBLE_API_KEY: ${OPENAI_COMPATIBLE_API_KEY:-}
+      OPENAI_COMPATIBLE_BASE_URL: ${OPENAI_COMPATIBLE_BASE_URL:-}
+      OPENAI_COMPATIBLE_MODEL: ${OPENAI_COMPATIBLE_MODEL:-}
       MODEL_REQUEST_TIMEOUT_SECONDS: ${MODEL_REQUEST_TIMEOUT_SECONDS:-60}
       MODEL_MAX_RETRIES: ${MODEL_MAX_RETRIES:-2}
       MODEL_RETRY_BACKOFF_SECONDS: ${MODEL_RETRY_BACKOFF_SECONDS:-1}


### PR DESCRIPTION
Found by smoke-testing the deploy on a local stack.

**Two gaps in `docker-compose.yml`:**
1. `APP_ENV` wasn't wired into the controller environment block, so setting it to production in the env file never reached the container (it ran in `development`, skipping production hardening). Verified against a running stack: `/readyz` reported `environment=development` before, `environment=production` after.
2. The v1.4.0 providers (`openrouter`/`xai`/`deepseek`/`minimax`/`openai_compatible`) were supported in code (#85) but not passed through compose, so they couldn't be configured in a standard deploy.

Both now sit in the controller environment block with the same `${VAR:-default}` pattern as the existing providers. Compose validated (`docker compose config`); stack smoke-tested healthy (`/healthz` ok, `/readyz` ready).