### PR TITLE
docs: correct the fastapi pin rationale after lifting the cap

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -1,6 +1,13 @@
-# Cap <0.137: 0.137 changed router internals so include_router silently mounts
-# nothing (every route vanishes, only FastAPI's default doc routes survive).
-# Revisit behind a route-presence smoke test. See closed PR #82.
+# Cap lifted 2026-07-24 (was <0.137). The old cap claimed 0.137 made
+# include_router mount nothing, leaving only FastAPI's default doc routes. That
+# did not reproduce: the real app exposes an identical 91-path surface on
+# 0.136.3, 0.137.0 and 0.139.2, and PR #82 -- the bump that triggered the cap --
+# was itself fully green. controller/tests/test_route_presence.py now guards
+# router mounting directly, so this pin no longer stands in for a missing test.
+#
+# What 0.137 DID change: app.routes holds _IncludedRouter wrappers instead of
+# flattened Route objects. Never enumerate app.routes expecting .path -- use
+# app.openapi() or a request. The <0.140 bound keeps minor bumps reviewed.
 fastapi>=0.139.2,<0.140
 starlette==1.3.1
 uvicorn[standard]==0.51.0


### PR DESCRIPTION
Follow-up to #99, which bumped the pin but left Dependabot's untouched comment above it.

The comment still read `# Cap <0.137: ...` above `fastapi>=0.139.2,<0.140`, and asserted a route-vanishing regression that **does not reproduce** — 0.136.3, 0.137.0 and 0.139.2 all expose the same 91-path surface, and PR #82 (the bump that triggered the cap) was itself fully green.

Replaces it with what is actually true:
- the cap is lifted, and the guard is now `controller/tests/test_route_presence.py` (#101) rather than a version bound standing in for a missing test;
- the real 0.137 change is that `app.routes` holds `_IncludedRouter` wrappers instead of flattened `Route` objects, so **nothing may enumerate `app.routes` expecting `.path`**.

Comment-only change to `controller/requirements.txt`; no dependency versions altered.