### PR TITLE
fix(deps): cryptography 50.0.0 for CVE-2026-69247

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -15,7 +15,7 @@ playwright==1.61.0
 pydantic-settings==2.14.2
 httpx==0.28.1
 redis==8.0.1
-cryptography==49.0.0
+cryptography==50.0.0
 Pillow==12.3.0
 pytesseract==0.3.13
 docker==7.2.0


### PR DESCRIPTION
`dependency-audit` went red on **every** open PR today -- including #116, which changes nothing but two README lines. The cause is on `main`, not in any of those PRs: [GHSA-g6cj-pr64-35w5](https://github.com/advisories/GHSA-g6cj-pr64-35w5) / CVE-2026-69247 was published 2026-08-03 against `cryptography` 49.0.0.

### The flaw

`pkcs7_decrypt_der` / `_pem` / `_smime` reported the outcome of decrypting a `RecipientInfo`'s `encryptedKey` in several distinguishable ways -- invalid RSA padding, valid padding with a bad key length (leaking the recovered length `N`), and correct length with the wrong key -- and the same distinction was observable by timing. A service that auto-decrypts attacker-supplied `EnvelopedData` and answers adaptively hands the attacker a Bleichenbacher oracle against the content-encryption key.

Introduced in 44.0.0. Fixed in 50.0.0 per RFC 3218: the content-encryption algorithm is resolved before the private key is used, so on failure a random key of the expected length is substituted and decryption continues down an identical path. All failures now report identically and do the same work.

### Exposure here: none reachable

This controller never decrypts PKCS#7. `cryptography` is used in exactly two places:

- `controller/app/auth_state.py` -- `Fernet`, for auth state at rest
- `controller/app/mesh/identity.py` / `mesh/transport.py` -- `Ed25519`

Neither is on the affected path. So this is hygiene on a pinned runtime dependency plus a merge-queue unblock, not a live hole -- worth stating plainly rather than overselling the severity.

### Risk of the bump

50.0.0 lists no backwards-incompatible changes. Its one deprecation is FFDH (`hazmat.primitives.asymmetric.dh`), which this repo does not use. Published 2026-07-31, so it also clears the 72h-old-package rule.

`cryptography==` appears in one file repo-wide, so there is no second pin to drift from.