### PR TITLE
chore(deps): coordinated playwright 1.61.0 -> 1.62.0 (supersedes #97)

### DIFF
--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -8,7 +8,7 @@
       "name": "auto-browser-browser-node",
       "version": "1.5.0",
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.62.0"
       }
     },
     "node_modules/fsevents": {
@@ -26,33 +26,33 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     }
   }

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "playwright": "1.61.0"
+    "playwright": "1.62.0"
   }
 }

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -11,7 +11,7 @@
 fastapi>=0.141.1,<0.142
 starlette==1.3.1
 uvicorn[standard]==0.51.0
-playwright==1.61.0
+playwright==1.62.0
 pydantic-settings==2.14.2
 httpx==0.28.1
 redis==8.0.1


### PR DESCRIPTION
Closes #97.

### Why #97 could not merge

#97 bumped `browser-node/package.json` to 1.62.0 and left `controller/requirements.txt` at 1.61.0, so `lint` failed on `scripts/check_playwright_pins.py`. That is the guard doing its job, not a flaky check.

The guard exists because of #60, which did exactly this: Dependabot bumped the npm side alone, Playwright's websocket protocol requires an **exact** client/server version match, and every `docker compose up --build` crash-looped on readiness. Dependabot cannot fix this itself -- pip and npm are separate ecosystems to it, so it will keep proposing half of this change. A single-side bump is not a smaller version of the upgrade; it is the bug.

### What this does

Both pins move together, lockfile regenerated with npm 11.14.1:

| | before | after |
|---|---|---|
| `controller/requirements.txt` (pip) | 1.61.0 | **1.62.0** |
| `browser-node/package.json` (npm) | 1.61.0 | **1.62.0** |

`scripts/check_playwright_pins.py` and `scripts/check_version_parity.py` both pass locally (the latter still reads 1.5.0 across all nine strings -- untouched by this).

### The engine bump, checked rather than assumed

Playwright 1.62 raises `engines.node` from `>=18` to `>=20`, which matters because `browser-node/Dockerfile` installs `nodejs` from Debian apt rather than pinning a Node version.

`python:3.11-slim` currently aliases `3.11-slim-trixie` (Debian 13), per `docker-library/official-images`. Trixie ships nodejs 20.19, so the floor is met and no base-image or NodeSource change is needed. Had the base still been bookworm (nodejs 18.19) this PR would have needed a Dockerfile change too. `compose-smoke` exercises the real build end to end.

### Why 1.62.0 and not 1.62.1

npm has 1.62.1; PyPI's latest is 1.62.0. Since the two sides must match exactly, 1.62.0 is the newest version both ecosystems can hold. Published 2026-07-24, so it also clears the 72h-old-package rule.