### PR TITLE
[codex] align harness attempt budgets

### DIFF
--- a/controller/app/harness/iterate.py
+++ b/controller/app/harness/iterate.py
@@ -129,13 +129,13 @@ class HarnessService:
             model_tiers=self.model_tiers,
         )
         self.store.save(record)
+        attempt_budget = min(max_attempts or contract.budget.max_attempts, contract.budget.max_attempts)
         detector = ConvergenceDetector(
             required_successes=min(3, max(1, contract.budget.max_attempts)),
-            max_attempts=max_attempts or contract.budget.max_attempts,
+            max_attempts=attempt_budget,
         )
         results: list[VerificationResult] = []
         latest_trace: TraceEnvelope | None = None
-        attempt_budget = min(max_attempts or contract.budget.max_attempts, contract.budget.max_attempts)
         deadline = time.monotonic() + contract.budget.max_wall_seconds
         for attempt_index in range(1, attempt_budget + 1):
             trace_path = run_dir / f"attempt-{attempt_index}" / "trace.json"

--- a/controller/tests/test_harness_trace_induction.py
+++ b/controller/tests/test_harness_trace_induction.py
@@ -312,6 +312,24 @@ class HarnessServiceTests(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(ValueError):
                 service.graduate(record.id)
 
+    async def test_caller_attempt_override_cannot_leave_exhausted_run_active(self) -> None:
+        # Given: the caller asks for more attempts than the contract permits.
+        contract = _contract(max_attempts=1)
+        with tempfile.TemporaryDirectory() as tmp:
+            service = HarnessService(tmp)
+
+            # When: the only permitted attempt fails verification.
+            record = await service.start_convergence(
+                contract,
+                mock_final_observation={"url": "https://example.com/not-done", "text": "still running"},
+                max_attempts=3,
+            )
+
+            # Then: the persisted run is terminal because its effective budget is exhausted.
+            self.assertEqual(record.status, "unconverged")
+            self.assertFalse(record.decision.should_continue)
+            self.assertEqual(record.decision.total_attempts, 1)
+
     async def test_attempt_exception_is_persisted_as_failed_run(self) -> None:
         contract = _contract(max_attempts=2)
         orchestrator = _FailingOrchestrator()


### PR DESCRIPTION
## Problema

Quando o chamador solicitava mais tentativas do que o contrato permitia, o laço de convergência respeitava o limite efetivo do contrato, mas o `ConvergenceDetector` recebia o limite maior solicitado pelo chamador. Após a única tentativa permitida falhar, a execução podia permanecer registrada como `running`, embora nenhuma nova tentativa fosse possível.

## Causa raiz

O orçamento efetivo era calculado para o laço somente depois da criação do detector. Assim, o laço e o detector podiam operar com limites diferentes.

## Solução

- calcula `attempt_budget` uma única vez;
- reutiliza o mesmo valor no `ConvergenceDetector` e no laço;
- adiciona teste de regressão para o caso em que o override do chamador excede o orçamento do contrato.

## Validação

- teste de regressão vermelho antes da correção e verde depois;
- suíte focada aprovada;
- QA manual confirmou `unconverged`, `should_continue=false` e uma tentativa;
- `make release-audit` da base v1.4 aprovado antes da publicação, incluindo lint, auditoria de dependências, suíte completa, cobertura, build e smoke Docker;
- commit assinado via GPG.

## Escopo

Este PR substitui o #94. A branch foi recriada sobre a `main` v1.4 atual e contém somente a correção funcional e seu teste. A atualização de dependências do PR anterior foi descartada porque a `main` já incorporou correções próprias e compatíveis.
