### PR TITLE
MCP cold start + text-first observation (v1.5.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: python scripts/check_playwright_pins.py
       - name: Check version strings matched across packages
         run: python scripts/check_version_parity.py
+      - name: Check stdio bridge copies matched (client <-> controller)
+        run: python scripts/check_bridge_parity.py
       - name: Validate agent eval matrix
         run: python scripts/agent_eval.py --mock --json --report-file /tmp/agent-evals.md
       - name: Validate fixture eval matrix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.5.0] — 2026-07-30
+
+### Added
+- **`text` observation preset — read a page without paying for pixels.** `browser.observe` (and `GET/POST /sessions/{id}/observe`) now takes `preset="text"`: populated accessibility outline, text excerpt, DOM outline, and interactables with **no screenshot and no OCR**. This is the cheapest way for an agent to read a page's content, and closes the cost gap with accessibility-snapshot-first browser MCP servers. `screenshot_path`/`screenshot_url` stay in the payload as `null`, so consumers keep a stable shape.
+- **`browser.find_elements` query mode.** Pass `query` (with optional `regex` and `context`) instead of `selector` to search the page's text content and get back each match plus surrounding text — locate one string on a page in a single cheap call instead of a full observe. Matching is case-insensitive in both modes; exactly one of `selector`/`query` is required.
+- **OCR skipping on `normal`/`rich` observes** when text extraction already produced usable content (`OCR_SKIP_WHEN_TEXT_AVAILABLE`, default on). Never skipped while screenshot PII scrubbing is active — scrubbing consumes OCR's bounding boxes, so redaction always wins over token savings. Under default config (scrubbing on) OCR therefore still runs; use `preset="text"` for the real savings.
+
+### Fixed
+- **The MCP stdio bridge's cold-start error is actionable.** A first-time `uvx auto-browser-mcp` user with no controller running used to get `Unable to reach Auto Browser MCP HTTP endpoint: [WinError 10061]` — the exact moment an agent silently falls back to a competing server. The error now names the endpoint it tried and the fix (`docker compose up -d`, or `--base-url`/`AUTO_BROWSER_BASE_URL` for remote deployments).
+- **Tool errors an agent can act on.** Invalid tool arguments now report pydantic's field-level errors, handler-raised `ValueError`/`KeyError`/`RuntimeError` messages ("Provide source_selector or source_x/source_y", "Memory profile not found") pass through to the caller, and an invalid regex in `find_elements` returns a structured `invalid_regex` error — all of these previously collapsed into an opaque `Tool execution failed`.
+- **`PERCEPTION_PRESET_DEFAULT` actually works.** The setting existed but every observe path hardcoded `normal`, so it was dead config. An omitted preset now resolves against it (unknown values clamp to `normal` with a warning), and the client SDK stopped forcing `preset="normal"` on every call — omitted means the deployment default. One env var now flips a whole deployment to screenshot-free observes.
+- **`./scripts/test_local.sh` no longer reports phantom failures on developer boxes.** It ran discovery from the repo root, where pydantic-settings picks up a developer's local dotenv — auth and rate limits turned on and ~138 route tests failed with 400s that CI and Docker (which have no dotenv) never see. Discovery now runs from `controller/`. The interpreter search also probes for the controller's dependencies rather than accepting on version alone, and falls back to the Windows `py` launcher — a stock Windows Git Bash box now finds its working interpreter without `AUTO_BROWSER_PYTHON_BIN`.
+
+### CI
+- **The stdio bridge's two copies are parity-enforced.** `client/auto_browser_client/mcp_bridge.py` and `controller/app/mcp_stdio.py` are intentionally byte-identical, and nothing caught an edit applied to only one. `scripts/check_bridge_parity.py` now fails CI on drift — same one-thing-two-sources class as the version and Playwright pin guards.
+
 ## [1.4.2] — 2026-07-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ Works with:
 - **Safety rails built in.** Approvals, operator identity, PII scrubbing, Witness receipts, and policy presets are all part of the product surface.
 - **Governed skill induction.** Verified browser traces can become staged skill candidates with signed provenance, verifier adapters, and review-only graduation — agents that prove they can repeat themselves correctly, not just act once.
 
-## Release Highlights (v1.4.0)
+## Release Highlights (v1.5.0)
 
+- **Read a page without paying for pixels.** The new `text` observation preset returns the accessibility outline, extracted text, and interactables with no screenshot and no OCR — the cheapest way for an agent to read a page. Set `PERCEPTION_PRESET_DEFAULT=text` to make it a deployment-wide default.
+- **Find a string on the page in one call.** `browser.find_elements` now takes a `query` (plain text or regex, case-insensitive) instead of a CSS selector and returns each match with surrounding context — no full observe needed to check one value.
+- **Errors agents can act on.** Invalid tool arguments report field-level details, handler messages pass through instead of a generic failure, and the MCP bridge's cold-start error now says exactly how to start the controller.
 - **Any OpenAI-compatible model can drive the browser.** A single generic adapter serves every model reachable over an OpenAI `/chat/completions` endpoint. New providers: `openrouter` (one key → ~every frontier model), `xai` (Grok), `deepseek`, `minimax`, and `openai_compatible` (custom base URL for self-hosted Ollama / vLLM / LM Studio, Azure, Together, Groq, Fireworks, …). Vision + function-calling with a content-parse fallback for endpoints that ignore `tool_choice`.
 - **`browser://audit/events` MCP resource.** List and read recent audit events across sessions directly over MCP.
 - **Playwright pin parity enforced in CI.** The controller (pip) and browser-node (npm) Playwright versions must match exactly — a single-side bump can no longer merge and crash-loop compose deployments.

--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-browser-browser-node",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "dependencies": {
         "playwright": "1.61.0"
       }

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -2,4 +2,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.4.2"
+__version__ = "1.5.0"

--- a/client/auto_browser_client/client.py
+++ b/client/auto_browser_client/client.py
@@ -188,23 +188,33 @@ class AutoBrowserClient:
         self,
         session_id: str,
         *,
-        preset: str = "normal",
+        preset: str | None = None,
         limit: int = 40,
     ) -> dict:
         """Observe the current browser state.
 
-        preset: "fast" (screenshot only), "normal" (default), "rich" (extended)
+        preset: "text" (no screenshot/OCR — cheapest way to read a page),
+        "fast" (screenshot only), "normal" (screenshot + OCR + accessibility),
+        "rich" (extended text + DOM outline). Omit to use the controller's
+        deployment default (PERCEPTION_PRESET_DEFAULT, normally "normal").
         """
-        return self._post(f"/sessions/{session_id}/observe", {"preset": preset, "limit": limit})
+        body: dict = {"limit": limit}
+        if preset is not None:
+            body["preset"] = preset
+        return self._post(f"/sessions/{session_id}/observe", body)
 
     async def async_observe(
         self,
         session_id: str,
         *,
-        preset: str = "normal",
+        preset: str | None = None,
         limit: int = 40,
     ) -> dict:
-        return await self._apost(f"/sessions/{session_id}/observe", {"preset": preset, "limit": limit})
+        """Async variant of observe; see observe for the preset values."""
+        body: dict = {"limit": limit}
+        if preset is not None:
+            body["preset"] = preset
+        return await self._apost(f"/sessions/{session_id}/observe", body)
 
     # ── Navigation & actions ─────────────────────────────────────────────────
 

--- a/client/auto_browser_client/mcp_bridge.py
+++ b/client/auto_browser_client/mcp_bridge.py
@@ -131,7 +131,13 @@ class StdioMcpBridge:
                 protocol_version=self.protocol_version,
             )
         except URLError as exc:
-            return self._jsonrpc_error(request_id, -32000, f"Unable to reach Auto Browser MCP HTTP endpoint: {exc.reason}")
+            return self._jsonrpc_error(
+                request_id,
+                -32000,
+                f"No Auto Browser controller reachable at {self.client.base_url} — "
+                "start one with 'docker compose up -d' in the auto-browser repo, or pass "
+                f"--base-url/AUTO_BROWSER_BASE_URL for a remote deployment. (underlying: {exc.reason})",
+            )
         except Exception as exc:  # pragma: no cover - defensive bridge guard
             print(f"stdio bridge unexpected error: {exc}", file=self.stderr)
             return self._jsonrpc_error(request_id, -32000, f"Unexpected stdio bridge failure: {exc}")

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.4.2"
+version = "1.5.0"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/client/tests/test_mcp_bridge_edges.py
+++ b/client/tests/test_mcp_bridge_edges.py
@@ -20,8 +20,9 @@ from auto_browser_client.mcp_bridge import (
 class RecordingHttpMcpClient:
     """Configurable fake honoring the HttpMcpClient interface."""
 
-    def __init__(self, response: HttpMcpResponse | Exception):
+    def __init__(self, response: HttpMcpResponse | Exception, *, base_url: str = "http://ctrl.test/mcp"):
         self.response = response
+        self.base_url = base_url
         self.posts: list[dict[str, object]] = []
         self.deleted_session_ids: list[str | None] = []
 
@@ -67,12 +68,15 @@ class BridgeProtocolEdgeTests(unittest.TestCase):
         self.assertEqual(len(client.posts), 1)
 
     def test_unreachable_endpoint_maps_to_jsonrpc_error(self) -> None:
-        client = RecordingHttpMcpClient(URLError("connection refused"))
+        client = RecordingHttpMcpClient(URLError("connection refused"), base_url="http://ctrl.test/mcp")
         bridge = StdioMcpBridge(client=client)
         payload = _run_line(bridge, json.dumps({"jsonrpc": "2.0", "id": 7, "method": "tools/list"}))
         self.assertEqual(payload["id"], 7)
         self.assertEqual(payload["error"]["code"], -32000)
-        self.assertIn("Unable to reach", payload["error"]["message"])
+        message = payload["error"]["message"]
+        self.assertIn("http://ctrl.test/mcp", message)
+        self.assertIn("docker compose up -d", message)
+        self.assertIn("--base-url/AUTO_BROWSER_BASE_URL", message)
 
     def test_empty_body_with_id_maps_to_error_with_status(self) -> None:
         client = RecordingHttpMcpClient(HttpMcpResponse(status_code=204, headers={}, body=None))

--- a/controller/app/browser/services/observation.py
+++ b/controller/app/browser/services/observation.py
@@ -23,7 +23,7 @@ class BrowserObservationService:
     def __init__(self, manager: Any) -> None:
         self.manager = manager
 
-    async def observe(self, session_id: str, limit: int = 40, preset: str = "normal") -> dict[str, Any]:
+    async def observe(self, session_id: str, limit: int = 40, preset: str | None = None) -> dict[str, Any]:
         session = await self.manager.get_session(session_id)
         async with session.lock:
             result = await self.observation_payload(session, limit=limit, preset=preset)
@@ -62,8 +62,14 @@ class BrowserObservationService:
         *,
         limit: int = 40,
         screenshot_label: str = "observe",
-        preset: str = "normal",
+        preset: str | None = None,
     ) -> dict[str, Any]:
+        if preset is None:
+            preset = self.manager.settings.perception_preset_default
+        if preset not in ("text", "fast", "normal", "rich"):
+            logger.warning("unknown perception preset %r; falling back to 'normal'", preset)
+            preset = "normal"
+
         if preset == "fast":
             screenshot = await self.manager._capture_screenshot(session, screenshot_label)
             title = await session.page.title()

--- a/controller/app/browser/services/observation.py
+++ b/controller/app/browser/services/observation.py
@@ -88,7 +88,7 @@ class BrowserObservationService:
                 "screenshot_url": screenshot["url"],
                 "console_messages": session.console_messages[-10:],
                 "page_errors": session.page_errors[-10:],
-                "request_failures": [],
+                "request_failures": session.request_failures[-10:],
                 "tabs": tabs,
                 "recent_downloads": session.downloads[-10:],
                 "takeover_url": self.manager._current_takeover_url(session),

--- a/controller/app/browser/services/observation.py
+++ b/controller/app/browser/services/observation.py
@@ -64,9 +64,8 @@ class BrowserObservationService:
         screenshot_label: str = "observe",
         preset: str = "normal",
     ) -> dict[str, Any]:
-        screenshot = await self.manager._capture_screenshot(session, screenshot_label)
-
         if preset == "fast":
+            screenshot = await self.manager._capture_screenshot(session, screenshot_label)
             title = await session.page.title()
             tabs = await self.manager.tabs.summaries(session)
             return {
@@ -91,11 +90,38 @@ class BrowserObservationService:
                 "preset": "fast",
             }
 
+        if preset == "text":
+            interactables = await session.page.evaluate(INTERACTABLES_SCRIPT, limit)
+            summary = await self.page_summary(session.page, text_limit=2000)
+            tabs = await self.manager.tabs.summaries(session)
+            return {
+                "session": await self.manager._session_summary(session),
+                "url": session.page.url,
+                "title": summary["title"],
+                "active_element": summary["active_element"],
+                "text_excerpt": summary["text_excerpt"],
+                "dom_outline": summary["dom_outline"],
+                "accessibility_outline": summary["accessibility_outline"],
+                "ocr": None,
+                "interactables": interactables,
+                "screenshot_path": None,
+                "screenshot_url": None,
+                "console_messages": session.console_messages[-10:],
+                "page_errors": session.page_errors[-10:],
+                "request_failures": session.request_failures[-10:],
+                "tabs": tabs,
+                "recent_downloads": session.downloads[-10:],
+                "takeover_url": self.manager._current_takeover_url(session),
+                "remote_access": self.manager.remote_access.session_info(session),
+                "preset": "text",
+            }
+
+        screenshot = await self.manager._capture_screenshot(session, screenshot_label)
         effective_limit = min(limit * 2, 200) if preset == "rich" else limit
         interactables = await session.page.evaluate(INTERACTABLES_SCRIPT, effective_limit)
         text_limit = 4000 if preset == "rich" else 2000
         summary = await self.page_summary(session.page, text_limit=text_limit)
-        ocr = await self.manager.ocr.extract_from_image(screenshot["path"])
+        ocr = await self._extract_ocr_if_needed(session, screenshot, summary)
         await self._scrub_screenshot_if_needed(session, screenshot, ocr)
         tabs = await self.manager.tabs.summaries(session)
         return {
@@ -119,6 +145,27 @@ class BrowserObservationService:
             "remote_access": self.manager.remote_access.session_info(session),
             "preset": preset,
         }
+
+    async def _extract_ocr_if_needed(
+        self,
+        session: "BrowserSession",
+        screenshot: dict[str, str],
+        summary: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Skip OCR when text extraction already produced usable content.
+
+        Never skips while screenshot PII scrubbing is active — scrubbing
+        consumes OCR's bounding boxes, so trading tokens for that would
+        weaken PII redaction.
+        """
+        skip_enabled = self.manager.settings.ocr_skip_when_text_available
+        scrubbing_active = self.manager.pii_scrubber.screenshot_enabled
+        text_available = bool(summary.get("text_excerpt")) and bool(
+            summary.get("accessibility_outline", {}).get("available")
+        )
+        if skip_enabled and not scrubbing_active and text_available:
+            return None
+        return await self.manager.ocr.extract_from_image(screenshot["path"])
 
     async def light_snapshot(self, session: "BrowserSession", *, label: str) -> dict[str, Any]:
         screenshot = await self.manager._capture_screenshot(session, label)

--- a/controller/app/browser_manager.py
+++ b/controller/app/browser_manager.py
@@ -400,7 +400,7 @@ class BrowserManager:
 
     # ── Observation ──────────────────────────────────────────────────────────
 
-    async def observe(self, session_id: str, limit: int = 40, preset: str = "normal") -> dict[str, Any]:
+    async def observe(self, session_id: str, limit: int = 40, preset: str | None = None) -> dict[str, Any]:
         return await self.observation.observe(session_id, limit=limit, preset=preset)
 
     async def capture_screenshot(self, session_id: str, *, label: str = "manual") -> dict[str, Any]:

--- a/controller/app/config.py
+++ b/controller/app/config.py
@@ -279,10 +279,17 @@ class Settings(BaseSettings):
     approval_webhook_secret: str | None = Field(None, alias="APPROVAL_WEBHOOK_SECRET")
 
     # Perception presets — default mode for /observe
+    # text: no screenshot, no OCR — accessibility tree + text extraction only
     # fast: screenshot only (skip OCR and accessibility tree)
     # normal: screenshot + OCR + accessibility tree (current default)
     # rich: normal + extended text + full DOM outline
     perception_preset_default: str = Field("normal", alias="PERCEPTION_PRESET_DEFAULT")
+
+    # Skip OCR on normal/rich observes when text extraction already produced usable
+    # content (non-empty text_excerpt + available accessibility tree). Never skipped
+    # while screenshot PII scrubbing is active, since scrubbing consumes OCR blocks.
+    # Escape hatch: set to false to always run OCR.
+    ocr_skip_when_text_available: bool = Field(True, alias="OCR_SKIP_WHEN_TEXT_AVAILABLE")
 
     # SSE keepalive — how often to send a comment to prevent proxy timeouts
     sse_keepalive_seconds: float = Field(15.0, alias="SSE_KEEPALIVE_SECONDS")

--- a/controller/app/mcp_stdio.py
+++ b/controller/app/mcp_stdio.py
@@ -131,7 +131,13 @@ class StdioMcpBridge:
                 protocol_version=self.protocol_version,
             )
         except URLError as exc:
-            return self._jsonrpc_error(request_id, -32000, f"Unable to reach Auto Browser MCP HTTP endpoint: {exc.reason}")
+            return self._jsonrpc_error(
+                request_id,
+                -32000,
+                f"No Auto Browser controller reachable at {self.client.base_url} — "
+                "start one with 'docker compose up -d' in the auto-browser repo, or pass "
+                f"--base-url/AUTO_BROWSER_BASE_URL for a remote deployment. (underlying: {exc.reason})",
+            )
         except Exception as exc:  # pragma: no cover - defensive bridge guard
             print(f"stdio bridge unexpected error: {exc}", file=self.stderr)
             return self._jsonrpc_error(request_id, -32000, f"Unexpected stdio bridge failure: {exc}")

--- a/controller/app/models.py
+++ b/controller/app/models.py
@@ -239,7 +239,8 @@ PerceptionPreset = Literal["text", "fast", "normal", "rich"]
 
 
 class ObserveRequest(StrictInputModel):
-    preset: PerceptionPreset = "normal"
+    # None → the deployment default (PERCEPTION_PRESET_DEFAULT, normally "normal")
+    preset: PerceptionPreset | None = None
     limit: int = Field(default=40, ge=1, le=200)
 
 

--- a/controller/app/models.py
+++ b/controller/app/models.py
@@ -235,7 +235,7 @@ class ActionEnvelope(BaseModel):
     target: dict[str, Any]
 
 
-PerceptionPreset = Literal["fast", "normal", "rich"]
+PerceptionPreset = Literal["text", "fast", "normal", "rich"]
 
 
 class ObserveRequest(StrictInputModel):

--- a/controller/app/routes/sessions.py
+++ b/controller/app/routes/sessions.py
@@ -71,7 +71,7 @@ def create_sessions_router(*, manager: Any) -> APIRouter:
         return await manager.get_session_record(session_id)
 
     @router.get("/sessions/{session_id}/observe")
-    async def observe(session_id: str, limit: int = 40, preset: str = "normal") -> dict[str, Any]:
+    async def observe(session_id: str, limit: int = 40, preset: str | None = None) -> dict[str, Any]:
         try:
             return await manager.observe(session_id, limit=limit, preset=preset)
         except KeyError:

--- a/controller/app/tool_gateway/gateway.py
+++ b/controller/app/tool_gateway/gateway.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -78,6 +79,11 @@ from .packs import register_all
 from .registry import ToolRegistry, ToolSpec
 
 logger = logging.getLogger(__name__)
+
+# Bound on the in-page text walk for find_elements' query mode — a
+# catastrophically backtracking regex would otherwise hang page.evaluate
+# (and the session) indefinitely.
+FIND_ELEMENTS_QUERY_TIMEOUT_SECONDS = 10.0
 
 
 class McpToolGateway:
@@ -531,7 +537,7 @@ class McpToolGateway:
     async def _find_elements(self, payload: FindElementsInput) -> dict[str, Any]:
         session = await self.manager.get_session(payload.session_id)
         if payload.query is not None:
-            elements = await session.page.evaluate(
+            evaluate = session.page.evaluate(
                 """([query, isRegex, context, limit]) => {
                     let matcher = null;
                     if (isRegex) {
@@ -571,7 +577,7 @@ class McpToolGateway:
                             value: el.value || null,
                             href: el.href || null,
                             id: el.id || null,
-                            class: el.className || null,
+                            class: (typeof el.className === 'string' ? el.className : el.getAttribute('class')) || null,
                             visible: r.width > 0 && r.height > 0,
                             x: Math.round(r.x), y: Math.round(r.y),
                             width: Math.round(r.width), height: Math.round(r.height),
@@ -581,6 +587,18 @@ class McpToolGateway:
                 }""",
                 [payload.query, payload.regex, payload.context, payload.limit],
             )
+            try:
+                elements = await asyncio.wait_for(
+                    evaluate, timeout=FIND_ELEMENTS_QUERY_TIMEOUT_SECONDS
+                )
+            except asyncio.TimeoutError:
+                raise BrowserActionError(
+                    f"find_elements query timed out after "
+                    f"{FIND_ELEMENTS_QUERY_TIMEOUT_SECONDS:g}s — the pattern may "
+                    "backtrack catastrophically on this page's text",
+                    code="query_timeout",
+                    action="find_elements",
+                ) from None
             if isinstance(elements, dict) and "__invalid_regex" in elements:
                 raise BrowserActionError(
                     f"Invalid regular expression: {elements['__invalid_regex']}",
@@ -600,7 +618,7 @@ class McpToolGateway:
                         value: el.value || null,
                         href: el.href || null,
                         id: el.id || null,
-                        class: el.className || null,
+                        class: (typeof el.className === 'string' ? el.className : el.getAttribute('class')) || null,
                         visible: r.width > 0 && r.height > 0,
                         x: Math.round(r.x), y: Math.round(r.y),
                         width: Math.round(r.width), height: Math.round(r.height),

--- a/controller/app/tool_gateway/gateway.py
+++ b/controller/app/tool_gateway/gateway.py
@@ -513,6 +513,52 @@ class McpToolGateway:
 
     async def _find_elements(self, payload: FindElementsInput) -> dict[str, Any]:
         session = await self.manager.get_session(payload.session_id)
+        if payload.query is not None:
+            elements = await session.page.evaluate(
+                """([query, isRegex, context, limit]) => {
+                    const matcher = isRegex ? new RegExp(query, 'gi') : null;
+                    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+                    const results = [];
+                    let node;
+                    while ((node = walker.nextNode()) && results.length < limit) {
+                        const text = node.textContent || '';
+                        if (!text.trim()) continue;
+                        let matchIndex = -1;
+                        let matchText = '';
+                        if (isRegex) {
+                            matcher.lastIndex = 0;
+                            const m = matcher.exec(text);
+                            if (m) { matchIndex = m.index; matchText = m[0]; }
+                        } else {
+                            const idx = text.toLowerCase().indexOf(query.toLowerCase());
+                            if (idx !== -1) { matchIndex = idx; matchText = text.substr(idx, query.length); }
+                        }
+                        if (matchIndex === -1) continue;
+                        const el = node.parentElement;
+                        if (!el) continue;
+                        const r = el.getBoundingClientRect();
+                        const start = Math.max(0, matchIndex - context);
+                        const end = Math.min(text.length, matchIndex + matchText.length + context);
+                        results.push({
+                            tag: el.tagName.toLowerCase(),
+                            text: text.trim().substring(0, 200),
+                            match: matchText,
+                            context_text: text.substring(start, end).trim(),
+                            value: el.value || null,
+                            href: el.href || null,
+                            id: el.id || null,
+                            class: el.className || null,
+                            visible: r.width > 0 && r.height > 0,
+                            x: Math.round(r.x), y: Math.round(r.y),
+                            width: Math.round(r.width), height: Math.round(r.height),
+                        });
+                    }
+                    return results;
+                }""",
+                [payload.query, payload.regex, payload.context, payload.limit],
+            )
+            return {"session_id": payload.session_id, "query": payload.query, "elements": elements}
+
         elements = await session.page.evaluate(
             """([selector, limit]) => {
                 const els = [...document.querySelectorAll(selector)].slice(0, limit);

--- a/controller/app/tool_gateway/gateway.py
+++ b/controller/app/tool_gateway/gateway.py
@@ -5,7 +5,7 @@ import logging
 import time
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from ..action_errors import BrowserActionError
 from ..approvals import ApprovalRequiredError
@@ -200,6 +200,23 @@ class McpToolGateway:
                 structuredContent=detail,
                 isError=True,
             )
+        except ValidationError as exc:
+            # Invalid tool arguments — report the field errors so the calling
+            # agent can fix its call, instead of "Tool execution failed".
+            details = "; ".join(
+                f"{'.'.join(str(part) for part in err['loc'])}: {err['msg']}"
+                if err.get("loc")
+                else err["msg"]
+                for err in exc.errors()
+            )
+            return self._error_response(f"Invalid arguments for {payload.name}: {details}")
+        except (ValueError, KeyError, RuntimeError) as exc:
+            # Handlers raise these with operator-facing messages ("Provide
+            # source_selector or source_x/source_y", "Memory profile not found").
+            # Surface them so the calling agent can self-correct, instead of
+            # collapsing them into the opaque catch-all below.
+            message = str(exc.args[0]) if exc.args else exc.__class__.__name__
+            return self._error_response(message)
         except Exception:
             logger.exception("tool %s failed", payload.name)
             return self._error_response("Tool execution failed")
@@ -516,7 +533,14 @@ class McpToolGateway:
         if payload.query is not None:
             elements = await session.page.evaluate(
                 """([query, isRegex, context, limit]) => {
-                    const matcher = isRegex ? new RegExp(query, 'gi') : null;
+                    let matcher = null;
+                    if (isRegex) {
+                        try {
+                            matcher = new RegExp(query, 'gi');
+                        } catch (e) {
+                            return {__invalid_regex: String((e && e.message) || e)};
+                        }
+                    }
                     const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
                     const results = [];
                     let node;
@@ -557,6 +581,12 @@ class McpToolGateway:
                 }""",
                 [payload.query, payload.regex, payload.context, payload.limit],
             )
+            if isinstance(elements, dict) and "__invalid_regex" in elements:
+                raise BrowserActionError(
+                    f"Invalid regular expression: {elements['__invalid_regex']}",
+                    code="invalid_regex",
+                    action="find_elements",
+                )
             return {"session_id": payload.session_id, "query": payload.query, "elements": elements}
 
         elements = await session.page.evaluate(

--- a/controller/app/tool_gateway/packs/core.py
+++ b/controller/app/tool_gateway/packs/core.py
@@ -88,7 +88,14 @@ def register(registry, gateway):
         ),
         ToolSpec(
             name="browser.observe",
-            description="Capture the current browser observation with screenshot, interactables, and perception summary.",
+            description=(
+                "Capture the current browser observation: interactables, tabs, console, and a "
+                "perception summary. Presets: 'text' — no screenshot, no OCR, just the "
+                "accessibility tree and extracted text; the cheapest choice for reading a page's "
+                "content. 'fast' — screenshot only, no text/accessibility extraction; for visual "
+                "models. 'normal' (default) — screenshot + OCR + accessibility tree. 'rich' — "
+                "normal with extended text and DOM outline."
+            ),
             input_model=ObserveInput,
             handler=gateway._observe,
         ),

--- a/controller/app/tool_gateway/packs/dom.py
+++ b/controller/app/tool_gateway/packs/dom.py
@@ -48,9 +48,12 @@ def register(registry, gateway):
         ToolSpec(
             name="browser.find_elements",
             description=(
-                "Find all elements matching a CSS selector and return their "
-                "text, href, value, bounding box, and visibility. "
-                "Useful before clicking or scraping multiple items."
+                "Find elements either by CSS selector or by a text/regex query across the "
+                "page's text content. selector mode returns matching elements' text, href, "
+                "value, bounding box, and visibility -- useful before clicking or scraping "
+                "multiple items. query mode (set query, optionally regex and context) returns "
+                "the matched text plus surrounding context for each hit -- a cheap way to "
+                "locate a specific string on the page without a full observe."
             ),
             input_model=FindElementsInput,
             handler=gateway._find_elements,

--- a/controller/app/tool_inputs.py
+++ b/controller/app/tool_inputs.py
@@ -156,7 +156,8 @@ class VerifyWitnessInput(SessionIdInput):
 
 
 class ObserveInput(SessionIdInput):
-    preset: PerceptionPreset = "normal"
+    # None → the deployment default (PERCEPTION_PRESET_DEFAULT, normally "normal")
+    preset: PerceptionPreset | None = None
     limit: int = Field(default=40, ge=1, le=200)
 
 

--- a/controller/app/tool_inputs.py
+++ b/controller/app/tool_inputs.py
@@ -392,12 +392,16 @@ class FindElementsInput(SessionIdInput):
         max_length=500,
         description=(
             "Text or regex to search for across the page's text content, as an "
-            "alternative to selector. Returns matched elements plus surrounding text."
+            "alternative to selector. Matching is case-insensitive in both modes. "
+            "Returns matched elements plus surrounding text."
         ),
     )
     regex: bool = Field(
         default=False,
-        description="Treat query as a regular expression instead of a plain-text substring match.",
+        description=(
+            "Treat query as a regular expression (JavaScript syntax, 'gi' flags) "
+            "instead of a plain-text substring match."
+        ),
     )
     context: int = Field(
         default=0,

--- a/controller/app/tool_inputs.py
+++ b/controller/app/tool_inputs.py
@@ -385,8 +385,35 @@ class SetViewportInput(SessionIdInput):
 
 
 class FindElementsInput(SessionIdInput):
-    selector: str = Field(min_length=1, max_length=2000)
+    selector: str | None = Field(default=None, min_length=1, max_length=2000)
+    query: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=500,
+        description=(
+            "Text or regex to search for across the page's text content, as an "
+            "alternative to selector. Returns matched elements plus surrounding text."
+        ),
+    )
+    regex: bool = Field(
+        default=False,
+        description="Treat query as a regular expression instead of a plain-text substring match.",
+    )
+    context: int = Field(
+        default=0,
+        ge=0,
+        le=500,
+        description="Characters of surrounding text to include around each match when query is used.",
+    )
     limit: int = Field(default=20, ge=1, le=100)
+
+    @model_validator(mode="after")
+    def validate_selector_or_query(self) -> "FindElementsInput":
+        if not self.selector and not self.query:
+            raise ValueError("find_elements requires either selector or query")
+        if self.selector and self.query:
+            raise ValueError("find_elements accepts either selector or query, not both")
+        return self
 
 
 class DragDropInput(SessionIdInput):

--- a/controller/app/version.py
+++ b/controller/app/version.py
@@ -3,4 +3,4 @@
 Bump together with the package versions in */pyproject.toml and
 browser-node/package.json during release prep.
 """
-__version__ = "1.4.2"
+__version__ = "1.5.0"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.4.2"
+version = "1.5.0"
 description = "Controller API for auto-browser"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]

--- a/controller/tests/test_extended_features.py
+++ b/controller/tests/test_extended_features.py
@@ -41,6 +41,10 @@ class TestObserveRequest(unittest.TestCase):
         req = ObserveRequest(preset="fast")
         self.assertEqual(req.preset, "fast")
 
+    def test_text_preset(self) -> None:
+        req = ObserveRequest(preset="text")
+        self.assertEqual(req.preset, "text")
+
     def test_rich_preset(self) -> None:
         req = ObserveRequest(preset="rich")
         self.assertEqual(req.preset, "rich")
@@ -215,6 +219,15 @@ class TestNewConfigSettings(unittest.TestCase):
         with patch.dict(os.environ, {"PERCEPTION_PRESET_DEFAULT": "fast"}):
             s = Settings()
             self.assertEqual(s.perception_preset_default, "fast")
+
+    def test_ocr_skip_when_text_available_default_true(self) -> None:
+        s = Settings()
+        self.assertTrue(s.ocr_skip_when_text_available)
+
+    def test_ocr_skip_when_text_available_from_env(self) -> None:
+        with patch.dict(os.environ, {"OCR_SKIP_WHEN_TEXT_AVAILABLE": "false"}):
+            s = Settings()
+            self.assertFalse(s.ocr_skip_when_text_available)
 
 
 # ── Auth Export / Import ─────────────────────────────────────────────────────

--- a/controller/tests/test_extended_features.py
+++ b/controller/tests/test_extended_features.py
@@ -33,9 +33,11 @@ from app.webhooks import _sign
 # ── Perception Preset Models ─────────────────────────────────────────────────
 
 class TestObserveRequest(unittest.TestCase):
-    def test_default_preset_is_normal(self) -> None:
+    def test_default_preset_is_unset(self) -> None:
+        # None defers to the deployment default (PERCEPTION_PRESET_DEFAULT,
+        # "normal" unless overridden) — resolved in observation_payload.
         req = ObserveRequest()
-        self.assertEqual(req.preset, "normal")
+        self.assertIsNone(req.preset)
 
     def test_fast_preset(self) -> None:
         req = ObserveRequest(preset="fast")

--- a/controller/tests/test_input_validation.py
+++ b/controller/tests/test_input_validation.py
@@ -26,6 +26,7 @@ from app.tool_inputs import (
     CreateCronJobInput,
     CreateProxyPersonaInput,
     DragDropInput,
+    FindElementsInput,
     GetNetworkLogInput,
     ObserveInput,
     SetCookiesInput,
@@ -122,6 +123,25 @@ class RequestValidationTests(unittest.TestCase):
     def test_drag_drop_requires_complete_coordinate_pairs(self) -> None:
         with self.assertRaises(ValidationError):
             DragDropInput(session_id="session-1", source_x=10, target_x=20, target_y=30)
+
+    def test_find_elements_requires_selector_or_query(self) -> None:
+        with self.assertRaises(ValidationError):
+            FindElementsInput(session_id="session-1")
+
+    def test_find_elements_rejects_both_selector_and_query(self) -> None:
+        with self.assertRaises(ValidationError):
+            FindElementsInput(session_id="session-1", selector="button", query="Submit")
+
+    def test_find_elements_accepts_selector_only(self) -> None:
+        payload = FindElementsInput(session_id="session-1", selector="button")
+        self.assertEqual(payload.selector, "button")
+        self.assertIsNone(payload.query)
+
+    def test_find_elements_accepts_query_only(self) -> None:
+        payload = FindElementsInput(session_id="session-1", query="Total: $", context=40)
+        self.assertEqual(payload.query, "Total: $")
+        self.assertEqual(payload.context, 40)
+        self.assertIsNone(payload.selector)
 
     def test_set_cookies_requires_name_and_domain_or_url(self) -> None:
         with self.assertRaises(ValidationError):

--- a/controller/tests/test_mcp_stdio.py
+++ b/controller/tests/test_mcp_stdio.py
@@ -286,6 +286,8 @@ class BridgeProtocolTests(unittest.TestCase):
 
     def test_unreachable_endpoint_becomes_a_jsonrpc_error(self) -> None:
         class DeadClient:
+            base_url = "http://ctrl.test/mcp"
+
             def post_json(self, *_args: object, **_kwargs: object):
                 raise URLError("connection refused")
 
@@ -295,7 +297,10 @@ class BridgeProtocolTests(unittest.TestCase):
         lines = self._run(DeadClient(), json.dumps({"jsonrpc": "2.0", "id": 7, "method": "tools/list"}) + "\n")
         self.assertEqual(lines[0]["id"], 7)
         self.assertEqual(lines[0]["error"]["code"], -32000)
-        self.assertIn("Unable to reach", lines[0]["error"]["message"])
+        message = lines[0]["error"]["message"]
+        self.assertIn("http://ctrl.test/mcp", message)
+        self.assertIn("docker compose up -d", message)
+        self.assertIn("--base-url/AUTO_BROWSER_BASE_URL", message)
 
     def test_empty_body_for_a_request_becomes_an_error(self) -> None:
         class EmptyBodyClient:

--- a/controller/tests/test_observation_text_preset.py
+++ b/controller/tests/test_observation_text_preset.py
@@ -52,9 +52,17 @@ def _make_session(*, text_excerpt: str = "Hello world") -> SimpleNamespace:
     )
 
 
-def _make_manager(*, ocr_skip: bool = True, scrubbing_active: bool = False) -> SimpleNamespace:
+def _make_manager(
+    *,
+    ocr_skip: bool = True,
+    scrubbing_active: bool = False,
+    preset_default: str = "normal",
+) -> SimpleNamespace:
     return SimpleNamespace(
-        settings=SimpleNamespace(ocr_skip_when_text_available=ocr_skip),
+        settings=SimpleNamespace(
+            ocr_skip_when_text_available=ocr_skip,
+            perception_preset_default=preset_default,
+        ),
         pii_scrubber=SimpleNamespace(screenshot_enabled=scrubbing_active, audit_report=False),
         _capture_screenshot=AsyncMock(return_value={"path": "/tmp/shot.png", "url": "/artifacts/shot.png"}),
         _session_summary=AsyncMock(return_value={"id": "session-1"}),
@@ -88,6 +96,24 @@ class TextPresetTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["interactables"], [{"element_id": "op-1", "label": "Submit"}])
         self.assertIsNone(result["ocr"])
         manager.ocr.extract_from_image.assert_not_called()
+
+    async def test_omitted_preset_resolves_from_settings_default(self) -> None:
+        # PERCEPTION_PRESET_DEFAULT steers the whole deployment when the caller
+        # does not pass a preset — here the default is "text", so no screenshot.
+        manager = _make_manager(preset_default="text")
+        service = BrowserObservationService(manager=manager)
+        result = await service.observation_payload(_make_session(), preset=None)
+
+        manager._capture_screenshot.assert_not_called()
+        self.assertEqual(result["preset"], "text")
+
+    async def test_unknown_preset_falls_back_to_normal(self) -> None:
+        manager = _make_manager(preset_default="bogus")
+        service = BrowserObservationService(manager=manager)
+        result = await service.observation_payload(_make_session(), preset=None)
+
+        manager._capture_screenshot.assert_awaited_once()
+        self.assertEqual(result["preset"], "normal")
 
     async def test_fast_preset_still_captures_screenshot(self) -> None:
         manager = _make_manager()

--- a/controller/tests/test_observation_text_preset.py
+++ b/controller/tests/test_observation_text_preset.py
@@ -118,11 +118,15 @@ class TextPresetTests(unittest.IsolatedAsyncioTestCase):
     async def test_fast_preset_still_captures_screenshot(self) -> None:
         manager = _make_manager()
         service = BrowserObservationService(manager=manager)
-        result = await service.observation_payload(_make_session(), preset="fast")
+        session = _make_session()
+        session.request_failures = [{"url": "https://example.com/x", "status": 500}]
+        result = await service.observation_payload(session, preset="fast")
 
         manager._capture_screenshot.assert_awaited_once()
         self.assertEqual(result["screenshot_path"], "/tmp/shot.png")
         self.assertEqual(result["screenshot_url"], "/artifacts/shot.png")
+        # fast reports the same diagnostic tails as the other presets
+        self.assertEqual(len(result["request_failures"]), 1)
 
     async def test_normal_preset_still_captures_screenshot(self) -> None:
         manager = _make_manager()

--- a/controller/tests/test_observation_text_preset.py
+++ b/controller/tests/test_observation_text_preset.py
@@ -1,0 +1,145 @@
+"""Tests for the text-first observation preset and OCR gating.
+
+Covers:
+- `text` preset skips screenshot capture (screenshot_path/url stay None, keys present)
+- `fast`/`normal`/`rich` still capture a screenshot
+- OCR is skipped on normal/rich only when text extraction already produced usable
+  content AND screenshot PII scrubbing is not active
+- OCR is never skipped while PII scrubbing is active, regardless of the config knob
+"""
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from app.browser.services.observation import BrowserObservationService
+from app.browser_scripts import ACTIVE_ELEMENT_SCRIPT, INTERACTABLES_SCRIPT, PAGE_SUMMARY_SCRIPT
+
+
+class FakeAccessibility:
+    async def snapshot(self, interesting_only: bool = True) -> dict:
+        return {"role": "WebArea", "name": "Example", "children": []}
+
+
+class FakePage:
+    def __init__(self, *, text_excerpt: str = "Hello world") -> None:
+        self.url = "https://example.com"
+        self.accessibility = FakeAccessibility()
+        self._text_excerpt = text_excerpt
+
+    async def title(self) -> str:
+        return "Example"
+
+    async def evaluate(self, script: str, *args: object) -> object:
+        if script is INTERACTABLES_SCRIPT:
+            return [{"element_id": "op-1", "label": "Submit"}]
+        if script is PAGE_SUMMARY_SCRIPT:
+            return {"text_excerpt": self._text_excerpt, "dom_outline": {"headings": []}}
+        if script is ACTIVE_ELEMENT_SCRIPT:
+            return {"tag": "body"}
+        raise AssertionError(f"unexpected script passed to evaluate: {script!r}")
+
+
+def _make_session(*, text_excerpt: str = "Hello world") -> SimpleNamespace:
+    return SimpleNamespace(
+        id="session-1",
+        page=FakePage(text_excerpt=text_excerpt),
+        console_messages=[],
+        page_errors=[],
+        request_failures=[],
+        downloads=[],
+    )
+
+
+def _make_manager(*, ocr_skip: bool = True, scrubbing_active: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        settings=SimpleNamespace(ocr_skip_when_text_available=ocr_skip),
+        pii_scrubber=SimpleNamespace(screenshot_enabled=scrubbing_active, audit_report=False),
+        _capture_screenshot=AsyncMock(return_value={"path": "/tmp/shot.png", "url": "/artifacts/shot.png"}),
+        _session_summary=AsyncMock(return_value={"id": "session-1"}),
+        _current_takeover_url=MagicMock(return_value=None),
+        remote_access=SimpleNamespace(session_info=MagicMock(return_value={})),
+        tabs=SimpleNamespace(summaries=AsyncMock(return_value=[])),
+        ocr=SimpleNamespace(extract_from_image=AsyncMock(return_value={"available": True, "blocks": []})),
+    )
+
+
+class TextPresetTests(unittest.IsolatedAsyncioTestCase):
+    async def test_text_preset_skips_screenshot(self) -> None:
+        manager = _make_manager()
+        service = BrowserObservationService(manager=manager)
+        result = await service.observation_payload(_make_session(), preset="text")
+
+        manager._capture_screenshot.assert_not_called()
+        self.assertIsNone(result["screenshot_path"])
+        self.assertIsNone(result["screenshot_url"])
+        self.assertIn("screenshot_path", result)
+        self.assertIn("screenshot_url", result)
+        self.assertEqual(result["preset"], "text")
+
+    async def test_text_preset_populates_text_and_accessibility(self) -> None:
+        manager = _make_manager()
+        service = BrowserObservationService(manager=manager)
+        result = await service.observation_payload(_make_session(), preset="text")
+
+        self.assertEqual(result["text_excerpt"], "Hello world")
+        self.assertTrue(result["accessibility_outline"]["available"])
+        self.assertEqual(result["interactables"], [{"element_id": "op-1", "label": "Submit"}])
+        self.assertIsNone(result["ocr"])
+        manager.ocr.extract_from_image.assert_not_called()
+
+    async def test_fast_preset_still_captures_screenshot(self) -> None:
+        manager = _make_manager()
+        service = BrowserObservationService(manager=manager)
+        result = await service.observation_payload(_make_session(), preset="fast")
+
+        manager._capture_screenshot.assert_awaited_once()
+        self.assertEqual(result["screenshot_path"], "/tmp/shot.png")
+        self.assertEqual(result["screenshot_url"], "/artifacts/shot.png")
+
+    async def test_normal_preset_still_captures_screenshot(self) -> None:
+        manager = _make_manager()
+        service = BrowserObservationService(manager=manager)
+        result = await service.observation_payload(_make_session(), preset="normal")
+
+        manager._capture_screenshot.assert_awaited_once()
+        self.assertEqual(result["screenshot_path"], "/tmp/shot.png")
+        self.assertEqual(result["screenshot_url"], "/artifacts/shot.png")
+
+
+class OcrGatingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_ocr_skipped_when_text_available_and_scrubbing_inactive(self) -> None:
+        manager = _make_manager(ocr_skip=True, scrubbing_active=False)
+        service = BrowserObservationService(manager=manager)
+        result = await service.observation_payload(_make_session(text_excerpt="Hello world"), preset="normal")
+
+        manager.ocr.extract_from_image.assert_not_called()
+        self.assertIsNone(result["ocr"])
+
+    async def test_ocr_runs_when_text_extraction_produced_nothing(self) -> None:
+        manager = _make_manager(ocr_skip=True, scrubbing_active=False)
+        service = BrowserObservationService(manager=manager)
+        result = await service.observation_payload(_make_session(text_excerpt=""), preset="normal")
+
+        manager.ocr.extract_from_image.assert_awaited_once()
+        self.assertEqual(result["ocr"], {"available": True, "blocks": []})
+
+    async def test_ocr_never_skipped_while_pii_scrubbing_active(self) -> None:
+        manager = _make_manager(ocr_skip=True, scrubbing_active=True)
+        service = BrowserObservationService(manager=manager)
+        result = await service.observation_payload(_make_session(text_excerpt="Hello world"), preset="normal")
+
+        manager.ocr.extract_from_image.assert_awaited_once()
+        self.assertEqual(result["ocr"], {"available": True, "blocks": []})
+
+    async def test_ocr_skip_config_knob_forces_ocr_back_on(self) -> None:
+        manager = _make_manager(ocr_skip=False, scrubbing_active=False)
+        service = BrowserObservationService(manager=manager)
+        await service.observation_payload(_make_session(text_excerpt="Hello world"), preset="normal")
+
+        manager.ocr.extract_from_image.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_tool_gateway.py
+++ b/controller/tests/test_tool_gateway.py
@@ -889,6 +889,55 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(response.isError)
         self.manager.observe.assert_awaited_once_with("session-1", limit=50, preset="rich")
 
+    async def test_find_elements_query_mode_returns_matches_and_echoes_query(self) -> None:
+        page = SimpleNamespace(
+            evaluate=AsyncMock(
+                return_value=[
+                    {
+                        "tag": "span",
+                        "text": "Total: $42.00",
+                        "match": "$42.00",
+                        "context_text": "Order Total: $42.00 due",
+                        "value": None,
+                        "href": None,
+                        "id": None,
+                        "class": None,
+                        "visible": True,
+                        "x": 0,
+                        "y": 0,
+                        "width": 10,
+                        "height": 10,
+                    }
+                ]
+            )
+        )
+        self.manager.get_session = AsyncMock(return_value=SimpleNamespace(page=page))
+
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(
+                name="browser.find_elements",
+                arguments={"session_id": "session-1", "query": "$42.00", "context": 20},
+            )
+        )
+
+        self.assertFalse(response.isError)
+        result = response.content[0].text
+        self.assertIn("$42.00", result)
+        self.assertIn("Order Total", result)
+        page.evaluate.assert_awaited_once()
+        call_args = page.evaluate.await_args.args[1]
+        self.assertEqual(call_args, ["$42.00", False, 20, 20])
+
+    async def test_find_elements_rejects_neither_selector_nor_query(self) -> None:
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(
+                name="browser.find_elements",
+                arguments={"session_id": "session-1"},
+            )
+        )
+
+        self.assertTrue(response.isError)
+
     async def test_approval_required_bubbles_back_as_tool_error(self) -> None:
         approval = ApprovalRecord(
             id="approval-1",

--- a/controller/tests/test_tool_gateway.py
+++ b/controller/tests/test_tool_gateway.py
@@ -938,6 +938,55 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(response.isError)
 
+    async def test_find_elements_invalid_regex_surfaces_structured_error(self) -> None:
+        page = SimpleNamespace(
+            evaluate=AsyncMock(return_value={"__invalid_regex": "Unterminated group"})
+        )
+        self.manager.get_session = AsyncMock(return_value=SimpleNamespace(page=page))
+
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(
+                name="browser.find_elements",
+                arguments={"session_id": "session-1", "query": "(unclosed", "regex": True},
+            )
+        )
+
+        self.assertTrue(response.isError)
+        self.assertEqual(response.structuredContent.get("code"), "invalid_regex")
+        self.assertIn("Invalid regular expression", response.content[0].text)
+        self.assertIn("Unterminated group", response.content[0].text)
+
+    async def test_invalid_arguments_message_reaches_the_caller(self) -> None:
+        # drag_drop with neither selectors nor coordinates fails validation with an
+        # operator-facing message; it must surface instead of "Tool execution failed".
+        self.manager.get_session = AsyncMock(return_value=SimpleNamespace(page=SimpleNamespace()))
+
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(
+                name="browser.drag_drop",
+                arguments={"session_id": "session-1"},
+            )
+        )
+
+        self.assertTrue(response.isError)
+        self.assertIn("source_selector", response.content[0].text)
+        self.assertNotIn("Tool execution failed", response.content[0].text)
+
+    async def test_handler_key_error_message_reaches_the_caller(self) -> None:
+        # get_memory_profile raises KeyError with an operator-facing message for an
+        # unknown profile; it must surface, not the opaque catch-all.
+        self.manager.memory = SimpleNamespace(get=AsyncMock(return_value=None))
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(
+                name="browser.get_memory_profile",
+                arguments={"profile_name": "no-such-profile"},
+            )
+        )
+
+        self.assertTrue(response.isError)
+        self.assertIn("no-such-profile", response.content[0].text)
+        self.assertNotIn("Tool execution failed", response.content[0].text)
+
     async def test_approval_required_bubbles_back_as_tool_error(self) -> None:
         approval = ApprovalRecord(
             id="approval-1",

--- a/controller/tests/test_tool_gateway.py
+++ b/controller/tests/test_tool_gateway.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -937,6 +938,34 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertTrue(response.isError)
+
+    async def test_find_elements_query_timeout_surfaces_structured_error(self) -> None:
+        # A catastrophically backtracking regex hangs page.evaluate; the query
+        # path is bounded and must come back as a structured error, not a hang.
+        from app.tool_gateway import gateway as gateway_module
+
+        async def never_finishes(*_args: object) -> object:
+            await asyncio.sleep(30)
+            return []
+
+        page = SimpleNamespace(evaluate=never_finishes)
+        self.manager.get_session = AsyncMock(return_value=SimpleNamespace(page=page))
+
+        original = gateway_module.FIND_ELEMENTS_QUERY_TIMEOUT_SECONDS
+        gateway_module.FIND_ELEMENTS_QUERY_TIMEOUT_SECONDS = 0.05
+        try:
+            response = await self.full_gateway.call_tool(
+                McpToolCallRequest(
+                    name="browser.find_elements",
+                    arguments={"session_id": "session-1", "query": "(a+)+$", "regex": True},
+                )
+            )
+        finally:
+            gateway_module.FIND_ELEMENTS_QUERY_TIMEOUT_SECONDS = original
+
+        self.assertTrue(response.isError)
+        self.assertEqual(response.structuredContent.get("code"), "query_timeout")
+        self.assertIn("timed out", response.content[0].text)
 
     async def test_find_elements_invalid_regex_surfaces_structured_error(self) -> None:
         page = SimpleNamespace(

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.4.2"
+version = "1.5.0"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -7,12 +7,12 @@ build-backend = "setuptools.build_meta"
 # console script against that dependency.
 [project]
 name = "auto-browser-mcp"
-version = "1.4.2"
+version = "1.5.0"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
-dependencies = ["auto-browser-client>=1.3.1"]
+dependencies = ["auto-browser-client>=1.5.0"]
 keywords = ["auto-browser", "mcp", "mcp-server", "browser-automation"]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/scripts/check_bridge_parity.py
+++ b/scripts/check_bridge_parity.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Fail if the two copies of the stdio MCP bridge drift apart.
+
+The bridge ships twice on purpose: ``client/auto_browser_client/mcp_bridge.py``
+is what ``uvx auto-browser-mcp`` runs, and ``controller/app/mcp_stdio.py`` is
+the same module inside the controller image (``python -m app.mcp_stdio``).
+They are intentionally byte-identical, and nothing structural enforces that —
+an edit applied to one silently strands the other, in a file that is on the
+published PyPI surface. Same failure class as the version-string drift guarded
+by ``check_version_parity.py``.
+
+Exit 0 when the copies match, 1 when they differ (or either is missing).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+COPIES = (
+    "client/auto_browser_client/mcp_bridge.py",
+    "controller/app/mcp_stdio.py",
+)
+
+
+def main() -> int:
+    contents: list[bytes] = []
+    for relative in COPIES:
+        path = REPO_ROOT / relative
+        if not path.is_file():
+            print(f"ERROR: missing bridge copy: {relative}", file=sys.stderr)
+            return 1
+        contents.append(path.read_bytes())
+
+    if contents[0] == contents[1]:
+        print(f"OK: {COPIES[0]} and {COPIES[1]} are byte-identical.")
+        return 0
+
+    print(
+        "ERROR: the stdio MCP bridge copies have drifted apart.\n"
+        f"  {COPIES[0]}\n"
+        f"  {COPIES[1]}\n"
+        "These are intentionally byte-identical; apply the same edit to both\n"
+        "(or run: diff " + " ".join(COPIES) + " to see the drift).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python_env.sh
+++ b/scripts/python_env.sh
@@ -1,37 +1,55 @@
 #!/usr/bin/env bash
 
+# Default acceptance probe: Python 3.10+. Callers may pass a stricter probe
+# (e.g. version + required packages) as $1 to the resolve/require functions;
+# a candidate is accepted when the probe snippet exits 0.
+AUTO_BROWSER_DEFAULT_PROBE='import sys
+raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'
+
 resolve_python310_bin() {
+  local probe="${1:-${AUTO_BROWSER_DEFAULT_PROBE}}"
   local candidate
   local -a candidates=()
   if [[ -n "${AUTO_BROWSER_PYTHON_BIN:-}" ]]; then
     candidates+=("${AUTO_BROWSER_PYTHON_BIN}")
   fi
-  candidates+=(python3 python3.11)
+  candidates+=(python3 python3.13 python3.12 python3.11 python3.10)
 
   for candidate in "${candidates[@]}"; do
     [[ -n "${candidate}" ]] || continue
     if ! command -v "${candidate}" >/dev/null 2>&1; then
       continue
     fi
-    if "${candidate}" - <<'PY' >/dev/null 2>&1
-import sys
-
-raise SystemExit(0 if sys.version_info >= (3, 10) else 1)
-PY
-    then
+    if "${candidate}" -c "${probe}" >/dev/null 2>&1; then
       printf '%s\n' "${candidate}"
       return 0
     fi
   done
 
+  # Windows Git Bash: interpreters often exist only via the `py` launcher
+  # (no python3 on PATH). Resolve a launcher hit to its real executable so
+  # callers get a plain quoted-safe path.
+  if command -v py >/dev/null 2>&1; then
+    local version_flag resolved
+    for version_flag in -3.13 -3.12 -3.11 -3.10 -3; do
+      resolved="$(py "${version_flag}" -c 'import sys; print(sys.executable)' 2>/dev/null)" || continue
+      [[ -n "${resolved}" ]] || continue
+      if "${resolved}" -c "${probe}" >/dev/null 2>&1; then
+        printf '%s\n' "${resolved}"
+        return 0
+      fi
+    done
+  fi
+
   return 1
 }
 
 require_python310_bin() {
+  local probe="${1:-}"
   local python_bin=""
   local detected_version=""
 
-  if python_bin="$(resolve_python310_bin)"; then
+  if python_bin="$(resolve_python310_bin "${probe:-${AUTO_BROWSER_DEFAULT_PROBE}}")"; then
     printf '%s\n' "${python_bin}"
     return 0
   fi

--- a/scripts/test_local.sh
+++ b/scripts/test_local.sh
@@ -5,12 +5,15 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}"
 
 source "${ROOT_DIR}/scripts/python_env.sh"
-PYTHON_BIN="$(require_python310_bin)"
-export PYTHONPATH="${ROOT_DIR}/controller${PYTHONPATH:+:${PYTHONPATH}}"
 
-if ! "${PYTHON_BIN}" - <<'PY' >/dev/null 2>&1
-import importlib.util
+# Accept an interpreter only if it is 3.10+ AND has the controller's deps —
+# probing both at once lets the resolver skip a bare system Python and keep
+# looking (e.g. the Windows `py` launcher) instead of failing on the first hit.
+CONTROLLER_DEPS_PROBE='import importlib.util
+import sys
 
+if sys.version_info < (3, 10):
+    raise SystemExit(1)
 required = [
     "apscheduler",
     "cryptography",
@@ -26,16 +29,25 @@ required = [
     "redis",
 ]
 missing = [name for name in required if importlib.util.find_spec(name) is None]
-raise SystemExit(0 if not missing else 1)
-PY
-then
+raise SystemExit(0 if not missing else 1)'
+
+if ! PYTHON_BIN="$(resolve_python310_bin "${CONTROLLER_DEPS_PROBE}")"; then
   cat >&2 <<EOF
-Missing Python dependencies for host-side controller tests.
+No Python 3.10+ interpreter with the controller's dependencies was found.
 
 Install them with:
-  ${PYTHON_BIN} -m pip install -e ./controller[dev]
+  python3 -m pip install -e ./controller[dev]
+
+or point AUTO_BROWSER_PYTHON_BIN at an interpreter that has them.
+If you only need the containerized path, use \`make test\`.
 EOF
   exit 1
 fi
+export PYTHONPATH="${ROOT_DIR}/controller${PYTHONPATH:+:${PYTHONPATH}}"
 
-exec "${PYTHON_BIN}" -m unittest discover -s "${ROOT_DIR}/controller/tests" -v
+# Run from controller/, not the repo root: pydantic-settings loads .env from the
+# current working directory, and a developer's root .env (bearer token, operator
+# id, rate limits) turns on auth the tests don't send — ~138 route tests then
+# fail with 400s that never happen in CI or Docker, which have no .env.
+cd "${ROOT_DIR}/controller"
+exec "${PYTHON_BIN}" -m unittest discover -s tests -v


### PR DESCRIPTION
## Why

auto-browser's MCP surface (64 tools) is ~2.5x richer than Playwright MCP's, yet agents default to the competitor. Measured today on a fresh box: the loss happens in the first 30 seconds (opaque cold-start error with no controller running) and on the cheapest call (no way to read a page without paying for a screenshot + OCR). Neither gap is capability — both are economics.

## What

**Adoption path**
- Bridge cold-start error now names the endpoint it tried and the exact fix, instead of `[WinError 10061]`
- `uvx auto-browser-mcp` floor raised so new users actually receive that fix

**Cheapest-call economics**
- New `text` observe preset: accessibility outline + text + interactables, **no screenshot, no OCR** (payload shape stable — screenshot keys stay as `null`)
- `browser.find_elements` query mode: find a string on the page plus surrounding context in one call (`query`/`regex`/`context`, case-insensitive, exactly-one-of with `selector`)
- OCR skipped on `normal`/`rich` when text extraction already succeeded (`OCR_SKIP_WHEN_TEXT_AVAILABLE`, default on) — **never** while screenshot PII scrubbing is active; redaction always wins

**Errors agents can act on**
- Pydantic validation failures report field-level details; handler `ValueError`/`KeyError`/`RuntimeError` messages pass through; invalid regex returns structured `invalid_regex` — all previously `Tool execution failed`

**Repo health**
- `PERCEPTION_PRESET_DEFAULT` wired (was dead config since it landed); SDK stops forcing `preset="normal"`, omitted = deployment default
- `./scripts/test_local.sh` fixed: ran from repo root so a developer's local dotenv turned on auth and ~138 route tests failed with 400s CI never sees; now runs from `controller/`, probes interpreters for deps, and resolves the Windows `py` launcher
- New CI guard: the stdio bridge's two intentionally-identical copies (`client/.../mcp_bridge.py` ↔ `controller/app/mcp_stdio.py`) fail CI on drift

**Release**
- v1.5.0 staged: all 9 version strings moved together (parity-enforced). Tag on merge publishes client + langchain + mcp via OIDC.

## Test plan

- [x] `./scripts/test_local.sh` — 560 controller tests OK (2 skipped), zero env vars, on the Windows box that previously showed 138 phantom failures
- [x] `client` pytest — 38 passed
- [x] `ruff check . --select E9,F,I` — clean
- [x] `check_version_parity.py` — 9/9 agree on 1.5.0
- [x] `check_bridge_parity.py` — byte-identical
- [x] `check_playwright_pins.py` — matched
- [ ] CI (Docker-path controller tests + langchain job) on this PR

Deliberately out of scope (follow-ups): implicit default session, pack-level lean tool profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)