### PR TITLE
docs: drop a shipped feature from the roadmap's Next list

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ This is the near-term direction for Auto Browser.
 - Shared session links — HMAC-signed TTL observer tokens
 - Vision-grounded targeting — Claude Vision element identification
 - Cron + webhook triggers — autonomous scheduled jobs
-- MCP Resources Protocol — live browser state as subscribable resources
+- MCP Resources Protocol — live browser state as subscribable resources, with `resources/subscribe` and `notifications/resources/updated` pushed over the event stream
 - Operator dashboard at `/dashboard` with SSE event stream
 - Durable background-agent checkpoints with dashboard resume/discard/cancel controls
 - Repeatable agent eval harness for provider and workflow-profile comparisons
@@ -33,8 +33,7 @@ This is the near-term direction for Auto Browser.
 ## Next
 
 - cleaner multi-tab / popup management
-- MCP `resources/subscribe` push notifications (live browser state streaming)
-- stronger trace viewer integration in operator dashboard
+- stronger trace viewer integration in operator dashboard (the API already returns a `viewer_url`; the dashboard does not surface it yet)
 
 ## Recently Shipped
 


### PR DESCRIPTION
The roadmap listed **MCP `resources/subscribe` push notifications** under `## Next`, but that shipped in **v1.1.0** (`6e20fab`, 2026-05-09) — over two months ago — and is documented in the CHANGELOG under "MCP Resources Protocol". The roadmap also contradicted itself, listing the same capability under `## Now`.

Verified in `controller/app/mcp_transport.py` before removing it — this is a complete implementation, not a stub:

- `resources/subscribe` with URI validation and `-32002` on an unknown resource, persisted per session
- `resources/unsubscribe`
- `_resource_event_stream` emitting `notifications/resources/updated` over SSE, with keepalives, disconnect detection, and per-subscription URI filtering

So the `Now` entry is the accurate one; it now says what the feature actually does rather than just naming it.

Also annotated the trace-viewer item with where the work actually stands: `/sessions/{id}/trace` already returns a `viewer_url` pointing at trace.playwright.dev — what's missing is surfacing it in the operator dashboard, which has no trace integration today.

Docs-only change. Matters because this is the public roadmap on a repo with 543 stars — a shipped feature sitting in "Next" understates what's already there.