### PR TITLE
chore: finish the dependency sweep, stop the Playwright PR loop, refresh the roadmap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,16 @@ updates:
         update-types:
           - minor
           - patch
+    # Playwright is upgraded by hand, on both sides at once. Its websocket
+    # protocol requires an exact client/server version match, and the pip pin
+    # here and the npm pin in /browser-node are separate ecosystems to
+    # Dependabot -- so it can only ever propose half the change. That half is
+    # not a smaller upgrade, it is the #60 outage: every docker compose up
+    # --build crash-looped on readiness. It has since re-proposed the npm half
+    # (#97) and the pip half (#121), both caught by
+    # scripts/check_playwright_pins.py. The guard stays; this stops feeding it.
+    ignore:
+      - dependency-name: playwright
 
   - package-ecosystem: npm
     directory: /browser-node
@@ -28,6 +38,10 @@ updates:
         update-types:
           - minor
           - patch
+    # Ignored for the same reason as the pip side above: coordinated manual
+    # bump only, guarded by scripts/check_playwright_pins.py.
+    ignore:
+      - dependency-name: playwright
 
   - package-ecosystem: github-actions
     directory: /

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,8 +2,10 @@
 
 This is the near-term direction for Auto Browser.
 
-## Now (current in v1.4.0)
+## Now (current in v1.5.0)
 
+- `text` observation preset — accessibility outline, extracted text, and interactables with no screenshot and no OCR
+- text/regex `query` mode on `browser.find_elements` — locate a string on the page without a full observe
 - any OpenAI-compatible model can drive the browser (OpenRouter, xAI, DeepSeek, MiniMax, custom base URL for Ollama / vLLM / Azure / Groq, …)
 - PyPI packages: `auto-browser-client` SDK, `auto-browser-langchain` adapters, `uvx auto-browser-mcp` stdio bridge
 - stable local-first browser control
@@ -37,6 +39,8 @@ This is the near-term direction for Auto Browser.
 
 ## Recently Shipped
 
+- v1.5.0 `text` observation preset, `find_elements` query mode, actionable MCP tool errors, and an MCP stdio bridge cold-start fix that names the endpoint and the remedy
+- v1.4.x whole-repo quality gates, nine-string version parity enforcement, `auto-browser-langchain` test coverage from zero to 94%, and the Python 3.14 `asyncio.get_event_loop()` fix
 - v1.4.0 generic OpenAI-compatible provider adapter (OpenRouter / xAI / DeepSeek / MiniMax / custom base URL), `browser://audit/events` MCP resource, and a CI guard for Playwright pin parity
 - v1.3.x operator dashboard run replay, auth-profile setup wizard, `browser_manager` facade refactor, encrypted fork-state exports, and fixture proof layers
 - v1.2.1 PyPI publishing: client SDK, LangChain adapters, and the `auto-browser-mcp` bridge via tag-triggered trusted publishing

--- a/controller/requirements-dev.txt
+++ b/controller/requirements-dev.txt
@@ -2,6 +2,6 @@ pytest
 pytest-asyncio>=1.4.0
 pytest-cov>=7.1.0
 respx
-ruff==0.15.22
+ruff==0.16.1
 build
 pip-audit

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -10,16 +10,16 @@
 # app.openapi() or a request. The <0.140 bound keeps minor bumps reviewed.
 fastapi>=0.141.1,<0.142
 starlette==1.3.1
-uvicorn[standard]==0.51.0
+uvicorn[standard]==0.52.0
 playwright==1.62.0
 pydantic-settings==2.14.2
 httpx==0.28.1
-redis==8.0.1
+redis==8.1.0
 cryptography==50.0.0
 Pillow==12.3.0
 pytesseract==0.3.13
 docker==7.2.0
-prometheus-client==0.25.0
+prometheus-client==0.26.0
 pyotp==2.10.0
 apscheduler==3.11.3
 tomli==2.4.1; python_version < "3.11"

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -7,7 +7,8 @@
 #
 # What 0.137 DID change: app.routes holds _IncludedRouter wrappers instead of
 # flattened Route objects. Never enumerate app.routes expecting .path -- use
-# app.openapi() or a request. The <0.140 bound keeps minor bumps reviewed.
+# app.openapi() or a request. The upper bound keeps minor bumps reviewed;
+# Dependabot moves it, so it is deliberately not restated as a number here.
 fastapi>=0.141.1,<0.142
 starlette==1.3.1
 uvicorn[standard]==0.52.0


### PR DESCRIPTION
The tail of today's PR sweep. Three commits, reviewable separately.

### 1. The four remaining dependency bumps

`uvicorn` 0.52.0, `redis` 8.1.0, `prometheus-client` 0.26.0, `ruff` 0.16.1.

These are what was left of the weekly `pip-minor-patch` group (#119, recreated as #121). Applied by hand rather than merged, because that PR could not be salvaged: after the cryptography CVE fix and the coordinated Playwright bump landed, Dependabot regenerated it carrying `playwright==1.62.0` **on the pip side alone** -- the exact mirror of #97 -- which tripped `check_playwright_pins.py` from the opposite direction and then conflicted with `main` outright. Playwright is already at 1.62.0 on both sides, so that line was redundant; these four are the real content.

`ruff` 0.16 is a minor, so it ships new rules. Verified rather than assumed: installed 0.16.1 locally and ran the CI-equivalent `ruff check .` across the repo -- clean, no new findings. All four clear the 72h-old-package floor (oldest 4.2 days).

### 2. Stop Dependabot proposing half a Playwright upgrade

Playwright's websocket protocol requires an **exact** client/server version match, but the pip pin in `controller/` and the npm pin in `browser-node/` are separate ecosystems to Dependabot. It can only ever open half the change, and that half is not a smaller upgrade -- it is the #60 outage, where every `docker compose up --build` crash-looped on readiness.

It has now proposed that half three times: **#60** (merged, broke compose), **#97** (npm side, blocked by lint), **#121** (pip side, blocked the same way from the other direction).

`scripts/check_playwright_pins.py` caught the last two and stays exactly as it is. This change just stops feeding it a doomed PR every week, by ignoring `playwright` in both the pip and npm updaters, with a comment on each explaining why.

**Tradeoff worth naming:** Playwright upgrades are now manual and Dependabot will no longer surface new versions. The procedure is the one #122 followed -- bump both pins, regenerate the npm lock, let `compose-smoke` prove the pair.

### 3. Roadmap and a comment that had already gone wrong

- `ROADMAP.md` still said "Now (current in **v1.4.0**)" and its Recently Shipped list stopped at 1.4.0, stale since 1.5.0 shipped 2026-07-30. Adds the two user-facing 1.5.0 capabilities and 1.5.0 / 1.4.x shipped lines. **Next is unchanged and checked, not assumed:** `viewer_url` still appears only in `controller/app/routes/session_diagnostics.py` and nowhere in the dashboard, so that item is genuinely still pending.
- The `fastapi` comment asserted "The `<0.140` bound keeps minor bumps reviewed". #115 had already falsified it -- the pin is at `<0.142`. Rather than write in the new number and wait for it to rot again, the prose now describes what the bound is *for*, since Dependabot owns the value.