### PR TITLE
release: v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.4.2] — 2026-07-25
+
 ### Fixed
 - **`AutoBrowserTool` works again on Python 3.14.** The synchronous path — what LangChain and CrewAI call for `.invoke()` — used `asyncio.get_event_loop().run_until_complete()`, and since 3.14 `get_event_loop()` raises `RuntimeError: There is no current event loop` rather than creating one. `auto-browser-langchain` advertises 3.14 in `requires-python` and its classifiers, and nothing tested the package at all, so this shipped unnoticed. Now uses `asyncio.run()`, which is correct on every supported version; callers already inside an event loop should await `_arun` via `ainvoke` (#110).
 - **`python -m app.harness.run` no longer crashes when a task fails to converge.** The run record's `candidate` field is present but null unless the run succeeded, and `payload.get("candidate", {})` returns `None` rather than the `{}` default when a key exists with a null value — so the summary line raised `AttributeError` instead of printing, exactly when an operator was reading the output to find out why the run failed. The `--json` path was unaffected (#108).

--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-browser-browser-node",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "playwright": "1.61.0"
       }

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -2,4 +2,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.4.1"
+version = "1.4.2"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/controller/app/version.py
+++ b/controller/app/version.py
@@ -3,4 +3,4 @@
 Bump together with the package versions in */pyproject.toml and
 browser-node/package.json during release prep.
 """
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.4.1"
+version = "1.4.2"
 description = "Controller API for auto-browser"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.4.1"
+version = "1.4.2"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # console script against that dependency.
 [project]
 name = "auto-browser-mcp"
-version = "1.4.1"
+version = "1.4.2"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Patch release. Unlike v1.4.1's follow-up work, this one **changes shipped code in a published package**, so it actually needs to go out.

## Why now

```
$ git diff --stat v1.4.1..main -- integrations/langchain/auto_browser_langchain/ client/auto_browser_client/ packaging/auto-browser-mcp/
 integrations/langchain/auto_browser_langchain/tool.py | 6 +++++-
```

Anyone on **Python 3.14** using `AutoBrowserTool`'s synchronous path (`.invoke()`, which is what LangChain and CrewAI call) is broken on PyPI right now with `RuntimeError: There is no current event loop`.

## Contents

**Fixed**
- `AutoBrowserTool` works again on Python 3.14 — `asyncio.get_event_loop()` raises since 3.14; now uses `asyncio.run()` (#110)
- `python -m app.harness.run` no longer crashes on an unconverged run (#108)

**Changed**
- Quality gates extended repo-wide; `auto-browser-langchain` **0% → 94%** with a 3.11/3.14 CI job; `auto-browser-client` gated at 85% (#110)
- Version parity across all nine strings machine-enforced (#110)
- Auth-profile containment guards and MCP stdio bridge failure paths now covered by tests (#105, #106)

## Pre-flight

- [x] `scripts/check_version_parity.py` — **all 9 version strings agree on 1.4.2** (first release with this enforced in CI rather than remembered)
- [x] Release workflow's tag-vs-version check simulated locally — all 3 published packages report `1.4.2`
- [x] `scripts/extract_changelog.py 1.4.2` returns the section, so release notes will not be empty
- [x] `ruff check .` clean repo-wide
- [x] Diff is version-only plus the changelog heading

Tag `v1.4.2` after merge triggers PyPI trusted publishing for the three packages, then the GitHub release.