### PR TITLE
ci: extend the quality gates to the whole repo (+ a 3.14 bug they exposed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: make lint
       - name: Check Playwright pins matched (controller <-> browser-node)
         run: python scripts/check_playwright_pins.py
+      - name: Check version strings matched across packages
+        run: python scripts/check_version_parity.py
       - name: Validate agent eval matrix
         run: python scripts/agent_eval.py --mock --json --report-file /tmp/agent-evals.md
       - name: Validate fixture eval matrix
@@ -67,9 +69,15 @@ jobs:
       - name: Install client test dependencies
         run: python -m pip install -e ./client[dev]
       - name: Run direct client tests
+        # The client SDK is published to PyPI and measured 90% when this gate was
+        # added; 85% leaves headroom while stopping a silent slide. The controller
+        # has had an 80% gate for releases — the SDK users actually install had none.
         run: |
           cd client
-          PYTHONPATH=. python -m pytest tests -q
+          PYTHONPATH=. python -m pytest tests -q \
+            --cov=auto_browser_client \
+            --cov-report=term-missing \
+            --cov-fail-under=85
 
   dependency-audit:
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,31 @@ jobs:
             --cov-fail-under=80 \
             -v
 
+  langchain-tests:
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.14 is in the matrix deliberately: the sync _run path was broken there
+        # (asyncio.get_event_loop() raises since 3.14) while the package metadata
+        # advertised support, and nothing tested it.
+        python-version: ["3.11", "3.14"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install langchain integration test dependencies
+        run: python -m pip install -e './integrations/langchain[langchain,dev]'
+      - name: Run langchain integration tests
+        run: |
+          cd integrations/langchain
+          python -m pytest tests -q \
+            --cov=auto_browser_langchain \
+            --cov-report=term-missing \
+            --cov-fail-under=90
+
   client-tests:
     needs: lint
     runs-on: ubuntu-latest
@@ -139,7 +164,7 @@ jobs:
 
   compose-smoke:
     runs-on: ubuntu-latest
-    needs: [host-tests, client-tests, dependency-audit, package-build, controller-tests]
+    needs: [host-tests, client-tests, langchain-tests, dependency-audit, package-build, controller-tests]
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,12 @@
 help: ## Show available commands
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | sed 's/:.*## /\t/' | sort
 
-lint: ## Run Ruff checks on app, tests, and Python scripts
-	ruff check controller/app controller/tests scripts/*.py --select E9,F,I
+lint: ## Run Ruff checks across the whole repo
+	# Repo-wide, not a path list: the previous scope (controller/app, controller/tests,
+	# scripts/*.py) silently excluded client/, integrations/ and benchmarks/ — including
+	# two packages published to PyPI — and four real errors had accumulated there unseen.
+	# Ruff's defaults plus .gitignore already exclude .venv*/, node_modules/, build/, dist/.
+	ruff check . --select E9,F,I
 
 up: ## Start the shared browser stack
 	./scripts/compose_local.sh up --build

--- a/benchmarks/webarena/run_stage0.py
+++ b/benchmarks/webarena/run_stage0.py
@@ -92,9 +92,8 @@ def _cmd_execute() -> int:
 def _execute_live(contracts: list[TaskContract], run_dir: Path, base_url: str) -> int:
     try:
         sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "controller"))
-        from fastapi.testclient import TestClient
-
         from app.main import app
+        from fastapi.testclient import TestClient
     except Exception as exc:  # noqa: BLE001 - missing controller is a skip
         print(f"[webarena] SKIP live execution: controller not importable ({exc}).")
         return 0

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -37,7 +37,7 @@ auto-browser-mcp = "auto_browser_client.mcp_bridge:main"
 include = ["auto_browser_client*"]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio", "respx"]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "respx"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/client/tests/test_client_paths.py
+++ b/client/tests/test_client_paths.py
@@ -5,7 +5,6 @@ import unittest
 from typing import Any
 
 import httpx
-
 from auto_browser_client import AutoBrowserClient
 
 

--- a/controller/harness/run.py
+++ b/controller/harness/run.py
@@ -9,6 +9,5 @@ if str(CONTROLLER_ROOT) not in sys.path:
 
 from app.harness.run import main
 
-
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/examples/workflows/social_empire.py
+++ b/examples/workflows/social_empire.py
@@ -195,7 +195,7 @@ def WARMUP_CHECK(
     for platform in platforms:
         steps.append({
             "id": f"check_{platform}",
-            "action": f"social.auth.verify",
+            "action": "social.auth.verify",
             "params": {
                 "platform": platform,
                 "auth_profile": f"{platform}-default",

--- a/integrations/langchain/auto_browser_langchain/tool.py
+++ b/integrations/langchain/auto_browser_langchain/tool.py
@@ -44,7 +44,11 @@ class AutoBrowserTool(BaseTool):
     def _run(self, action: str, arguments: dict[str, Any] | None = None) -> str:
         import asyncio
 
-        return asyncio.get_event_loop().run_until_complete(self._arun(action, arguments or {}))
+        # asyncio.run, not get_event_loop().run_until_complete(): since Python 3.14
+        # get_event_loop() raises RuntimeError when no loop is running, which broke
+        # this sync path outright on a version the package claims to support.
+        # Callers already inside a running loop should await _arun via ainvoke.
+        return asyncio.run(self._arun(action, arguments or {}))
 
     async def _arun(self, action: str, arguments: dict[str, Any] | None = None) -> str:
         headers: dict[str, str] = {"Content-Type": "application/json"}

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -27,6 +27,13 @@ classifiers = [
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.2"]
 crewai = ["crewai>=0.28"]
+# langchain-core is pinned rather than floated: the tests need it installed to
+# exercise AutoBrowserTool at all, and 1.5.0 was the newest release older than
+# the 72-hour supply-chain window when this suite was added. Bump deliberately.
+dev = ["pytest", "pytest-cov", "respx", "langchain-core==1.5.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [project.urls]
 Homepage = "https://github.com/LvcidPsyche/auto-browser"

--- a/integrations/langchain/tests/test_langchain_integration.py
+++ b/integrations/langchain/tests/test_langchain_integration.py
@@ -1,0 +1,263 @@
+"""Tests for the auto-browser LangChain / LangGraph integration.
+
+This package is published to PyPI as ``auto-browser-langchain`` and had no
+tests at all. It is also the thinnest surface in the repo — every method is a
+small HTTP call plus response unwrapping — which is exactly where a silent
+shape change (``content[0].text`` moving, an error flag renamed) goes unnoticed
+until a user's agent starts returning empty strings.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+
+import httpx
+import respx
+from auto_browser_langchain import AutoBrowserNode, AutoBrowserTool
+
+BASE_URL = "http://auto-browser.test"
+
+
+def _content(text: str) -> dict:
+    return {"content": [{"text": text}]}
+
+
+class AutoBrowserToolTests(unittest.TestCase):
+    @respx.mock
+    def test_run_executes_synchronously(self) -> None:
+        # Regression: _run used asyncio.get_event_loop().run_until_complete(),
+        # which raises RuntimeError on Python 3.14 ("no current event loop") --
+        # breaking the sync path LangChain and CrewAI call, on a version this
+        # package's metadata claims to support.
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content("observed"))
+        )
+
+        result = AutoBrowserTool(base_url=BASE_URL)._run("browser.observe", {"session_id": "s1"})
+
+        self.assertEqual(result, "observed")
+        self.assertTrue(route.called)
+
+    @respx.mock
+    def test_run_defaults_arguments_to_an_empty_object(self) -> None:
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content("ok"))
+        )
+
+        AutoBrowserTool(base_url=BASE_URL)._run("browser.observe")
+
+        self.assertEqual(json.loads(route.calls[0].request.content)["arguments"], {})
+
+
+class AutoBrowserToolAsyncTests(unittest.IsolatedAsyncioTestCase):
+    @respx.mock
+    async def test_arun_returns_the_first_content_text(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content("page title"))
+        )
+
+        result = await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
+
+        self.assertEqual(result, "page title")
+
+    @respx.mock
+    async def test_arun_surfaces_tool_errors(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json={"isError": True, "content": [{"text": "session gone"}]})
+        )
+
+        result = await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
+
+        self.assertEqual(result, "ERROR: session gone")
+
+    @respx.mock
+    async def test_arun_falls_back_to_the_raw_payload_without_text(self) -> None:
+        payload = {"content": [{"data": "no text field"}]}
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=payload))
+
+        result = await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
+
+        self.assertEqual(json.loads(result), payload)
+
+    @respx.mock
+    async def test_arun_sends_the_action_and_arguments(self) -> None:
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content("ok"))
+        )
+
+        await AutoBrowserTool(base_url=BASE_URL)._arun("browser.click", {"selector": "#go"})
+
+        body = json.loads(route.calls[0].request.content)
+        self.assertEqual(body, {"name": "browser.click", "arguments": {"selector": "#go"}})
+
+    @respx.mock
+    async def test_arun_sends_bearer_token_when_configured(self) -> None:
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content("ok"))
+        )
+
+        await AutoBrowserTool(base_url=BASE_URL, bearer_token="s3cret")._arun("browser.observe", {})
+
+        self.assertEqual(route.calls[0].request.headers["Authorization"], "Bearer s3cret")
+
+    @respx.mock
+    async def test_arun_omits_authorization_without_a_token(self) -> None:
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content("ok"))
+        )
+
+        await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
+
+        self.assertNotIn("authorization", {k.lower() for k in route.calls[0].request.headers})
+
+    @respx.mock
+    async def test_arun_raises_on_http_error(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(401, json={"detail": "nope"}))
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
+
+
+class AutoBrowserToolListToolsTests(unittest.TestCase):
+    @respx.mock
+    def test_list_tools_returns_the_catalogue(self) -> None:
+        respx.get(f"{BASE_URL}/mcp/tools").mock(
+            return_value=httpx.Response(200, json=[{"name": "browser.observe"}])
+        )
+
+        self.assertEqual(AutoBrowserTool.list_tools(base_url=BASE_URL), [{"name": "browser.observe"}])
+
+    @respx.mock
+    def test_list_tools_sends_bearer_token(self) -> None:
+        route = respx.get(f"{BASE_URL}/mcp/tools").mock(return_value=httpx.Response(200, json=[]))
+
+        AutoBrowserTool.list_tools(base_url=BASE_URL, bearer_token="s3cret")
+
+        self.assertEqual(route.calls[0].request.headers["Authorization"], "Bearer s3cret")
+
+
+class AutoBrowserNodeTests(unittest.TestCase):
+    def test_base_url_trailing_slash_is_stripped(self) -> None:
+        self.assertEqual(AutoBrowserNode(base_url=f"{BASE_URL}/").base_url, BASE_URL)
+
+    def test_headers_include_bearer_only_when_set(self) -> None:
+        self.assertNotIn("Authorization", AutoBrowserNode(base_url=BASE_URL)._headers())
+        self.assertEqual(
+            AutoBrowserNode(base_url=BASE_URL, bearer_token="s3cret")._headers()["Authorization"],
+            "Bearer s3cret",
+        )
+
+
+class AutoBrowserNodeAsyncTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.node = AutoBrowserNode(base_url=BASE_URL)
+
+    @respx.mock
+    async def test_call_tool_posts_name_and_arguments(self) -> None:
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        result = await self.node.call_tool("browser.observe", {"session_id": "s1"})
+
+        self.assertEqual(result, {"ok": True})
+        body = json.loads(route.calls[0].request.content)
+        self.assertEqual(body, {"name": "browser.observe", "arguments": {"session_id": "s1"}})
+
+    @respx.mock
+    async def test_create_session_reads_session_id(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content(json.dumps({"session_id": "sess-1"})))
+        )
+
+        self.assertEqual(await self.node.create_session(), "sess-1")
+
+    @respx.mock
+    async def test_create_session_accepts_id_as_an_alias(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content(json.dumps({"id": "sess-2"})))
+        )
+
+        self.assertEqual(await self.node.create_session(), "sess-2")
+
+    @respx.mock
+    async def test_create_session_forwards_start_url(self) -> None:
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content(json.dumps({"session_id": "sess-3"})))
+        )
+
+        await self.node.create_session(start_url="https://example.com")
+
+        body = json.loads(route.calls[0].request.content)
+        self.assertEqual(body["arguments"], {"start_url": "https://example.com"})
+
+    @respx.mock
+    async def test_create_session_omits_start_url_when_absent(self) -> None:
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content(json.dumps({"session_id": "sess-4"})))
+        )
+
+        await self.node.create_session()
+
+        self.assertEqual(json.loads(route.calls[0].request.content)["arguments"], {})
+
+    @respx.mock
+    async def test_create_session_raises_when_no_id_is_returned(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content(json.dumps({"unexpected": "shape"})))
+        )
+
+        with self.assertRaises(KeyError):
+            await self.node.create_session()
+
+    @respx.mock
+    async def test_observe_parses_the_embedded_json(self) -> None:
+        observation = {"url": "https://example.com/a", "screenshot_url": "/artifacts/a.png"}
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content(json.dumps(observation)))
+        )
+
+        self.assertEqual(await self.node.observe("sess-1"), observation)
+
+    @respx.mock
+    async def test_run_creates_a_session_when_state_has_none(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            side_effect=[
+                httpx.Response(200, json=_content(json.dumps({"session_id": "sess-new"}))),
+                httpx.Response(200, json=_content(json.dumps({"url": "https://example.com/x"}))),
+            ]
+        )
+
+        state = await self.node.run({"goal": "look around"})
+
+        self.assertEqual(state["session_id"], "sess-new")
+        self.assertEqual(state["current_url"], "https://example.com/x")
+        self.assertEqual(state["goal"], "look around")
+
+    @respx.mock
+    async def test_run_reuses_an_existing_session(self) -> None:
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content(json.dumps({"url": "https://example.com/y"})))
+        )
+
+        state = await self.node.run({"session_id": "sess-existing"})
+
+        # Exactly one call: observe. No session was created.
+        self.assertEqual(len(route.calls), 1)
+        self.assertEqual(json.loads(route.calls[0].request.content)["name"], "browser.observe")
+        self.assertEqual(state["session_id"], "sess-existing")
+
+    @respx.mock
+    async def test_run_defaults_missing_observation_fields_to_empty_strings(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json=_content(json.dumps({})))
+        )
+
+        state = await self.node.run({"session_id": "sess-1"})
+
+        self.assertEqual(state["current_url"], "")
+        self.assertEqual(state["screenshot_url"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,16 @@
+# Ruff settings for everything outside controller/, which keeps its own
+# [tool.ruff] in controller/pyproject.toml and is unaffected by this file
+# (Ruff resolves the nearest config per file).
+#
+# Before this existed, scripts/, client/, integrations/, benchmarks/ and
+# examples/ were linted with Ruff's bare defaults — a different line length
+# than the controller, and a target version old enough that `tomllib` was
+# classified as third-party rather than stdlib. Matching the controller's
+# settings keeps one repo linting one way.
+line-length = 120
+target-version = "py311"
+
+[lint]
+# The gate is deliberately narrow: syntax errors, undefined/unused names, and
+# import order. Widening it is a separate decision from widening the scope.
+select = ["E9", "F", "I"]

--- a/scripts/check_version_parity.py
+++ b/scripts/check_version_parity.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Fail if the version strings across the repo's packages drift apart.
+
+The release workflow verifies the tag against the three *published* pyproject
+files only. Everything else — the controller's runtime version, the client's
+``__version__``, browser-node's package files — is unchecked, and that gap has
+bitten before: v1.4.0 shipped with the four pyprojects bumped while the runtime
+strings sat at 1.3.1, needing a follow-up alignment commit (0e41f95).
+
+This makes the matched-set invariant machine-enforced instead of a checklist
+someone has to remember during a release. Every location below must agree.
+
+Exit 0 when all versions match, 1 (listing every offender) when they don't.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PYPROJECTS = (
+    "client/pyproject.toml",
+    "controller/pyproject.toml",
+    "integrations/langchain/pyproject.toml",
+    "packaging/auto-browser-mcp/pyproject.toml",
+)
+
+DUNDER_VERSIONS = (
+    "controller/app/version.py",
+    "client/auto_browser_client/__init__.py",
+)
+
+_DUNDER = re.compile(r'^__version__\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def _pyproject_version(relative: str) -> tuple[str, str]:
+    path = REPO_ROOT / relative
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    return relative, data["project"]["version"]
+
+
+def _dunder_version(relative: str) -> tuple[str, str]:
+    path = REPO_ROOT / relative
+    match = _DUNDER.search(path.read_text(encoding="utf-8"))
+    if match is None:
+        raise SystemExit(f"could not find a '__version__ = \"...\"' in {relative}")
+    return relative, match.group(1)
+
+
+def _npm_versions() -> list[tuple[str, str]]:
+    found: list[tuple[str, str]] = []
+
+    package = json.loads((REPO_ROOT / "browser-node/package.json").read_text(encoding="utf-8"))
+    found.append(("browser-node/package.json", package["version"]))
+
+    lock = json.loads((REPO_ROOT / "browser-node/package-lock.json").read_text(encoding="utf-8"))
+    found.append(("browser-node/package-lock.json", lock["version"]))
+    # The lockfile repeats the version on its root package entry; npm rewrites
+    # both, so a hand-edit that misses one is exactly the drift worth catching.
+    root_entry = lock.get("packages", {}).get("")
+    if isinstance(root_entry, dict) and "version" in root_entry:
+        found.append(('browser-node/package-lock.json (packages."")', root_entry["version"]))
+
+    return found
+
+
+def collect() -> list[tuple[str, str]]:
+    versions = [_pyproject_version(path) for path in PYPROJECTS]
+    versions += [_dunder_version(path) for path in DUNDER_VERSIONS]
+    versions += _npm_versions()
+    return versions
+
+
+def main() -> int:
+    versions = collect()
+    distinct = {version for _, version in versions}
+
+    if len(distinct) == 1:
+        print(f"OK: all {len(versions)} version strings agree on {versions[0][1]}.")
+        return 0
+
+    # Report against the most common value so the odd ones out are obvious.
+    counts = {value: sum(1 for _, v in versions if v == value) for value in distinct}
+    expected = max(counts, key=lambda value: counts[value])
+
+    print(
+        "ERROR: version strings have drifted apart.\n"
+        f"  most common: {expected} ({counts[expected]} of {len(versions)})\n",
+        file=sys.stderr,
+    )
+    for location, version in versions:
+        marker = "  " if version == expected else "->"
+        print(f"{marker} {location:52} {version}", file=sys.stderr)
+    print(
+        "\nAll of these must move together in a release commit. See "
+        "scripts/check_version_parity.py for why.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Four gates that stopped at the controller boundary now cover what actually ships — and widening them immediately surfaced a real bug in a published package.

## 0. The bug the gates found

`AutoBrowserTool._run()` — the **synchronous** path LangChain and CrewAI call for `.invoke()` — was broken on **Python 3.14**:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
```

It called `asyncio.get_event_loop().run_until_complete()`. Since 3.14, `get_event_loop()` raises when no loop is running rather than creating one. The package advertises 3.14 in `requires-python` and its classifiers, and **nothing tested it**, so this shipped in 1.4.x unnoticed. Fixed with `asyncio.run()`, which is correct on every supported version and fails just as clearly when called from inside a running loop.

Verified broken-then-fixed on 3.14, unchanged on 3.12. The regression test fails without the fix (2 failures) and passes with it.

## 1. Lint the whole repo

`make lint` ran on `controller/app controller/tests scripts/*.py` — so `client/`, `integrations/`, `benchmarks/` and `examples/` were **never linted**, including two packages published to PyPI. Four real errors had accumulated there:

```
benchmarks/webarena/run_stage0.py:95    I001  unsorted imports
client/tests/test_client_paths.py:1     I001  unsorted imports
controller/harness/run.py:10            I001  unsorted imports
examples/workflows/social_empire.py:198 F541  f-string without placeholders
```

Scope is now `.` — no path list, which is the point: **a list is what silently went stale.** Adds a root `ruff.toml` because the unlinted areas were falling back to Ruff's bare defaults (different line length; a target version old enough to call `tomllib` third-party). `controller/` keeps its own `[tool.ruff]`, so its settings are unchanged.

## 2. Version-parity guard

The release workflow verifies the tag against the **three published pyprojects only** — the exact gap that shipped **v1.4.0 with runtime strings stuck at 1.3.1**, needing the follow-up in `0e41f95`. `scripts/check_version_parity.py` now enforces all **nine** strings and reports every offender rather than failing on the first.

## 3. Tests for `auto-browser-langchain`

It ships to PyPI and had **zero tests** — no test directory, nothing referencing it elsewhere, and outside the lint scope too. Now 23 tests over both classes: sync/async paths, error surfacing, bearer headers, raw-payload fallback, session-id aliasing, the missing-id `KeyError`, and `run()` both creating and reusing a session. **0% → 94%** (remainder is the no-langchain-core import fallback).

New `langchain-tests` job runs **3.11 and 3.14** deliberately — 3.14 is where `_run` was broken.

## 4. Coverage gate on the client SDK

The controller enforced 80% while `auto-browser-client` — the package users `pip install` — had none. Measures 90%; gated at 85%.

## Note for you

`langchain-core` is pinned to `1.5.0` in the dev extra: the tests need it installed to exercise `AutoBrowserTool` at all, and 1.5.0 was the newest release outside your 72-hour supply-chain window when this landed (1.5.1 was ~27h old). Worth bumping deliberately later — or loosening to a floor if you'd rather catch upstream breakage than pin.

**Branch protection will need `langchain-tests (3.11)` and `langchain-tests (3.14)` added to the required contexts once this merges.**