### PR TITLE
MCP: omitted session_id resolves against the live session set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+### Added
+- **`session_id` may be omitted on MCP tools.** With exactly one live session, tools target it; with none live, observe/act tools (`observe`, `execute_action`, `find_elements`, `screenshot`, `get_html`, `wait_for_selector`) create one on demand — an agent's first `browser.observe` now works with zero setup calls. Anything ambiguous (multiple live sessions, or a non-create tool with none) stays an explicit structured error (`ambiguous_session` / `no_session`) rather than a guess. Explicit `session_id` behavior is unchanged.
+
 ## [1.5.0] — 2026-07-30
 
 ### Added

--- a/controller/app/tool_gateway/gateway.py
+++ b/controller/app/tool_gateway/gateway.py
@@ -85,6 +85,21 @@ logger = logging.getLogger(__name__)
 # (and the session) indefinitely.
 FIND_ELEMENTS_QUERY_TIMEOUT_SECONDS = 10.0
 
+# Tools allowed to create a session on demand when session_id is omitted and no
+# session is live — the first call an agent makes is almost always one of these.
+# Everything else resolves an omitted session_id only when exactly one session
+# is live; creating a session as a side effect of, say, close_tab helps nobody.
+IMPLICIT_SESSION_CREATE_TOOLS = frozenset(
+    {
+        "browser.execute_action",
+        "browser.observe",
+        "browser.find_elements",
+        "browser.screenshot",
+        "browser.get_html",
+        "browser.wait_for_selector",
+    }
+)
+
 
 class McpToolGateway:
     def __init__(
@@ -178,6 +193,7 @@ class McpToolGateway:
                     "harness service unavailable - check controller startup logs and HARNESS_* config"
                 )
             arguments = spec.input_model.model_validate(raw_arguments)
+            arguments = await self._resolve_implicit_session(spec, arguments)
             approval = await self._require_governed_tool_approval(
                 spec,
                 arguments,
@@ -233,6 +249,36 @@ class McpToolGateway:
             content=[McpToolCallContent(text=message)],
             structuredContent={"error": message},
             isError=True,
+        )
+
+    async def _resolve_implicit_session(self, spec: Any, arguments: BaseModel) -> BaseModel:
+        """Resolve an omitted session_id against the live session set.
+
+        Exactly one live session → target it. None live → create one on demand,
+        but only for observe/act tools (IMPLICIT_SESSION_CREATE_TOOLS). Anything
+        ambiguous stays an explicit, actionable error rather than a guess.
+        """
+        if not isinstance(arguments, SessionIdInput) or arguments.session_id:
+            return arguments
+        sessions = await self.manager.list_sessions()
+        if len(sessions) == 1:
+            return arguments.model_copy(update={"session_id": sessions[0]["id"]})
+        if not sessions:
+            if spec.name in IMPLICIT_SESSION_CREATE_TOOLS:
+                created = await self.manager.create_session()
+                return arguments.model_copy(update={"session_id": created["id"]})
+            raise BrowserActionError(
+                f"{spec.name} needs a session and none are live — create one with "
+                "browser.create_session (or call an observe/act tool, which creates "
+                "one on demand).",
+                code="no_session",
+                action=spec.name,
+            )
+        ids = ", ".join(str(item.get("id")) for item in sessions)
+        raise BrowserActionError(
+            f"session_id is required when multiple sessions are live ({ids}).",
+            code="ambiguous_session",
+            action=spec.name,
         )
 
     @staticmethod

--- a/controller/app/tool_inputs.py
+++ b/controller/app/tool_inputs.py
@@ -141,12 +141,15 @@ class HarnessGraduateInput(HarnessGetStatusInput):
 
 
 class SessionIdInput(StrictInputModel):
-    session_id: str = Field(
+    session_id: str | None = Field(
+        default=None,
         min_length=1,
         max_length=120,
         description=(
             "ID of the target browser session, as returned by browser.create_session "
-            "or listed by browser.list_sessions."
+            "or listed by browser.list_sessions. May be omitted: with exactly one "
+            "live session that session is used, and observe/act tools create one on "
+            "demand when none are live."
         ),
     )
 

--- a/controller/tests/test_tool_gateway.py
+++ b/controller/tests/test_tool_gateway.py
@@ -939,6 +939,65 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(response.isError)
 
+    async def test_omitted_session_id_resolves_to_single_live_session(self) -> None:
+        self.manager.list_sessions = AsyncMock(return_value=[{"id": "session-42"}])
+
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(name="browser.observe", arguments={})
+        )
+
+        self.assertFalse(response.isError)
+        self.manager.observe.assert_awaited_once()
+        self.assertEqual(self.manager.observe.await_args.args[0], "session-42")
+
+    async def test_omitted_session_id_creates_session_for_observe_when_none_live(self) -> None:
+        self.manager.list_sessions = AsyncMock(return_value=[])
+        self.manager.create_session = AsyncMock(return_value={"id": "session-new"})
+
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(name="browser.observe", arguments={})
+        )
+
+        self.assertFalse(response.isError)
+        self.manager.create_session.assert_awaited_once()
+        self.assertEqual(self.manager.observe.await_args.args[0], "session-new")
+
+    async def test_omitted_session_id_errors_for_non_create_tool_when_none_live(self) -> None:
+        self.manager.list_sessions = AsyncMock(return_value=[])
+        self.manager.create_session = AsyncMock(return_value={"id": "session-new"})
+
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(name="browser.get_console", arguments={})
+        )
+
+        self.assertTrue(response.isError)
+        self.assertEqual(response.structuredContent.get("code"), "no_session")
+        self.manager.create_session.assert_not_awaited()
+
+    async def test_omitted_session_id_errors_when_multiple_sessions_live(self) -> None:
+        self.manager.list_sessions = AsyncMock(
+            return_value=[{"id": "session-a"}, {"id": "session-b"}]
+        )
+
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(name="browser.observe", arguments={})
+        )
+
+        self.assertTrue(response.isError)
+        self.assertEqual(response.structuredContent.get("code"), "ambiguous_session")
+        self.assertIn("session-a", response.content[0].text)
+        self.assertIn("session-b", response.content[0].text)
+
+    async def test_explicit_session_id_skips_implicit_resolution(self) -> None:
+        self.manager.list_sessions = AsyncMock(return_value=[])
+
+        response = await self.full_gateway.call_tool(
+            McpToolCallRequest(name="browser.observe", arguments={"session_id": "session-1"})
+        )
+
+        self.assertFalse(response.isError)
+        self.manager.list_sessions.assert_not_awaited()
+
     async def test_find_elements_query_timeout_surfaces_structured_error(self) -> None:
         # A catastrophically backtracking regex hangs page.evaluate; the query
         # path is bounded and must come back as a structured error, not a hang.


### PR DESCRIPTION
## Why

The last ergonomic gap vs snapshot-first browser MCP servers (follow-up deferred from #117): every tool demanded a `session_id`, so an agent's first page read cost `create_session` → `execute_action` → `observe`. Competing servers do it in one call.

## What

- `SessionIdInput.session_id` is now optional. Resolution when omitted:
  - exactly **one live session** → target it
  - **none live** + observe/act tool (`observe`, `execute_action`, `find_elements`, `screenshot`, `get_html`, `wait_for_selector`) → create one on demand
  - **none live** + any other tool → structured `no_session` error naming the fix
  - **multiple live** → structured `ambiguous_session` error listing the ids
- Resolution happens before governed-approval evaluation, so approval records always see the real session id. Explicit `session_id` calls bypass resolution entirely (no `list_sessions` overhead).
- Never guesses: ambiguity is always an actionable error, not a heuristic.

Controller-only — no published-package paths touched, so no release cut; rides in `[Unreleased]` until the next one.

## Test plan

- [x] 5 new gateway tests: single-session resolution, create-on-demand, `no_session` for non-create tools, `ambiguous_session` with ids listed, explicit-id fast path
- [x] `./scripts/test_local.sh` — 566 controller tests OK (2 skipped)
- [x] client pytest — 38 passed; ruff clean; bridge + version parity OK
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)