### PR TITLE
release: v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.4.1] — 2026-07-24
+
 ### Added
 - **Route-presence gate (`controller/tests/test_route_presence.py`).** Router mounting is now verified directly instead of being guarded by a dependency pin. Three independent layers: every `include_router` call site is represented in the OpenAPI surface (13 canaries, each naming its owning module), the surface has not collapsed, and the canaries actually dispatch at runtime. Layer 3 is not redundant — since FastAPI 0.137 `app.routes` holds `_IncludedRouter` wrappers rather than flattened `Route` objects, so introspection and dispatch can diverge (#101).
 

--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-browser-browser-node",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "playwright": "1.61.0"
       }

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -2,4 +2,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.4.0"
+version = "1.4.1"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/controller/app/version.py
+++ b/controller/app/version.py
@@ -3,4 +3,4 @@
 Bump together with the package versions in */pyproject.toml and
 browser-node/package.json during release prep.
 """
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.4.0"
+version = "1.4.1"
 description = "Controller API for auto-browser"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.4.0"
+version = "1.4.1"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # console script against that dependency.
 [project]
 name = "auto-browser-mcp"
-version = "1.4.0"
+version = "1.4.1"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Patch release cutting the CI/correctness work from today.

## Contents

**Added**
- Route-presence gate (`controller/tests/test_route_presence.py`) — router mounting is now verified directly instead of guarded by a dependency pin (#101)

**Changed**
- `fastapi` cap `<0.137` lifted to `>=0.139.2,<0.140`, and its stated rationale corrected — the cap's premise did not reproduce (#99, #102)
- CI lint reads the ruff pin from `requirements-dev.txt` instead of hardcoding it, closing a 9-patch-version drift (#101)
- Richer MCP tool schemas for the five Glama C-rated tools

**Fixed**
- Compose deploy wires `APP_ENV` and the v1.4.0 OpenAI-compatible providers

**Deps** — ruff 0.15.22 (#98), actions/setup-python v7 (#100), actions/setup-node v7 (#96)

## Version surface

All **nine** version strings move together. v1.4.0 shipped with the four `pyproject.toml` files bumped but the runtime strings left at 1.3.1, which needed the follow-up in `0e41f95` — this covers the full set:

`client/pyproject.toml` · `controller/pyproject.toml` · `integrations/langchain/pyproject.toml` · `packaging/auto-browser-mcp/pyproject.toml` · `controller/app/version.py` · `client/auto_browser_client/__init__.py` · `browser-node/package.json` · `browser-node/package-lock.json` (×2)

## Pre-flight

- [x] Release workflow's tag-vs-version check simulated locally — all 3 published packages report `1.4.1`
- [x] `scripts/extract_changelog.py 1.4.1` returns the section (release notes will not be empty)
- [x] Diff is version-only; no reformatting

Tag `v1.4.1` after merge triggers PyPI trusted publishing for `auto-browser-client`, `auto-browser-langchain`, `auto-browser-mcp`, then the GitHub release.