### PR TITLE
[codex] align harness attempt budgets and clear dependency audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+### Security
+
+- Upgraded FastAPI, Starlette, cryptography, and Pillow to versions that clear the release dependency audit.
+
 ## [1.0.6] — 2026-05-09
 
 ### Added

--- a/controller/app/harness/iterate.py
+++ b/controller/app/harness/iterate.py
@@ -127,13 +127,13 @@ class HarnessService:
             model_tiers=self.model_tiers,
         )
         self.store.save(record)
+        attempt_budget = min(max_attempts or contract.budget.max_attempts, contract.budget.max_attempts)
         detector = ConvergenceDetector(
             required_successes=min(3, max(1, contract.budget.max_attempts)),
-            max_attempts=max_attempts or contract.budget.max_attempts,
+            max_attempts=attempt_budget,
         )
         results: list[VerificationResult] = []
         latest_trace: TraceEnvelope | None = None
-        attempt_budget = min(max_attempts or contract.budget.max_attempts, contract.budget.max_attempts)
         deadline = time.monotonic() + contract.budget.max_wall_seconds
         for attempt_index in range(1, attempt_budget + 1):
             trace_path = run_dir / f"attempt-{attempt_index}" / "trace.json"

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -1,12 +1,12 @@
-fastapi==0.120.4
-starlette==0.49.3
+fastapi==0.139.0
+starlette==1.3.1
 uvicorn[standard]==0.35.0
 playwright==1.56.0
 pydantic-settings==2.10.1
 httpx==0.28.1
 redis==7.1.1
-cryptography==46.0.7
-Pillow==12.2.0
+cryptography==48.0.1
+Pillow==12.3.0
 pytesseract==0.3.13
 docker==7.1.0
 prometheus-client==0.22.1

--- a/controller/tests/test_harness_trace_induction.py
+++ b/controller/tests/test_harness_trace_induction.py
@@ -238,6 +238,24 @@ class HarnessServiceTests(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(ValueError):
                 service.graduate(record.id)
 
+    async def test_caller_attempt_override_cannot_leave_exhausted_run_active(self) -> None:
+        # Given: the caller asks for more attempts than the contract permits.
+        contract = _contract(max_attempts=1)
+        with tempfile.TemporaryDirectory() as tmp:
+            service = HarnessService(tmp)
+
+            # When: the only permitted attempt fails verification.
+            record = await service.start_convergence(
+                contract,
+                mock_final_observation={"url": "https://example.com/not-done", "text": "still running"},
+                max_attempts=3,
+            )
+
+            # Then: the persisted run is terminal because its effective budget is exhausted.
+            self.assertEqual(record.status, "unconverged")
+            self.assertFalse(record.decision.should_continue)
+            self.assertEqual(record.decision.total_attempts, 1)
+
     async def test_attempt_exception_is_persisted_as_failed_run(self) -> None:
         contract = _contract(max_attempts=2)
         orchestrator = _FailingOrchestrator()


### PR DESCRIPTION
## Problema

Quando o chamador solicitava mais tentativas do que o contrato permitia, o laço de convergência respeitava o limite do contrato, mas o `ConvergenceDetector` recebia o limite maior do chamador. Após a última tentativa efetivamente permitida falhar, a execução podia permanecer persistida como `running` embora não houvesse novas tentativas possíveis.

Além disso, o gate canônico de release identificou vulnerabilidades conhecidas nas versões fixadas de Starlette, cryptography e Pillow.

## Causa raiz

O orçamento efetivo era calculado separadamente para o laço e para o detector. Os pins de dependências também estavam abaixo das primeiras versões corrigidas apontadas pelo `pip-audit`; a atualização de Starlette exigiu atualizar FastAPI para uma versão compatível.

## Solução

- calcula `attempt_budget` uma única vez e o reutiliza no laço e no `ConvergenceDetector`;
- adiciona regressão cobrindo override do chamador maior que o contrato;
- atualiza FastAPI para 0.139.0, Starlette para 1.3.1, cryptography para 48.0.1 e Pillow para 12.3.0;
- registra a atualização de segurança no changelog.

## Validação

- `make release-audit` aprovado;
- 447 testes e 150 subtestes aprovados;
- cobertura total: 80,91% (gate: 80%);
- Ruff aprovado;
- auditorias Python e npm: zero vulnerabilidades conhecidas;
- wheels do controller, client e integração LangChain construídos e inspecionados;
- smoke real via Docker aprovado, incluindo sessão em `example.com` e observação do navegador;
- varredura de tokens em arquivos rastreados aprovada.

## Commits

- `fix: align harness attempt budgets`
- `chore: clear release dependency audit`
