### PR TITLE
chore(langchain): float the langchain-core test pin

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -27,10 +27,11 @@ classifiers = [
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.2"]
 crewai = ["crewai>=0.28"]
-# langchain-core is pinned rather than floated: the tests need it installed to
-# exercise AutoBrowserTool at all, and 1.5.0 was the newest release older than
-# the 72-hour supply-chain window when this suite was added. Bump deliberately.
-dev = ["pytest", "pytest-cov", "respx", "langchain-core==1.5.0"]
+# dev pulls the langchain extra rather than naming langchain-core again, so the
+# version constraint has exactly one home. Floated deliberately: this package's
+# whole job is to sit on top of langchain-core, so testing against whatever is
+# current is how upstream breakage gets caught rather than discovered by users.
+dev = ["auto-browser-langchain[langchain]", "pytest", "pytest-cov", "respx"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
The `dev` extra pinned `langchain-core==1.5.0` — chosen because it was the newest release outside the 72-hour supply-chain window when the suite landed in #110.

A hard pin means this package is only ever tested against **one** version of the library it exists to sit on top of, so upstream breakage would reach users before CI ever saw it. For an integration package that trade is the wrong way round.

## Change

```diff
-dev = ["pytest", "pytest-cov", "respx", "langchain-core==1.5.0"]
+dev = ["auto-browser-langchain[langchain]", "pytest", "pytest-cov", "respx"]
```

`dev` now pulls the `langchain` extra rather than naming `langchain-core` again, so the constraint has **exactly one home** (`langchain = ["langchain-core>=0.2"]`) instead of two that can drift — the same failure mode as the ruff and Playwright pins fixed earlier.

## Verified

- `pip install -e ./integrations/langchain[dev]` **alone** resolves langchain-core via the self-referential extra (this was the risk — a bare `[dev]` must stay self-sufficient)
- CI's exact form `[langchain,dev]` still resolves
- Suite passes against current langchain-core **1.5.1**: 23 passed, 94%

## Note

CI will now install whatever langchain-core is current at run time. As of this PR that's 1.5.1, published ~46h ago — inside your 72-hour supply-chain window. That's inherent to floating rather than a defect in this change, and it's the trade you asked for: catching upstream breakage in CI instead of in user reports.