### PR TITLE
docs: record the post-1.4.1 fix and coverage work in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **`python -m app.harness.run` no longer crashes when a task fails to converge.** The run record's `candidate` field is present but null unless the run succeeded, and `payload.get("candidate", {})` returns `None` rather than the `{}` default when a key exists with a null value — so the summary line raised `AttributeError` instead of printing, exactly when an operator was reading the output to find out why the run failed. The `--json` path was unaffected (#108).
+
+### Changed
+- **The auth-profile containment guards are now pinned by tests.** `BrowserAuthProfileService` handles stored browser auth state (cookies, session tokens) and was the least-covered module in the controller at 22%; its guards were correct but untested, so a refactor that weakened one would have shipped green. Rejection behaviour is now covered for Zip Slip member names, symlink/hardlink/device archive members, containment on a separator boundary rather than a raw string prefix, the profile-name whitelist, and archive-path traversal — plus the end-to-end property that a malicious archive writes nothing outside the root. Each guard's test was verified by breaking the guard and confirming the failure (#105).
+- **The MCP stdio bridge's failure paths are covered.** `app/mcp_stdio.py` — what `uvx auto-browser-mcp` runs — went from 58% to 99%, covering HTTP errors being returned rather than raised (so the server's JSON-RPC error reaches the client instead of a transport crash), teardown swallowing a dead connection, batch/non-object rejection, unreachable-endpoint handling, and protocol-version fallback when the response header is absent (#106).
+- Roadmap corrected: MCP `resources/subscribe` push notifications were listed under "Next" but shipped in v1.1.0 (#107).
+
 ## [1.4.1] — 2026-07-24
 
 ### Added


### PR DESCRIPTION
Documentation-only. Records the work merged after v1.4.1 in the `[Unreleased]` section:

- **Fixed** — `python -m app.harness.run` crashing on an unconverged run (#108). A real user-facing crash, so it belongs in the changelog rather than only in commit history.
- **Changed** — the auth-profile containment guards now pinned by tests (#105), MCP stdio bridge failure paths covered 58% → 99% (#106), and the roadmap correction (#107).

Note the harness fix lives in the controller, not in any of the three PyPI packages (`auto-browser-client`, `auto-browser-langchain`, `auto-browser-mcp`) — it ships in the controller image, so a tag purely to publish it would republish those three unchanged. Left for you to decide when the next release is worth cutting.