### PR TITLE
docs: show the real Glama grades instead of a static badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![MCP Server](https://img.shields.io/badge/MCP-server-blue)](./README.md)
 [![Local First](https://img.shields.io/badge/local--first-0ea5e9)](./README.md)
-[![Glama](https://img.shields.io/badge/Glama-listed-8B5CF6)](https://glama.ai/mcp/servers/LvcidPsyche/auto-browser)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/LvcidPsyche/auto-browser?quickstart=1)
+
+<a href="https://glama.ai/mcp/servers/LvcidPsyche/auto-browser">
+  <img src="https://glama.ai/mcp/servers/LvcidPsyche/auto-browser/badge" alt="Auto-Browser on Glama: grade A for license, quality, and maintenance" width="420">
+</a>
 
 ![Auto Browser demo](docs/assets/demo.gif)
 


### PR DESCRIPTION
The Glama badge in the README was a hand-rolled shields.io label reading **"listed"** -- it conveyed nothing beyond existence.

Glama serves a live card at `/badge` for this server that renders the actual grading: **A for license, A for quality, A for maintenance**, plus star count, license, and platform support. Swapped the static label for the real card at 420px.

Two reasons this is the better artifact:

1. **Strictly more information in about the same space.** "listed" -> three A grades and the supporting facts.
2. **It stays honest by itself.** If a grade ever slips, the card reflects that rather than continuing to assert "listed". A static badge can only ever be stale or wrong.

I verified the endpoint before wiring it in -- fetched it, confirmed it returns a real 760x400 PNG, and looked at the rendered image to check it actually shows the grades rather than a generic logo.

Docs only. Nothing else in this PR.