### PR TITLE
style: apply ruff format across the repo

### DIFF
--- a/benchmarks/adapters/README.md
+++ b/benchmarks/adapters/README.md
@@ -46,5 +46,6 @@ Or programmatically:
 
 ```python
 from verifier_adapter import adapt
-records = adapt(run_result_dict)   # {"online_mind2web": {...}, "cuaverifier": {...}}
+
+records = adapt(run_result_dict)  # {"online_mind2web": {...}, "cuaverifier": {...}}
 ```

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -1,4 +1,5 @@
 """auto-browser Python client SDK."""
+
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]

--- a/client/auto_browser_client/client.py
+++ b/client/auto_browser_client/client.py
@@ -16,6 +16,7 @@ Usage (async):
         obs = await client.async_observe(session["id"])
         await client.async_close_session(session["id"])
 """
+
 from __future__ import annotations
 
 from typing import Any, Generator
@@ -224,7 +225,15 @@ class AutoBrowserClient:
     async def async_navigate(self, session_id: str, url: str) -> dict:
         return await self._apost(f"/sessions/{session_id}/actions/navigate", {"url": url})
 
-    def click(self, session_id: str, *, selector: str | None = None, element_id: str | None = None, x: float | None = None, y: float | None = None) -> dict:
+    def click(
+        self,
+        session_id: str,
+        *,
+        selector: str | None = None,
+        element_id: str | None = None,
+        x: float | None = None,
+        y: float | None = None,
+    ) -> dict:
         body: dict[str, Any] = {}
         if selector:
             body["selector"] = selector
@@ -236,7 +245,15 @@ class AutoBrowserClient:
             body["y"] = y
         return self._post(f"/sessions/{session_id}/actions/click", body)
 
-    async def async_click(self, session_id: str, *, selector: str | None = None, element_id: str | None = None, x: float | None = None, y: float | None = None) -> dict:
+    async def async_click(
+        self,
+        session_id: str,
+        *,
+        selector: str | None = None,
+        element_id: str | None = None,
+        x: float | None = None,
+        y: float | None = None,
+    ) -> dict:
         body: dict[str, Any] = {}
         if selector:
             body["selector"] = selector
@@ -248,7 +265,15 @@ class AutoBrowserClient:
             body["y"] = y
         return await self._apost(f"/sessions/{session_id}/actions/click", body)
 
-    def type_text(self, session_id: str, text: str, *, selector: str | None = None, element_id: str | None = None, clear_first: bool = True) -> dict:
+    def type_text(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        selector: str | None = None,
+        element_id: str | None = None,
+        clear_first: bool = True,
+    ) -> dict:
         body: dict[str, Any] = {"text": text, "clear_first": clear_first}
         if selector:
             body["selector"] = selector
@@ -256,7 +281,15 @@ class AutoBrowserClient:
             body["element_id"] = element_id
         return self._post(f"/sessions/{session_id}/actions/type", body)
 
-    async def async_type_text(self, session_id: str, text: str, *, selector: str | None = None, element_id: str | None = None, clear_first: bool = True) -> dict:
+    async def async_type_text(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        selector: str | None = None,
+        element_id: str | None = None,
+        clear_first: bool = True,
+    ) -> dict:
         body: dict[str, Any] = {"text": text, "clear_first": clear_first}
         if selector:
             body["selector"] = selector
@@ -292,10 +325,14 @@ class AutoBrowserClient:
         return await self._apost(f"/sessions/{session_id}/agent/step", {"provider": provider, "goal": goal, **kwargs})
 
     def agent_run(self, session_id: str, *, provider: str, goal: str, max_steps: int = 6, **kwargs) -> dict:
-        return self._post(f"/sessions/{session_id}/agent/run", {"provider": provider, "goal": goal, "max_steps": max_steps, **kwargs})
+        return self._post(
+            f"/sessions/{session_id}/agent/run", {"provider": provider, "goal": goal, "max_steps": max_steps, **kwargs}
+        )
 
     async def async_agent_run(self, session_id: str, *, provider: str, goal: str, max_steps: int = 6, **kwargs) -> dict:
-        return await self._apost(f"/sessions/{session_id}/agent/run", {"provider": provider, "goal": goal, "max_steps": max_steps, **kwargs})
+        return await self._apost(
+            f"/sessions/{session_id}/agent/run", {"provider": provider, "goal": goal, "max_steps": max_steps, **kwargs}
+        )
 
     # ── Approvals ────────────────────────────────────────────────────────────
 

--- a/client/auto_browser_client/mcp_bridge.py
+++ b/client/auto_browser_client/mcp_bridge.py
@@ -6,6 +6,7 @@ script) and as ``app.mcp_stdio`` inside the controller image (Glama/Docker
 entrypoint). A guard test asserts the two copies stay byte-identical, so any
 edit here must be mirrored to the other copy.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -159,7 +160,9 @@ class StdioMcpBridge:
         if payload.get("id") is None:
             return None
         if response.body is None:
-            return self._jsonrpc_error(request_id, -32000, f"Empty response from Auto Browser MCP endpoint ({response.status_code})")
+            return self._jsonrpc_error(
+                request_id, -32000, f"Empty response from Auto Browser MCP endpoint ({response.status_code})"
+            )
         return response.body
 
     @staticmethod

--- a/client/tests/test_mcp_bridge_edges.py
+++ b/client/tests/test_mcp_bridge_edges.py
@@ -27,9 +27,7 @@ class RecordingHttpMcpClient:
         self.deleted_session_ids: list[str | None] = []
 
     def post_json(self, payload, *, session_id=None, protocol_version=None):
-        self.posts.append(
-            {"payload": payload, "session_id": session_id, "protocol_version": protocol_version}
-        )
+        self.posts.append({"payload": payload, "session_id": session_id, "protocol_version": protocol_version})
         if isinstance(self.response, Exception):
             raise self.response
         return self.response
@@ -144,9 +142,7 @@ class HttpMcpClientTests(unittest.TestCase):
     def test_http_error_is_returned_as_response_not_raised(self) -> None:
         headers = email.message.Message()
         headers["Content-Type"] = "application/json"
-        error = HTTPError(
-            "http://ctrl.test/mcp", 401, "Unauthorized", headers, io.BytesIO(b'{"detail": "no"}')
-        )
+        error = HTTPError("http://ctrl.test/mcp", 401, "Unauthorized", headers, io.BytesIO(b'{"detail": "no"}'))
 
         def fake(request, timeout=None):
             raise error

--- a/controller/app/agent_jobs.py
+++ b/controller/app/agent_jobs.py
@@ -229,7 +229,6 @@ class AgentJobStore:
                 time.sleep(0.01 * (attempt + 1))
 
 
-
 class AgentJobQueue:
     def __init__(self, *, orchestrator, store_root: str | Path, worker_count: int = 1, audit_store=None):
         self.orchestrator = orchestrator
@@ -502,8 +501,7 @@ class AgentJobQueue:
             f"Resuming background agent job {record.id} after {len(record.checkpoints)} completed step(s). "
             f"Latest checkpoint: status={latest.status}, action={latest.action or 'unknown'}, "
             f"url={latest.url or 'unknown'}. Continue from the current browser state; do not repeat completed "
-            "actions unless the page state requires it.\nCompleted checkpoints:\n"
-            + "\n".join(step_lines)
+            "actions unless the page state requires it.\nCompleted checkpoints:\n" + "\n".join(step_lines)
         )
 
     @staticmethod

--- a/controller/app/audit.py
+++ b/controller/app/audit.py
@@ -182,9 +182,7 @@ class SQLiteAuditStore:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_audit_events_session ON audit_events(session_id, timestamp DESC)"
             )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_audit_events_type ON audit_events(event_type, timestamp DESC)"
-            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_audit_events_type ON audit_events(event_type, timestamp DESC)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_audit_events_operator ON audit_events(operator_id, timestamp DESC)"
             )
@@ -324,4 +322,3 @@ class AuditStore:
             event_type=event_type,
             operator_id=operator_id,
         )
-

--- a/controller/app/browser/dom_pruner.py
+++ b/controller/app/browser/dom_pruner.py
@@ -10,6 +10,7 @@ Scoring factors:
   - Visibility (above fold, not hidden)
   - Recency (recently interacted elements score higher)
 """
+
 from __future__ import annotations
 
 import re
@@ -86,7 +87,11 @@ def _visibility_score(element: dict[str, Any]) -> float:
     """Prefer elements that appear to be visible and above the fold."""
     if not element.get("is_visible", True):
         return -20.0  # strongly penalize hidden elements
-    y = element.get("y") or element.get("bounding_box", {}).get("y", 500) if isinstance(element.get("bounding_box"), dict) else 500
+    y = (
+        element.get("y") or element.get("bounding_box", {}).get("y", 500)
+        if isinstance(element.get("bounding_box"), dict)
+        else 500
+    )
     # Above fold (y < 800) gets a bonus, below gets a penalty
     if isinstance(y, (int, float)):
         return max(0.0, 5.0 - (y / 200.0))

--- a/controller/app/browser/services/actions.py
+++ b/controller/app/browser/services/actions.py
@@ -518,18 +518,8 @@ class BrowserActionService:
         for step in range(1, steps + 1):
             t = step / steps
             inv = 1 - t
-            px = (
-                inv**3 * start_x
-                + 3 * inv * inv * t * control_1[0]
-                + 3 * inv * t * t * control_2[0]
-                + t**3 * x
-            )
-            py = (
-                inv**3 * start_y
-                + 3 * inv * inv * t * control_1[1]
-                + 3 * inv * t * t * control_2[1]
-                + t**3 * y
-            )
+            px = inv**3 * start_x + 3 * inv * inv * t * control_1[0] + 3 * inv * t * t * control_2[0] + t**3 * x
+            py = inv**3 * start_y + 3 * inv * inv * t * control_1[1] + 3 * inv * t * t * control_2[1] + t**3 * y
             await session.page.mouse.move(px, py)
             await asyncio.sleep(random.uniform(0.004, 0.018))
         session.mouse_position = (x, y)
@@ -720,9 +710,10 @@ class BrowserActionService:
                 & set(signals)
             )
         elif action_name == "hover":
-            verified = bool(
-                {"active_element_changed", "text_excerpt_changed", "accessibility_focus_changed"} & set(signals)
-            ) or target_seen_after is not None
+            verified = (
+                bool({"active_element_changed", "text_excerpt_changed", "accessibility_focus_changed"} & set(signals))
+                or target_seen_after is not None
+            )
         elif action_name in {"type", "select_option"}:
             verified = bool(
                 {"active_element_changed", "text_excerpt_changed", "accessibility_focus_changed"} & set(signals)

--- a/controller/app/browser/services/diagnostics.py
+++ b/controller/app/browser/services/diagnostics.py
@@ -94,23 +94,29 @@ class BrowserDiagnosticsService:
             return
         session.attached_pages.add(page)
 
-        page.on("console", lambda message: self._bounded_append(
-            session.console_messages,
-            {
-                "type": message.type,
-                "text": message.text,
-                "location": message.location,
-            },
-        ))
+        page.on(
+            "console",
+            lambda message: self._bounded_append(
+                session.console_messages,
+                {
+                    "type": message.type,
+                    "text": message.text,
+                    "location": message.location,
+                },
+            ),
+        )
         page.on("pageerror", lambda error: self._bounded_append(session.page_errors, str(error)))
-        page.on("requestfailed", lambda request: self._bounded_append(
-            session.request_failures,
-            {
-                "url": request.url,
-                "method": request.method,
-                "failure": str(request.failure) if request.failure else None,
-            },
-        ))
+        page.on(
+            "requestfailed",
+            lambda request: self._bounded_append(
+                session.request_failures,
+                {
+                    "url": request.url,
+                    "method": request.method,
+                    "failure": str(request.failure) if request.failure else None,
+                },
+            ),
+        )
         page.on("download", lambda download: spawn_background_task(self.manager._handle_download(session, download)))
 
     @staticmethod
@@ -198,9 +204,7 @@ class BrowserDiagnosticsService:
 
             data = diff.tobytes()
             changed = sum(
-                1
-                for index in range(0, len(data), 3)
-                if data[index] > 8 or data[index + 1] > 8 or data[index + 2] > 8
+                1 for index in range(0, len(data), 3) if data[index] > 8 or data[index + 1] > 8 or data[index + 2] > 8
             )
             changed_pct = round(changed / total_pixels * 100, 4) if total_pixels > 0 else 0.0
 

--- a/controller/app/browser/services/remote_access.py
+++ b/controller/app/browser/services/remote_access.py
@@ -83,11 +83,7 @@ class BrowserRemoteAccessService:
                 "source": "metadata_file",
                 "takeover_url": takeover_url,
                 "api_url": api_url,
-                "last_updated": (
-                    last_updated.isoformat().replace("+00:00", "Z")
-                    if last_updated is not None
-                    else None
-                ),
+                "last_updated": (last_updated.isoformat().replace("+00:00", "Z") if last_updated is not None else None),
                 "age_seconds": age_seconds,
                 "stale_after_seconds": stale_after_seconds,
                 "tunnel": tunnel,
@@ -148,9 +144,7 @@ class BrowserRemoteAccessService:
             {
                 "session_id": session.id,
                 "source": (
-                    "isolated_session_tunnel"
-                    if session_tunnel and session_tunnel.get("active")
-                    else "isolated_runtime"
+                    "isolated_session_tunnel" if session_tunnel and session_tunnel.get("active") else "isolated_runtime"
                 ),
                 "configured_takeover_url": takeover_url,
                 "takeover_url": effective_takeover_url,

--- a/controller/app/browser/services/runtime.py
+++ b/controller/app/browser/services/runtime.py
@@ -26,9 +26,7 @@ class BrowserRuntimeService:
 
             if manager.settings.cdp_connect_url:
                 logger.info("connecting to existing Chrome via CDP at %s", manager.settings.cdp_connect_url)
-                manager.browser = await manager.playwright.chromium.connect_over_cdp(
-                    manager.settings.cdp_connect_url
-                )
+                manager.browser = await manager.playwright.chromium.connect_over_cdp(manager.settings.cdp_connect_url)
                 logger.info("CDP attach succeeded")
                 return manager.browser
 

--- a/controller/app/browser/services/sessions.py
+++ b/controller/app/browser/services/sessions.py
@@ -29,10 +29,7 @@ class BrowserSessionService:
         self.manager = manager
 
     async def list(self) -> list[dict[str, Any]]:
-        session_map = {
-            record.id: record.model_dump()
-            for record in await self.manager.session_store.list()
-        }
+        session_map = {record.id: record.model_dump() for record in await self.manager.session_store.list()}
         for session in self.manager.sessions.values():
             summary = await self.manager._session_summary(session)
             session_map[summary["id"]] = summary
@@ -257,9 +254,8 @@ class BrowserSessionService:
             },
             "accept_downloads": True,
         }
-        effective_ua = (
-            user_agent
-            or (self.manager.settings.random_user_agent if self.manager.settings.stealth_enabled else None)
+        effective_ua = user_agent or (
+            self.manager.settings.random_user_agent if self.manager.settings.stealth_enabled else None
         )
         if effective_ua:
             kwargs["user_agent"] = effective_ua

--- a/controller/app/browser/services/witness.py
+++ b/controller/app/browser/services/witness.py
@@ -198,13 +198,10 @@ class BrowserWitnessService:
         risk_category = witness_context.get("risk_category")
         action_class = self.action_class(action_name, risk_category=risk_category)
         sensitive_input = bool(
-            witness_context.get("sensitive_input")
-            or target.get("text_redacted")
-            or target.get("sensitive")
+            witness_context.get("sensitive_input") or target.get("text_redacted") or target.get("sensitive")
         )
         stores_auth_material = bool(
-            witness_context.get("stores_auth_material")
-            or action_name in {"save_auth_profile", "save_storage_state"}
+            witness_context.get("stores_auth_material") or action_name in {"save_auth_profile", "save_storage_state"}
         )
         return WitnessActionContext(
             action=action_name,

--- a/controller/app/browser_scripts.py
+++ b/controller/app/browser_scripts.py
@@ -1,4 +1,5 @@
 """Browser-side JavaScript constants used by BrowserManager for page observation."""
+
 from __future__ import annotations
 
 # Injected before every page load via add_init_script().
@@ -608,6 +609,7 @@ FIND_ACCESSIBLE_TARGET_SCRIPT = r"""
   return matches[index] || matches[0] || null;
 }
 """
+
 
 async def apply_stealth(page: object) -> None:
     """Inject stealth init script into a page before any navigation."""

--- a/controller/app/cdp/passthrough.py
+++ b/controller/app/cdp/passthrough.py
@@ -6,6 +6,7 @@ animations, and asset references for a given CSS selector.
 
 raw_cdp_command() is a constrained passthrough for trusted CDP commands.
 """
+
 from __future__ import annotations
 
 import fnmatch
@@ -15,20 +16,22 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Commands allowed through the raw CDP passthrough
-_ALLOWED_CDP_COMMANDS = frozenset([
-    "Runtime.evaluate",
-    "DOM.getDocument",
-    "DOM.querySelector",
-    "DOM.getAttributes",
-    "DOM.getBoxModel",
-    "CSS.getComputedStyleForNode",
-    "CSS.getMatchedStylesForNode",
-    "Animation.getPlaybackRate",
-    "Network.getCookies",
-    "Performance.getMetrics",
-    "Page.getLayoutMetrics",
-    "Accessibility.getFullAXTree",
-])
+_ALLOWED_CDP_COMMANDS = frozenset(
+    [
+        "Runtime.evaluate",
+        "DOM.getDocument",
+        "DOM.querySelector",
+        "DOM.getAttributes",
+        "DOM.getBoxModel",
+        "CSS.getComputedStyleForNode",
+        "CSS.getMatchedStylesForNode",
+        "Animation.getPlaybackRate",
+        "Network.getCookies",
+        "Performance.getMetrics",
+        "Page.getLayoutMetrics",
+        "Accessibility.getFullAXTree",
+    ]
+)
 
 # Domains allowed for element extraction (empty = all allowed)
 _ALLOWED_DOMAINS: list[str] = []
@@ -68,10 +71,13 @@ class CDPPassthrough:
             doc_node_id = doc["root"]["nodeId"]
 
             # Find element
-            result = await self._cdp.send("DOM.querySelector", {
-                "nodeId": doc_node_id,
-                "selector": selector,
-            })
+            result = await self._cdp.send(
+                "DOM.querySelector",
+                {
+                    "nodeId": doc_node_id,
+                    "selector": selector,
+                },
+            )
             node_id = result.get("nodeId", 0)
             if node_id == 0:
                 return {"error": f"Selector not found: {selector!r}"}
@@ -86,19 +92,29 @@ class CDPPassthrough:
             computed = await self._cdp.send("CSS.getComputedStyleForNode", {"nodeId": node_id})
             # Filter to useful style properties
             _STYLE_KEYS = {
-                "display", "visibility", "opacity", "position", "z-index",
-                "width", "height", "color", "background-color", "font-size",
-                "cursor", "pointer-events", "overflow",
+                "display",
+                "visibility",
+                "opacity",
+                "position",
+                "z-index",
+                "width",
+                "height",
+                "color",
+                "background-color",
+                "font-size",
+                "cursor",
+                "pointer-events",
+                "overflow",
             }
             styles = {
-                prop["name"]: prop["value"]
-                for prop in computed.get("computedStyle", [])
-                if prop["name"] in _STYLE_KEYS
+                prop["name"]: prop["value"] for prop in computed.get("computedStyle", []) if prop["name"] in _STYLE_KEYS
             }
 
             # Event listeners via Runtime.evaluate (type names only)
-            listeners_result = await self._cdp.send("Runtime.evaluate", {
-                "expression": f"""
+            listeners_result = await self._cdp.send(
+                "Runtime.evaluate",
+                {
+                    "expression": f"""
                     (function() {{
                         const el = document.querySelector({selector!r});
                         if (!el) return [];
@@ -111,13 +127,16 @@ class CDPPassthrough:
                         return events;
                     }})()
                 """,
-                "returnByValue": True,
-            })
+                    "returnByValue": True,
+                },
+            )
             listener_types = listeners_result.get("result", {}).get("value", [])
 
             # Asset references
-            asset_result = await self._cdp.send("Runtime.evaluate", {
-                "expression": f"""
+            asset_result = await self._cdp.send(
+                "Runtime.evaluate",
+                {
+                    "expression": f"""
                     (function() {{
                         const el = document.querySelector({selector!r});
                         if (!el) return {{}};
@@ -129,8 +148,9 @@ class CDPPassthrough:
                         }};
                     }})()
                 """,
-                "returnByValue": True,
-            })
+                    "returnByValue": True,
+                },
+            )
             assets = asset_result.get("result", {}).get("value", {})
 
             return {
@@ -159,8 +179,7 @@ class CDPPassthrough:
         params = params or {}
         if method not in _ALLOWED_CDP_COMMANDS:
             raise ValueError(
-                f"CDP command {method!r} is not in the allowed list. "
-                f"Allowed: {sorted(_ALLOWED_CDP_COMMANDS)}"
+                f"CDP command {method!r} is not in the allowed list. Allowed: {sorted(_ALLOWED_CDP_COMMANDS)}"
             )
         try:
             result = await self._cdp.send(method, params)

--- a/controller/app/compliance.py
+++ b/controller/app/compliance.py
@@ -53,9 +53,7 @@ def apply_compliance_template(settings: Any, template_name: str) -> dict[str, An
         )
         normalized = target
     if normalized not in _PRESETS:
-        raise ValueError(
-            f"Unknown compliance preset: {raw!r}. Valid options: {sorted(_PRESETS)}"
-        )
+        raise ValueError(f"Unknown compliance preset: {raw!r}. Valid options: {sorted(_PRESETS)}")
 
     overrides = _PRESETS[normalized]
     applied: dict[str, Any] = {}
@@ -74,8 +72,7 @@ def write_compliance_manifest(*, template_name: str, overrides: dict[str, Any], 
         "template": template_name,
         "applied_overrides": overrides,
         "note": (
-            "This manifest records the compliance preset applied at startup. "
-            "Settings were overridden as shown above."
+            "This manifest records the compliance preset applied at startup. Settings were overridden as shown above."
         ),
     }
     tmp_path = output_path.with_suffix(".json.tmp")

--- a/controller/app/config.py
+++ b/controller/app/config.py
@@ -362,11 +362,11 @@ class Settings(BaseSettings):
     def is_production(self) -> bool:
         return self.environment_name == "production"
 
-
     @property
     def random_user_agent(self) -> str:
         agents = [a.strip() for a in self.user_agent_pool.split(",") if a.strip()]
         return random.choice(agents) if agents else ""
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/controller/app/cron_service.py
+++ b/controller/app/cron_service.py
@@ -48,13 +48,11 @@ from .utils import UTC
 try:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
     from apscheduler.triggers.cron import CronTrigger
+
     _APSCHEDULER_AVAILABLE = True
 except ImportError:
     _APSCHEDULER_AVAILABLE = False
-    logger.info(
-        "APScheduler not installed — cron scheduling disabled. "
-        "Install: pip install apscheduler"
-    )
+    logger.info("APScheduler not installed — cron scheduling disabled. Install: pip install apscheduler")
 
 
 class CronService:
@@ -66,7 +64,7 @@ class CronService:
         *,
         max_jobs: int = 50,
         job_queue: Any = None,  # AgentJobQueue
-        manager: Any = None,   # BrowserManager
+        manager: Any = None,  # BrowserManager
     ):
         self._store_path = Path(store_path)
         self._max_jobs = max_jobs
@@ -156,8 +154,17 @@ class CronService:
             if job_id not in jobs:
                 raise KeyError(f"Cron job not found: {job_id}")
             job = jobs[job_id]
-            allowed = {"name", "goal", "provider", "schedule", "enabled", "start_url",
-                       "auth_profile", "proxy_persona", "max_steps"}
+            allowed = {
+                "name",
+                "goal",
+                "provider",
+                "schedule",
+                "enabled",
+                "start_url",
+                "auth_profile",
+                "proxy_persona",
+                "max_steps",
+            }
             for k, v in updates.items():
                 if k in allowed:
                     job[k] = v
@@ -191,9 +198,7 @@ class CronService:
 
     # ── Webhook trigger ─────────────────────────────────────────────────────
 
-    async def trigger_via_webhook(
-        self, job_id: str, webhook_key: str
-    ) -> dict[str, Any]:
+    async def trigger_via_webhook(self, job_id: str, webhook_key: str) -> dict[str, Any]:
         """Verify webhook key and enqueue the job for immediate execution."""
         jobs = self._load()
         if job_id not in jobs:

--- a/controller/app/curator_llm.py
+++ b/controller/app/curator_llm.py
@@ -12,6 +12,7 @@ Ships with graceful degradation:
 
 Carried into the current release line from an earlier staging branch.
 """
+
 from __future__ import annotations
 
 import logging

--- a/controller/app/events.py
+++ b/controller/app/events.py
@@ -5,6 +5,7 @@ Subscribers receive a queue that gets populated when the browser manager
 emits observe/action/approval events. The SSE endpoint drains the queue
 and streams events to the client.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -74,44 +75,57 @@ def _dispatch(session_id: str, event: dict[str, Any]) -> None:
 
 # ── Public emit helpers ──────────────────────────────────────────────────────
 
+
 def emit_observe(session_id: str, url: str, title: str, screenshot_url: str | None = None) -> None:
-    _dispatch(session_id, {
-        "event": "observe",
-        "session_id": session_id,
-        "timestamp": _now(),
-        "url": url,
-        "title": title,
-        "screenshot_url": screenshot_url,
-    })
+    _dispatch(
+        session_id,
+        {
+            "event": "observe",
+            "session_id": session_id,
+            "timestamp": _now(),
+            "url": url,
+            "title": title,
+            "screenshot_url": screenshot_url,
+        },
+    )
 
 
 def emit_action(session_id: str, action: str, status: str, details: dict[str, Any] | None = None) -> None:
-    _dispatch(session_id, {
-        "event": "action",
-        "session_id": session_id,
-        "timestamp": _now(),
-        "action": action,
-        "status": status,
-        "details": details or {},
-    })
+    _dispatch(
+        session_id,
+        {
+            "event": "action",
+            "session_id": session_id,
+            "timestamp": _now(),
+            "action": action,
+            "status": status,
+            "details": details or {},
+        },
+    )
 
 
 def emit_approval(session_id: str, approval_id: str, kind: str, status: str, reason: str) -> None:
-    _dispatch(session_id, {
-        "event": "approval",
-        "session_id": session_id,
-        "timestamp": _now(),
-        "approval_id": approval_id,
-        "kind": kind,
-        "status": status,
-        "reason": reason,
-    })
+    _dispatch(
+        session_id,
+        {
+            "event": "approval",
+            "session_id": session_id,
+            "timestamp": _now(),
+            "approval_id": approval_id,
+            "kind": kind,
+            "status": status,
+            "reason": reason,
+        },
+    )
 
 
 def emit_session(session_id: str, status: str) -> None:
-    _dispatch(session_id, {
-        "event": "session",
-        "session_id": session_id,
-        "timestamp": _now(),
-        "status": status,
-    })
+    _dispatch(
+        session_id,
+        {
+            "event": "session",
+            "session_id": session_id,
+            "timestamp": _now(),
+            "status": status,
+        },
+    )

--- a/controller/app/harness/induce.py
+++ b/controller/app/harness/induce.py
@@ -209,7 +209,7 @@ def run(page: Page) -> dict:
 
 
 def _render_self_test(contract: TaskContract) -> str:
-    return f'''from __future__ import annotations
+    return f"""from __future__ import annotations
 
 import json
 from pathlib import Path
@@ -219,4 +219,4 @@ def test_contract_is_embedded() -> None:
     contract = json.loads((Path(__file__).parent / "contract.json").read_text(encoding="utf-8"))
     assert contract["id"] == {contract.id!r}
     assert contract["postconditions"]
-'''
+"""

--- a/controller/app/harness/run.py
+++ b/controller/app/harness/run.py
@@ -14,7 +14,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run one auto-browser convergence harness task contract.")
     parser.add_argument("--contract", required=True, help="Path to a TaskContract JSON file.")
     parser.add_argument("--root", default=".autonomous/harness", help="Harness state root.")
-    parser.add_argument("--mock-final-observation", default="", help="JSON object or path for deterministic local runs.")
+    parser.add_argument(
+        "--mock-final-observation", default="", help="JSON object or path for deterministic local runs."
+    )
     parser.add_argument("--mock-final-url", default="", help="Convenience URL for deterministic local runs.")
     parser.add_argument("--mock-final-text", default="", help="Convenience text for deterministic local runs.")
     parser.add_argument("--max-attempts", type=int, default=None)

--- a/controller/app/harness/verifier/__init__.py
+++ b/controller/app/harness/verifier/__init__.py
@@ -4,4 +4,10 @@ from .base import EnsembleVerifier, VerificationResult, VerifierAdapter
 from .programmatic import ProgrammaticVerifier
 from .uv import UniversalVerifierAdapter
 
-__all__ = ["EnsembleVerifier", "ProgrammaticVerifier", "UniversalVerifierAdapter", "VerificationResult", "VerifierAdapter"]
+__all__ = [
+    "EnsembleVerifier",
+    "ProgrammaticVerifier",
+    "UniversalVerifierAdapter",
+    "VerificationResult",
+    "VerifierAdapter",
+]

--- a/controller/app/main.py
+++ b/controller/app/main.py
@@ -108,6 +108,7 @@ app.include_router(
 )
 install_controller_http_middleware(app, settings=settings, rate_limiter=rate_limiter, metrics=metrics)
 
+
 # Legacy operator dashboard aliases now redirect to the auth-bootstrap-aware dashboard.
 @app.get("/ui", include_in_schema=False)
 @app.get("/ui/", include_in_schema=False)

--- a/controller/app/maintenance.py
+++ b/controller/app/maintenance.py
@@ -137,7 +137,9 @@ class MaintenanceService:
                 stats.deleted_files += 1
                 stats.bytes_reclaimed += size
 
-        for path in sorted((item for item in root.rglob("*") if item.is_dir()), key=lambda item: len(item.parts), reverse=True):
+        for path in sorted(
+            (item for item in root.rglob("*") if item.is_dir()), key=lambda item: len(item.parts), reverse=True
+        ):
             resolved = path.resolve()
             if self._protected_match(resolved, protected_roots) is not None:
                 continue

--- a/controller/app/mcp_stdio.py
+++ b/controller/app/mcp_stdio.py
@@ -6,6 +6,7 @@ script) and as ``app.mcp_stdio`` inside the controller image (Glama/Docker
 entrypoint). A guard test asserts the two copies stay byte-identical, so any
 edit here must be mirrored to the other copy.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -159,7 +160,9 @@ class StdioMcpBridge:
         if payload.get("id") is None:
             return None
         if response.body is None:
-            return self._jsonrpc_error(request_id, -32000, f"Empty response from Auto Browser MCP endpoint ({response.status_code})")
+            return self._jsonrpc_error(
+                request_id, -32000, f"Empty response from Auto Browser MCP endpoint ({response.status_code})"
+            )
         return response.body
 
     @staticmethod

--- a/controller/app/mcp_transport.py
+++ b/controller/app/mcp_transport.py
@@ -134,7 +134,9 @@ class McpHttpTransport:
 
         session_id = self._read_session_id(request)
         if not session_id:
-            return self._json_error_response(None, -32000, f"Missing required header: {MCP_SESSION_HEADER}", status_code=400)
+            return self._json_error_response(
+                None, -32000, f"Missing required header: {MCP_SESSION_HEADER}", status_code=400
+            )
         if self._sessions.pop(session_id, None) is None:
             return self._json_error_response(None, -32001, f"Unknown MCP session: {session_id}", status_code=404)
         self._persist_sessions()
@@ -325,7 +327,7 @@ class McpHttpTransport:
         # Parse browser://{session_id}/{resource}
         if not uri.startswith("browser://"):
             return None
-        path = uri[len("browser://"):]
+        path = uri[len("browser://") :]
         parts = path.split("/", 1)
         if len(parts) != 2:
             return None
@@ -340,6 +342,7 @@ class McpHttpTransport:
                 shot_path = Path(shot["screenshot_path"])
                 if shot_path.exists():
                     import base64
+
                     img_b64 = base64.standard_b64encode(shot_path.read_bytes()).decode()
                     return {"uri": uri, "mimeType": "image/png", "blob": img_b64}
                 return None
@@ -545,7 +548,9 @@ class McpHttpTransport:
             )
         return session
 
-    def _validate_protocol_header(self, request: Request, session: McpSession, *, request_id: Any = None) -> Response | None:
+    def _validate_protocol_header(
+        self, request: Request, session: McpSession, *, request_id: Any = None
+    ) -> Response | None:
         protocol_version = request.headers.get(MCP_PROTOCOL_HEADER)
         if not protocol_version:
             return None
@@ -582,9 +587,7 @@ class McpHttpTransport:
 
         allowed_origins = {
             normalized
-            for normalized in (
-                self._normalize_origin(origin_value) for origin_value in self.allowed_origins
-            )
+            for normalized in (self._normalize_origin(origin_value) for origin_value in self.allowed_origins)
             if normalized
         }
         request_origin = self._normalize_origin(str(request.base_url))
@@ -631,9 +634,7 @@ class McpHttpTransport:
                     initialized=bool(item.get("initialized", False)),
                     created_at=str(item.get("created_at") or ""),
                     resource_subscriptions=[
-                        str(uri)
-                        for uri in item.get("resource_subscriptions", [])
-                        if isinstance(uri, str)
+                        str(uri) for uri in item.get("resource_subscriptions", []) if isinstance(uri, str)
                     ],
                 )
             except Exception:

--- a/controller/app/memory_manager.py
+++ b/controller/app/memory_manager.py
@@ -31,10 +31,7 @@ class MemoryProfile(BaseModel):
             steps = "\n".join(f"  - {step}" for step in self.completed_steps[-10:])
             parts.append(f"Previously completed steps:\n{steps}")
         if self.discovered_selectors:
-            selectors = "\n".join(
-                f"  {key}: {value}"
-                for key, value in list(self.discovered_selectors.items())[:20]
-            )
+            selectors = "\n".join(f"  {key}: {value}" for key, value in list(self.discovered_selectors.items())[:20])
             parts.append(f"Known selectors:\n{selectors}")
         if self.notes:
             notes = "\n".join(f"  - {note}" for note in self.notes[-5:])

--- a/controller/app/mesh/__init__.py
+++ b/controller/app/mesh/__init__.py
@@ -3,6 +3,7 @@ auto-browser mesh — multi-node peer delegation with Ed25519 envelope security.
 
 Public surface (26 names):
 """
+
 from .delegation import (
     ApprovalFn,
     DelegationError,

--- a/controller/app/mesh/delegation.py
+++ b/controller/app/mesh/delegation.py
@@ -4,6 +4,7 @@ mesh.delegation — Orchestrator for outbound and inbound capability delegation.
 receive_inbound is fully implemented: routes tool/session/workflow capabilities,
 honors require_approval, returns DelegationResponse.
 """
+
 from __future__ import annotations
 
 import logging
@@ -41,6 +42,7 @@ _NONCE_CACHE_MAX = 10_000
 # Errors
 # ---------------------------------------------------------------------------
 
+
 class DelegationError(Exception):
     pass
 
@@ -56,6 +58,7 @@ class DelegationReplayError(DelegationError):
 # ---------------------------------------------------------------------------
 # Nonce cache
 # ---------------------------------------------------------------------------
+
 
 class _NonceCache:
     """Thread-safe LRU nonce cache for replay defense."""
@@ -98,6 +101,7 @@ ApprovalFn = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
 # ---------------------------------------------------------------------------
 # Main orchestrator
 # ---------------------------------------------------------------------------
+
 
 class DelegationManager:
     """
@@ -279,7 +283,10 @@ class DelegationManager:
             if approval_status != "approved":
                 logger.info(
                     "mesh.delegation.approval_denied peer=%s capability=%s approval_id=%s status=%s",
-                    sender_id, request.capability, approval_id, approval_status,
+                    sender_id,
+                    request.capability,
+                    approval_id,
+                    approval_status,
                 )
                 return DelegationResponse(
                     request_id=request.request_id,

--- a/controller/app/mesh/identity.py
+++ b/controller/app/mesh/identity.py
@@ -5,6 +5,7 @@ Each auto-browser instance generates a keypair on first start.
 The node_id is the hex-encoded SHA-256 of the public key bytes.
 Private key lives on disk at 0600; never transmitted.
 """
+
 from __future__ import annotations
 
 import base64
@@ -45,16 +46,12 @@ class NodeIdentity:
         if priv_path.exists():
             logger.info("mesh.identity: loading existing keypair from %s", self._dir)
             pem = priv_path.read_bytes()
-            self._private_key = Ed25519PrivateKey.from_private_bytes(
-                self._extract_raw_ed25519(pem)
-            )
+            self._private_key = Ed25519PrivateKey.from_private_bytes(self._extract_raw_ed25519(pem))
         else:
             logger.info("mesh.identity: generating new keypair in %s", self._dir)
             self._private_key = Ed25519PrivateKey.generate()
             # Write private key
-            priv_pem = self._private_key.private_bytes(
-                Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
-            )
+            priv_pem = self._private_key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
             priv_path.write_bytes(priv_pem)
             priv_path.chmod(0o600)
 
@@ -87,6 +84,7 @@ class NodeIdentity:
     def _extract_raw_ed25519(pem: bytes) -> bytes:
         """Extract 32-byte raw private key from PKCS8 PEM."""
         from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
         key = load_pem_private_key(pem, password=None)
         return key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
 

--- a/controller/app/mesh/models.py
+++ b/controller/app/mesh/models.py
@@ -4,6 +4,7 @@ mesh.models — Wire formats for the auto-browser peer mesh.
 All models are credential-free by design: no passwords, no API keys.
 Authentication is done entirely through Ed25519 envelope signatures.
 """
+
 from __future__ import annotations
 
 import time
@@ -17,10 +18,12 @@ from pydantic import BaseModel, Field
 # Capability types
 # ---------------------------------------------------------------------------
 
+
 class CapabilityKind(str, Enum):
     """What kind of action a grant allows."""
-    TOOL = "tool"          # delegate a named browser tool call
-    SESSION = "session"    # delegate session-level verbs (create/close/observe)
+
+    TOOL = "tool"  # delegate a named browser tool call
+    SESSION = "session"  # delegate session-level verbs (create/close/observe)
     WORKFLOW = "workflow"  # delegate a named workflow run
 
 
@@ -28,8 +31,10 @@ class CapabilityKind(str, Enum):
 # Policy / grants
 # ---------------------------------------------------------------------------
 
+
 class CapabilityGrant(BaseModel):
     """A single permission entry: what this peer may ask us to do."""
+
     capability: str = Field(..., description="e.g. 'tool:browser.click' or 'session:observe'")
     url_allowlist: list[str] = Field(default_factory=list, description="Allowed URL patterns (empty = unrestricted)")
     require_approval: bool = Field(False, description="Gate this capability behind operator approval")
@@ -39,6 +44,7 @@ class CapabilityGrant(BaseModel):
 
 class PeerGrant(BaseModel):
     """All capabilities granted to one peer node."""
+
     node_id: str
     grants: list[CapabilityGrant] = Field(default_factory=list)
 
@@ -47,8 +53,10 @@ class PeerGrant(BaseModel):
 # Peer registry
 # ---------------------------------------------------------------------------
 
+
 class PeerRecord(BaseModel):
     """A registered peer node."""
+
     node_id: str
     display_name: str = ""
     pubkey_b64: str = Field(..., description="Base64-encoded Ed25519 public key (32 bytes → 44 chars)")
@@ -62,8 +70,10 @@ class PeerRecord(BaseModel):
 # Signed envelopes
 # ---------------------------------------------------------------------------
 
+
 class SignedEnvelope(BaseModel):
     """A tamper-evident message between mesh nodes."""
+
     sender_node_id: str
     recipient_node_id: str
     nonce: str = Field(default_factory=lambda: str(uuid.uuid4()))
@@ -76,8 +86,10 @@ class SignedEnvelope(BaseModel):
 # Delegation request / response
 # ---------------------------------------------------------------------------
 
+
 class DelegationRequest(BaseModel):
     """Sent by an orchestrator to ask a peer to execute a capability."""
+
     request_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     capability: str = Field(..., description="e.g. 'tool:browser.click'")
     arguments: dict[str, Any] = Field(default_factory=dict)
@@ -87,6 +99,7 @@ class DelegationRequest(BaseModel):
 
 class DelegationResponse(BaseModel):
     """Returned by the receiving peer after executing (or rejecting)."""
+
     request_id: str
     status: str  # "ok" | "rejected" | "approval_required" | "error"
     result: dict[str, Any] = Field(default_factory=dict)

--- a/controller/app/mesh/peers.py
+++ b/controller/app/mesh/peers.py
@@ -4,6 +4,7 @@ mesh.peers — Peer registry backed by a JSON file.
 Hot-reloadable: the file is re-read when its mtime changes.
 Atomic writes via a temp file + rename.
 """
+
 from __future__ import annotations
 
 import json

--- a/controller/app/mesh/policy.py
+++ b/controller/app/mesh/policy.py
@@ -4,6 +4,7 @@ mesh.policy — Capability grant evaluator.
 Default-deny: if no matching grant exists, the request is rejected.
 All four constraint evaluators are real implementations (no stubs).
 """
+
 from __future__ import annotations
 
 import fnmatch
@@ -63,6 +64,7 @@ def _count_invocations(key: str) -> int:
 # Constraint evaluators
 # ---------------------------------------------------------------------------
 
+
 def _check_url_allowlist(grant: CapabilityGrant, request: DelegationRequest) -> None:
     """
     Enforce url_allowlist constraint.
@@ -82,8 +84,7 @@ def _check_url_allowlist(grant: CapabilityGrant, request: DelegationRequest) -> 
             return  # matched
 
     raise PolicyDenied(
-        f"URL {url!r} not in allowlist for capability {grant.capability!r}. "
-        f"Allowed patterns: {grant.url_allowlist}"
+        f"URL {url!r} not in allowlist for capability {grant.capability!r}. Allowed patterns: {grant.url_allowlist}"
     )
 
 
@@ -93,8 +94,7 @@ def _check_expires_at(grant: CapabilityGrant) -> None:
         return  # never expires
     if time.time() > grant.expires_at:
         raise PolicyExpired(
-            f"Grant for capability {grant.capability!r} expired at "
-            f"{grant.expires_at} (now={time.time():.1f})"
+            f"Grant for capability {grant.capability!r} expired at {grant.expires_at} (now={time.time():.1f})"
         )
 
 
@@ -122,6 +122,7 @@ def _record_invocation_for_grant(grant: CapabilityGrant, peer_node_id: str) -> N
 # Main evaluator
 # ---------------------------------------------------------------------------
 
+
 class PolicyEvaluator:
     """
     Evaluates whether a peer's DelegationRequest is permitted.
@@ -144,8 +145,7 @@ class PolicyEvaluator:
 
         if matching_grant is None:
             raise PolicyDenied(
-                f"No grant for capability {request.capability!r} "
-                f"from peer {peer.node_id!r}. Default-deny."
+                f"No grant for capability {request.capability!r} from peer {peer.node_id!r}. Default-deny."
             )
 
         # Run all constraint evaluators

--- a/controller/app/mesh/transport.py
+++ b/controller/app/mesh/transport.py
@@ -4,6 +4,7 @@ mesh.transport — Envelope signing, verification, and HTTP delivery.
 All envelope crypto is real Ed25519.
 send_envelope is a real async HTTPS POST — no longer a stub.
 """
+
 from __future__ import annotations
 
 import base64
@@ -26,6 +27,7 @@ _SEND_TIMEOUT_SECONDS = 10.0
 # Exceptions
 # ---------------------------------------------------------------------------
 
+
 class EnvelopeVerificationError(Exception):
     pass
 
@@ -37,6 +39,7 @@ class TransportError(Exception):
 # ---------------------------------------------------------------------------
 # Signing helpers
 # ---------------------------------------------------------------------------
+
 
 def _canonical_bytes(envelope: SignedEnvelope) -> bytes:
     """Produce a deterministic byte string over the envelope fields that matter."""
@@ -86,13 +89,11 @@ def verify_envelope(
     # Resolve sender's pinned public key
     if envelope.sender_node_id != expected_peer.node_id:
         raise EnvelopeVerificationError(
-            f"sender_node_id {envelope.sender_node_id!r} != "
-            f"expected {expected_peer.node_id!r}"
+            f"sender_node_id {envelope.sender_node_id!r} != expected {expected_peer.node_id!r}"
         )
     if expected_recipient_node_id is not None and envelope.recipient_node_id != expected_recipient_node_id:
         raise EnvelopeVerificationError(
-            f"recipient_node_id {envelope.recipient_node_id!r} != "
-            f"expected {expected_recipient_node_id!r}"
+            f"recipient_node_id {envelope.recipient_node_id!r} != expected {expected_recipient_node_id!r}"
         )
 
     try:
@@ -114,6 +115,7 @@ def verify_envelope(
 # ---------------------------------------------------------------------------
 # HTTP transport — REAL implementation (was stub)
 # ---------------------------------------------------------------------------
+
 
 async def send_envelope(peer: PeerRecord, envelope: SignedEnvelope) -> SignedEnvelope:
     """
@@ -140,8 +142,7 @@ async def send_envelope(peer: PeerRecord, envelope: SignedEnvelope) -> SignedEnv
 
     if response.status_code not in (200, 201, 202):
         raise TransportError(
-            f"Peer {peer.node_id!r} returned HTTP {response.status_code} "
-            f"from {url}: {response.text[:200]}"
+            f"Peer {peer.node_id!r} returned HTTP {response.status_code} from {url}: {response.text[:200]}"
         )
 
     try:

--- a/controller/app/network_inspector.py
+++ b/controller/app/network_inspector.py
@@ -101,7 +101,9 @@ class NetworkInspector:
         # Drain pending entries — requestfailed/requestfinished will never fire after detach
         spawn_background_task(self._flush_pending())
 
-    def entries(self, limit: int = 100, method: str | None = None, url_contains: str | None = None) -> list[dict[str, Any]]:
+    def entries(
+        self, limit: int = 100, method: str | None = None, url_contains: str | None = None
+    ) -> list[dict[str, Any]]:
         """Return captured network entries, most recent first."""
         items = list(self._log)
         if method:
@@ -191,10 +193,14 @@ class NetworkInspector:
             # Scrub request body
             pii_hit = False
             if req_body and self.scrubber:
-                ct = (request.headers.get("content-type") or "")
+                ct = request.headers.get("content-type") or ""
                 scrubbed, hits = self.scrubber.network_body(req_body, ct)
                 if hits:
-                    req_body = scrubbed if isinstance(scrubbed, str) else (scrubbed.decode("utf-8", "replace") if scrubbed else req_body)
+                    req_body = (
+                        scrubbed
+                        if isinstance(scrubbed, str)
+                        else (scrubbed.decode("utf-8", "replace") if scrubbed else req_body)
+                    )
                     pii_hit = True
 
             # Sanitize headers — remove Authorization / Cookie values
@@ -256,10 +262,7 @@ class NetworkInspector:
                 try:
                     raw_bytes = await response.body()
                     if raw_bytes and len(raw_bytes) <= self.body_max_bytes:
-                        is_text = any(
-                            m in content_type.lower()
-                            for m in ("json", "text", "html", "xml", "javascript")
-                        )
+                        is_text = any(m in content_type.lower() for m in ("json", "text", "html", "xml", "javascript"))
                         if is_text:
                             resp_body = raw_bytes.decode("utf-8", errors="replace")
                             if self.scrubber:
@@ -323,18 +326,23 @@ class NetworkInspector:
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
-_SENSITIVE_HEADER_NAMES = frozenset({
-    "authorization", "cookie", "set-cookie", "x-api-key", "x-auth-token",
-    "x-csrf-token", "proxy-authorization", "www-authenticate",
-})
+_SENSITIVE_HEADER_NAMES = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "set-cookie",
+        "x-api-key",
+        "x-auth-token",
+        "x-csrf-token",
+        "proxy-authorization",
+        "www-authenticate",
+    }
+)
 
 
 def _mask_sensitive_headers(headers: dict[str, str]) -> dict[str, str]:
     """Replace values of security-sensitive headers with [MASKED]."""
-    return {
-        k: "[MASKED]" if k.lower() in _SENSITIVE_HEADER_NAMES else v
-        for k, v in headers.items()
-    }
+    return {k: "[MASKED]" if k.lower() in _SENSITIVE_HEADER_NAMES else v for k, v in headers.items()}
 
 
 def _elapsed_ms(entry: dict[str, Any]) -> float | None:

--- a/controller/app/pii_scrub.py
+++ b/controller/app/pii_scrub.py
@@ -57,11 +57,11 @@ _RAW_PATTERNS: list[tuple[str, str]] = [
     # Generic API key / token / secret / password in query params or JSON fields
     (
         "api_key_param",
-        r'(?i)(?:api[_-]?key|apikey|access[_-]?token|auth[_-]?token|'
-        r'client[_-]?secret|app[_-]?secret|secret[_-]?key|private[_-]?key|'
-        r'x-api-key|access_key|refresh_token|id_token|session_token|'
-        r'auth_secret|webhook_secret|signing_secret|consumer_secret|'
-        r'oauth_token|oauth_secret)'
+        r"(?i)(?:api[_-]?key|apikey|access[_-]?token|auth[_-]?token|"
+        r"client[_-]?secret|app[_-]?secret|secret[_-]?key|private[_-]?key|"
+        r"x-api-key|access_key|refresh_token|id_token|session_token|"
+        r"auth_secret|webhook_secret|signing_secret|consumer_secret|"
+        r"oauth_token|oauth_secret)"
         r'\s*[=:]\s*["\']?([A-Za-z0-9\-._~+/!@#$%^&*()]{8,})["\']?',
     ),
     # Password fields in JSON or form data
@@ -97,7 +97,7 @@ _RAW_PATTERNS: list[tuple[str, str]] = [
     # Azure / generic client secrets (long hex strings after known labels)
     (
         "azure_secret",
-        r'(?i)(?:client_secret|tenant_id|application_id)\s*[=:]\s*'
+        r"(?i)(?:client_secret|tenant_id|application_id)\s*[=:]\s*"
         r'["\']?([a-f0-9\-]{32,})["\']?',
     ),
     # Generic hex API tokens 32+ chars (last resort, low-specificity)
@@ -106,14 +106,12 @@ _RAW_PATTERNS: list[tuple[str, str]] = [
     # (appears after = in assignments / JSON)
     (
         "generic_b64_secret",
-        r'(?i)(?:secret|token|key|credential|cred)\s*[=:]\s*'
+        r"(?i)(?:secret|token|key|credential|cred)\s*[=:]\s*"
         r'"?([A-Za-z0-9+/]{30,}={0,2})"?',
     ),
 ]
 
-_COMPILED: dict[str, re.Pattern[str]] = {
-    name: re.compile(pattern) for name, pattern in _RAW_PATTERNS
-}
+_COMPILED: dict[str, re.Pattern[str]] = {name: re.compile(pattern) for name, pattern in _RAW_PATTERNS}
 
 # Pattern display order (for reports)
 ALL_PATTERN_NAMES = [name for name, _ in _RAW_PATTERNS]
@@ -121,6 +119,7 @@ _NOISY_PATTERNS = {"generic_hex_token"}
 
 
 # ── Luhn check for credit card validation ─────────────────────────────────
+
 
 def _luhn_check(number: str) -> bool:
     """Return True if number passes Luhn algorithm."""
@@ -139,6 +138,7 @@ def _luhn_check(number: str) -> bool:
 
 
 # ── Core text scrubber ─────────────────────────────────────────────────────
+
 
 @dataclass
 class ScrubResult:
@@ -195,6 +195,7 @@ def scrub_text(
 
 # ── Screenshot pixel redaction ─────────────────────────────────────────────
 
+
 def scrub_screenshot(
     image_bytes: bytes,
     ocr_blocks: list[dict[str, Any]],
@@ -241,6 +242,7 @@ def scrub_screenshot(
 
     try:
         from PIL import Image, ImageDraw  # lazy import — Pillow is in requirements
+
         img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
         draw = ImageDraw.Draw(img)
         for box in boxes_to_redact:
@@ -254,6 +256,7 @@ def scrub_screenshot(
 
 
 # ── Network payload scrubber ───────────────────────────────────────────────
+
 
 def scrub_network_body(
     body: str | bytes | None,
@@ -271,10 +274,7 @@ def scrub_network_body(
         return body, []
 
     ct = content_type.lower()
-    is_text = any(
-        marker in ct
-        for marker in ("json", "text", "form", "xml", "javascript", "graphql")
-    )
+    is_text = any(marker in ct for marker in ("json", "text", "form", "xml", "javascript", "graphql"))
     if not is_text:
         return body, []
 
@@ -292,6 +292,7 @@ def scrub_network_body(
 
 
 # ── Console log scrubber ───────────────────────────────────────────────────
+
 
 def scrub_console_messages(
     messages: list[dict[str, Any]],
@@ -318,6 +319,7 @@ def scrub_console_messages(
 
 
 # ── Scrubber service (stateful, configured once) ───────────────────────────
+
 
 class PiiScrubber:
     """
@@ -382,15 +384,11 @@ class PiiScrubber:
             return ScrubResult(text=value)
         return scrub_text(value, self.replacement, self.enabled_patterns)
 
-    def screenshot(
-        self, image_bytes: bytes, ocr_blocks: list[dict[str, Any]]
-    ) -> tuple[bytes, list[dict[str, Any]]]:
+    def screenshot(self, image_bytes: bytes, ocr_blocks: list[dict[str, Any]]) -> tuple[bytes, list[dict[str, Any]]]:
         """Pixel-redact PII in a PNG screenshot using OCR bounding boxes."""
         if not self.screenshot_enabled:
             return image_bytes, []
-        return scrub_screenshot(
-            image_bytes, ocr_blocks, self.replacement, self.enabled_patterns
-        )
+        return scrub_screenshot(image_bytes, ocr_blocks, self.replacement, self.enabled_patterns)
 
     def network_body(
         self, body: str | bytes | None, content_type: str = ""
@@ -398,13 +396,9 @@ class PiiScrubber:
         """Scrub a network request/response body."""
         if not self.network_enabled:
             return body, []
-        return scrub_network_body(
-            body, content_type, self.replacement, self.enabled_patterns
-        )
+        return scrub_network_body(body, content_type, self.replacement, self.enabled_patterns)
 
-    def console(
-        self, messages: list[dict[str, Any]]
-    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    def console(self, messages: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         """Scrub PII from console log messages."""
         if not self.console_enabled:
             return messages, []
@@ -432,11 +426,7 @@ class PiiScrubber:
             "screenshot": self.screenshot_enabled,
             "network": self.network_enabled,
             "console": self.console_enabled,
-            "patterns": (
-                list(self.enabled_patterns)
-                if self.enabled_patterns is not None
-                else ALL_PATTERN_NAMES
-            ),
+            "patterns": (list(self.enabled_patterns) if self.enabled_patterns is not None else ALL_PATTERN_NAMES),
             "replacement": self.replacement,
             "audit_report": self.audit_report,
         }

--- a/controller/app/playwright_export.py
+++ b/controller/app/playwright_export.py
@@ -43,14 +43,14 @@ def run() -> None:
 
 '''
 
-_SCRIPT_FOOTER = '''\
+_SCRIPT_FOOTER = """\
         context.close()
         browser.close()
 
 
 if __name__ == "__main__":
     run()
-'''
+"""
 
 
 def _indent(code: str, spaces: int = 8) -> str:
@@ -61,7 +61,7 @@ def _action_to_code(action: str, details: dict[str, Any]) -> str | None:
     """Convert a single audit action to a Playwright Python statement."""
     if action == "navigate":
         url = details.get("url", "")
-        return f'page.goto({url!r})\n'
+        return f"page.goto({url!r})\n"
 
     if action == "click":
         mode = details.get("mode")
@@ -69,7 +69,7 @@ def _action_to_code(action: str, details: dict[str, Any]) -> str | None:
             x, y = details.get("x", 0), details.get("y", 0)
             return f"page.mouse.click({x}, {y})\n"
         selector = details.get("selector", "")
-        return f'page.locator({selector!r}).first.click()\n'
+        return f"page.locator({selector!r}).first.click()\n"
 
     if action == "hover":
         mode = details.get("mode")
@@ -77,7 +77,7 @@ def _action_to_code(action: str, details: dict[str, Any]) -> str | None:
             x, y = details.get("x", 0), details.get("y", 0)
             return f"page.mouse.move({x}, {y})\n"
         selector = details.get("selector", "")
-        return f'page.locator({selector!r}).first.hover()\n'
+        return f"page.locator({selector!r}).first.hover()\n"
 
     if action == "type":
         selector = details.get("selector", "")
@@ -89,16 +89,16 @@ def _action_to_code(action: str, details: dict[str, Any]) -> str | None:
             text = details.get("text_preview", "")
             comment = ""
         clear_first = details.get("clear_first", True)
-        loc = f'page.locator({selector!r}).first'
+        loc = f"page.locator({selector!r}).first"
         lines = ""
         if clear_first:
-            lines += f'{loc}.clear()\n'
-        lines += f'{loc}.fill({text!r}){comment}\n' if not comment else f'{loc}.fill({text!r}){comment}'
+            lines += f"{loc}.clear()\n"
+        lines += f"{loc}.fill({text!r}){comment}\n" if not comment else f"{loc}.fill({text!r}){comment}"
         return lines
 
     if action == "press":
         key = details.get("key", "")
-        return f'page.keyboard.press({key!r})\n'
+        return f"page.keyboard.press({key!r})\n"
 
     if action == "scroll":
         dx = details.get("delta_x", 0)
@@ -124,23 +124,23 @@ def _action_to_code(action: str, details: dict[str, Any]) -> str | None:
         label = details.get("label")
         index = details.get("index")
         if value is not None:
-            return f'page.locator({selector!r}).first.select_option(value={value!r})\n'
+            return f"page.locator({selector!r}).first.select_option(value={value!r})\n"
         if label is not None:
-            return f'page.locator({selector!r}).first.select_option(label={label!r})\n'
+            return f"page.locator({selector!r}).first.select_option(label={label!r})\n"
         if index is not None:
-            return f'page.locator({selector!r}).first.select_option(index={index!r})\n'
+            return f"page.locator({selector!r}).first.select_option(index={index!r})\n"
         return None
 
     if action == "open_tab":
         url = details.get("url")
         if url:
-            return f'tab = context.new_page()\ntab.goto({url!r})\npage = tab\n'
+            return f"tab = context.new_page()\ntab.goto({url!r})\npage = tab\n"
         return "page = context.new_page()\n"
 
     if action == "upload":
         selector = details.get("selector", "")
         file_path = details.get("file_path", "<path/to/file>")
-        return f'page.locator({selector!r}).first.set_input_files({file_path!r})  # verify file path before running\n'
+        return f"page.locator({selector!r}).first.set_input_files({file_path!r})  # verify file path before running\n"
 
     return None  # unsupported — skip
 
@@ -248,9 +248,9 @@ async def export_session_script(
         filename=f"{session_id}_replay.py",
     )
     action_events = [
-        e for e in events
-        if e.get("event_type") in {"browser_action", "action"}
-        and e.get("status") in {"ok", "success", "completed"}
+        e
+        for e in events
+        if e.get("event_type") in {"browser_action", "action"} and e.get("status") in {"ok", "success", "completed"}
     ]
     return {
         "session_id": session_id,

--- a/controller/app/providers/base.py
+++ b/controller/app/providers/base.py
@@ -263,8 +263,7 @@ class BaseProviderAdapter(ABC):
                 continue
             if key in {"properties", "$defs", "definitions"} and isinstance(value, dict):
                 normalized[key] = {
-                    child_key: cls._normalize_json_schema_node(child_value)
-                    for child_key, child_value in value.items()
+                    child_key: cls._normalize_json_schema_node(child_value) for child_key, child_value in value.items()
                 }
                 continue
             if key in {"items", "anyOf", "allOf", "oneOf", "not", "if", "then", "else"}:
@@ -295,14 +294,11 @@ class BaseProviderAdapter(ABC):
                 "Do not wrap it in markdown.\n"
                 f"{json.dumps(self.action_schema, ensure_ascii=False)}\n\n"
             )
-        return (
-            schema_text
-            + self.build_text_prompt(
-                goal=goal,
-                observation=observation,
-                context_hints=context_hints,
-                previous_steps=previous_steps,
-            )
+        return schema_text + self.build_text_prompt(
+            goal=goal,
+            observation=observation,
+            context_hints=context_hints,
+            previous_steps=previous_steps,
         )
 
     def cli_environment(self) -> dict[str, str]:
@@ -353,7 +349,10 @@ class BaseProviderAdapter(ABC):
 
         cli_home = (self.settings.cli_home or "").strip()
         if not cli_home:
-            return True, f"ready via {cli_label} CLI ({resolved_cli}); CLI_HOME is unset so auth state is delegated to the CLI environment"
+            return (
+                True,
+                f"ready via {cli_label} CLI ({resolved_cli}); CLI_HOME is unset so auth state is delegated to the CLI environment",
+            )
 
         home_path = Path(cli_home)
         if not home_path.exists():

--- a/controller/app/providers/claude_adapter.py
+++ b/controller/app/providers/claude_adapter.py
@@ -73,8 +73,7 @@ class ClaudeAdapter(BaseProviderAdapter):
             "model": model,
             "max_tokens": 1024,
             "system": (
-                "You are the Auto Browser planner. Pick exactly one next action. "
-                "Return it via the browser_action tool."
+                "You are the Auto Browser planner. Pick exactly one next action. Return it via the browser_action tool."
             ),
             "tool_choice": {"type": "tool", "name": "browser_action"},
             "tools": [

--- a/controller/app/providers/openai_adapter.py
+++ b/controller/app/providers/openai_adapter.py
@@ -290,9 +290,7 @@ class OpenAIAdapter(BaseProviderAdapter):
                     response = await client.post("/openai/decide", json=payload)
                 except (httpx.TimeoutException, httpx.NetworkError) as exc:
                     if attempt < max_attempts:
-                        await asyncio.sleep(
-                            self.settings.model_retry_backoff_seconds * (2 ** (attempt - 1))
-                        )
+                        await asyncio.sleep(self.settings.model_retry_backoff_seconds * (2 ** (attempt - 1)))
                         continue
                     raise ProviderAPIError(
                         provider=self.provider,
@@ -309,9 +307,7 @@ class OpenAIAdapter(BaseProviderAdapter):
                 retryable_status = response.status_code == 429 or response.status_code >= 500
                 if response.status_code >= 400:
                     if retryable_status and attempt < max_attempts:
-                        await asyncio.sleep(
-                            self.settings.model_retry_backoff_seconds * (2 ** (attempt - 1))
-                        )
+                        await asyncio.sleep(self.settings.model_retry_backoff_seconds * (2 ** (attempt - 1)))
                         continue
                     detail = None
                     if isinstance(body, dict):

--- a/controller/app/providers/openai_compatible.py
+++ b/controller/app/providers/openai_compatible.py
@@ -171,9 +171,7 @@ class OpenAICompatibleAdapter(BaseProviderAdapter):
         ]
         if self.profile.supports_vision:
             mime_type, image_b64 = self.encode_image(observation["screenshot_path"])
-            content.append(
-                {"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{image_b64}"}}
-            )
+            content.append({"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{image_b64}"}})
 
         payload = {
             "model": model,
@@ -225,9 +223,7 @@ class OpenAICompatibleAdapter(BaseProviderAdapter):
             # Some OpenAI-compatible endpoints ignore tool_choice; parse the content.
             raw_text = str(message.get("content") or "").strip()
             if not raw_text:
-                raise RuntimeError(
-                    f"{self.profile.label} returned neither a browser_action tool call nor content"
-                )
+                raise RuntimeError(f"{self.profile.label} returned neither a browser_action tool call nor content")
             decision = self.parse_decision_text(raw_text)
 
         return ProviderDecision(

--- a/controller/app/routes/extensions/__init__.py
+++ b/controller/app/routes/extensions/__init__.py
@@ -6,6 +6,7 @@ Registers: /mesh, /network, /cdp, /workflow, /dashboard
 One module per pillar; this package facade preserves the original
 ``app.routes.extensions`` import surface.
 """
+
 from __future__ import annotations
 
 import logging

--- a/controller/app/routes/extensions/cdp.py
+++ b/controller/app/routes/extensions/cdp.py
@@ -1,4 +1,5 @@
 """Pillar 3 — CDP routes (/sessions/{session_id}/cdp)."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/controller/app/routes/extensions/dashboard.py
+++ b/controller/app/routes/extensions/dashboard.py
@@ -1,4 +1,5 @@
 """Operator dashboard route (/dashboard)."""
+
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request

--- a/controller/app/routes/extensions/dashboard_html.py
+++ b/controller/app/routes/extensions/dashboard_html.py
@@ -1,4 +1,5 @@
 """Operator dashboard HTML template (served by routes.extensions.dashboard)."""
+
 from __future__ import annotations
 
 _DASHBOARD_HTML = """<!DOCTYPE html>

--- a/controller/app/routes/extensions/mesh.py
+++ b/controller/app/routes/extensions/mesh.py
@@ -1,4 +1,5 @@
 """Pillar 1 — Mesh routes (/mesh)."""
+
 from __future__ import annotations
 
 import logging
@@ -64,6 +65,7 @@ async def mesh_list_peers(request: Request):
 @mesh_router.post("/peers")
 async def mesh_add_peer(body: dict[str, Any], request: Request):
     from app.mesh import PeerRecord
+
     peers = getattr(request.app.state, "peer_registry", None)
     if peers is None:
         raise HTTPException(503, "Mesh not initialized")

--- a/controller/app/routes/extensions/network.py
+++ b/controller/app/routes/extensions/network.py
@@ -1,4 +1,5 @@
 """Pillar 3 — Network inspector routes (/sessions/{session_id}/network)."""
+
 from __future__ import annotations
 
 import logging

--- a/controller/app/routes/extensions/workflow.py
+++ b/controller/app/routes/extensions/workflow.py
@@ -1,4 +1,5 @@
 """Pillar 5 — Workflow routes (/workflows)."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/controller/app/routes/session_diagnostics.py
+++ b/controller/app/routes/session_diagnostics.py
@@ -98,18 +98,24 @@ def create_session_diagnostics_router(*, manager: Any, settings: Any) -> APIRout
         def esc(s: object) -> str:
             return _html.escape(str(s or ""))
 
-        screenshots_html = "".join(
-            f'<figure><img src="{esc(url)}" loading="lazy"><figcaption>{esc(lbl)}</figcaption></figure>'
-            for url, lbl in screenshots
-        ) or "<p class=muted>No screenshots captured yet.</p>"
+        screenshots_html = (
+            "".join(
+                f'<figure><img src="{esc(url)}" loading="lazy"><figcaption>{esc(lbl)}</figcaption></figure>'
+                for url, lbl in screenshots
+            )
+            or "<p class=muted>No screenshots captured yet.</p>"
+        )
 
-        events_html = "".join(
-            f'<tr><td class=muted>{esc(e.get("timestamp","")[:19])}</td>'
-            f'<td>{esc(e.get("event_type",""))}</td>'
-            f'<td>{esc(e.get("operator_id",""))}</td>'
-            f'<td>{esc(str(e.get("data",""))[:120])}</td></tr>'
-            for e in events
-        ) or '<tr><td colspan=4 class=muted>No audit events.</td></tr>'
+        events_html = (
+            "".join(
+                f"<tr><td class=muted>{esc(e.get('timestamp', '')[:19])}</td>"
+                f"<td>{esc(e.get('event_type', ''))}</td>"
+                f"<td>{esc(e.get('operator_id', ''))}</td>"
+                f"<td>{esc(str(e.get('data', ''))[:120])}</td></tr>"
+                for e in events
+            )
+            or "<tr><td colspan=4 class=muted>No audit events.</td></tr>"
+        )
 
         status = esc(session_info.get("status", "unknown"))
         current_url = esc(session_info.get("url", ""))
@@ -148,7 +154,7 @@ def create_session_diagnostics_router(*, manager: Any, settings: Any) -> APIRout
   <span>Status: <strong>{status}</strong></span>
   <span>Created: {created}</span>
   <span>Title: {title}</span>
-  {f'<span>URL: <a href="{current_url}" target="_blank">{current_url}</a></span>' if current_url else ''}
+  {f'<span>URL: <a href="{current_url}" target="_blank">{current_url}</a></span>' if current_url else ""}
 </div>
 <h2>Screenshots ({len(screenshots)})</h2>
 <div class="gallery">{screenshots_html}</div>
@@ -168,9 +174,7 @@ def create_session_diagnostics_router(*, manager: Any, settings: Any) -> APIRout
         method: str | None = None,
         url_contains: str | None = None,
     ) -> dict[str, Any]:
-        return await manager.get_network_log(
-            session_id, limit=limit, method=method, url_contains=url_contains
-        )
+        return await manager.get_network_log(session_id, limit=limit, method=method, url_contains=url_contains)
 
     @router.post("/sessions/{session_id}/shadow-browse")
     async def enable_shadow_browse(session_id: str) -> dict[str, Any]:

--- a/controller/app/runtime_policy.py
+++ b/controller/app/runtime_policy.py
@@ -70,9 +70,7 @@ def _validate_provider_runtime(settings: Settings, report: RuntimePolicyReport) 
         auth_mode = (getattr(settings, auth_mode_attr.lower()) or "").strip().lower()
         if auth_mode not in allowed_modes:
             supported = ", ".join(sorted(allowed_modes))
-            report.errors.append(
-                f"{auth_mode_attr}={auth_mode or '<empty>'} is invalid; expected one of: {supported}"
-            )
+            report.errors.append(f"{auth_mode_attr}={auth_mode or '<empty>'} is invalid; expected one of: {supported}")
             continue
 
         if auth_mode == "api":
@@ -96,9 +94,7 @@ def _validate_provider_runtime(settings: Settings, report: RuntimePolicyReport) 
         cli_path = getattr(settings, cli_path_attr.lower())
         resolved_cli = which(cli_path) if cli_path else None
         if not resolved_cli:
-            report.errors.append(
-                f"{auth_mode_attr}=cli requires a working {cli_label} CLI in {cli_path_attr}"
-            )
+            report.errors.append(f"{auth_mode_attr}=cli requires a working {cli_label} CLI in {cli_path_attr}")
             continue
 
         if cli_home_path is None:
@@ -150,17 +146,13 @@ def validate_runtime_policy(settings: Settings) -> RuntimePolicyReport:
         report.errors.append("AUTH_STATE_ENCRYPTION_KEY is required when APP_ENV=production")
 
     if not settings.require_auth_state_encryption:
-        report.errors.append(
-            "REQUIRE_AUTH_STATE_ENCRYPTION=true is required when APP_ENV=production"
-        )
+        report.errors.append("REQUIRE_AUTH_STATE_ENCRYPTION=true is required when APP_ENV=production")
 
     if not settings.request_rate_limit_enabled:
         report.errors.append("REQUEST_RATE_LIMIT_ENABLED=true is required when APP_ENV=production")
 
     if settings.request_rate_limit_requests <= 0 or settings.request_rate_limit_window_seconds <= 0:
-        report.errors.append(
-            "REQUEST_RATE_LIMIT_REQUESTS and REQUEST_RATE_LIMIT_WINDOW_SECONDS must be positive"
-        )
+        report.errors.append("REQUEST_RATE_LIMIT_REQUESTS and REQUEST_RATE_LIMIT_WINDOW_SECONDS must be positive")
 
     if settings.request_rate_limit_max_buckets <= 0:
         report.errors.append("REQUEST_RATE_LIMIT_MAX_BUCKETS must be positive")
@@ -180,9 +172,7 @@ def validate_runtime_policy(settings: Settings) -> RuntimePolicyReport:
         "example.com,localhost,127.0.0.1,::1",
     }
     if settings.allowed_hosts.strip() in default_allowed_hosts:
-        report.warnings.append(
-            "ALLOWED_HOSTS still contains the default placeholder values; tighten it before launch"
-        )
+        report.warnings.append("ALLOWED_HOSTS still contains the default placeholder values; tighten it before launch")
 
     if settings.session_isolation_mode != "docker_ephemeral":
         report.warnings.append(

--- a/controller/app/session_isolation.py
+++ b/controller/app/session_isolation.py
@@ -275,9 +275,7 @@ class DockerBrowserNodeProvisioner:
                     return endpoint
             await asyncio.sleep(0.25)
         logs = self._container_logs(container)
-        raise RuntimeError(
-            f"Timed out waiting for isolated browser endpoint file {endpoint_file}. {logs}"
-        )
+        raise RuntimeError(f"Timed out waiting for isolated browser endpoint file {endpoint_file}. {logs}")
 
     def _cleanup_pending_container(self, pending: PendingBrowserProvision) -> None:
         runtime = IsolatedBrowserRuntime(

--- a/controller/app/session_share.py
+++ b/controller/app/session_share.py
@@ -41,6 +41,7 @@ class SessionShareManager:
             # Auto-generate an ephemeral secret if none configured.
             # Tokens created with this secret won't survive server restarts.
             import os
+
             secret = os.urandom(32).hex()
             logger.warning(
                 "SHARE_TOKEN_SECRET not configured — using ephemeral secret. "

--- a/controller/app/session_tunnel.py
+++ b/controller/app/session_tunnel.py
@@ -234,10 +234,7 @@ class IsolatedSessionTunnelBroker:
             "-i",
             self.settings.isolated_tunnel_key_path,
             "-R",
-            (
-                f"{tunnel.remote_bind_address}:{tunnel.remote_port}:"
-                f"{tunnel.local_host}:{tunnel.local_port}"
-            ),
+            (f"{tunnel.remote_bind_address}:{tunnel.remote_port}:{tunnel.local_host}:{tunnel.local_port}"),
             f"{tunnel.ssh_user}@{tunnel.ssh_host}",
         ]
 
@@ -258,9 +255,7 @@ class IsolatedSessionTunnelBroker:
             return
         if tunnel.status in {"inactive", "error", "degraded"}:
             return
-        tunnel.error = self._tail_file(tunnel.log_path) or (
-            f"autossh exited with code {tunnel.process.returncode}"
-        )
+        tunnel.error = self._tail_file(tunnel.log_path) or (f"autossh exited with code {tunnel.process.returncode}")
         self._write_metadata(tunnel, status="degraded")
 
     def _write_metadata(self, tunnel: IsolatedSessionTunnel, *, status: str) -> None:
@@ -308,7 +303,9 @@ class IsolatedSessionTunnelBroker:
         }
         missing = [name for name, value in required.items() if not value]
         if missing:
-            raise RuntimeError(f"isolated tunnel support is enabled but missing required settings: {', '.join(missing)}")
+            raise RuntimeError(
+                f"isolated tunnel support is enabled but missing required settings: {', '.join(missing)}"
+            )
 
         key_path = Path(self.settings.isolated_tunnel_key_path)
         if not key_path.is_file():
@@ -318,8 +315,7 @@ class IsolatedSessionTunnelBroker:
         known_hosts = Path(self.settings.isolated_tunnel_known_hosts_path)
         if strict in {"yes", "accept-new"} and not known_hosts.is_file():
             raise RuntimeError(
-                "isolated tunnel known_hosts file is required when strict host key checking is enabled: "
-                f"{known_hosts}"
+                f"isolated tunnel known_hosts file is required when strict host key checking is enabled: {known_hosts}"
             )
 
         allowed_modes = {"private", "tailscale", "cloudflare-access", "unsafe-public"}
@@ -344,10 +340,7 @@ class IsolatedSessionTunnelBroker:
         ):
             raise RuntimeError("Cloudflare Access mode expects ISOLATED_TUNNEL_PUBLIC_SCHEME=https")
 
-        if (
-            self.settings.isolated_tunnel_remote_port_start
-            > self.settings.isolated_tunnel_remote_port_end
-        ):
+        if self.settings.isolated_tunnel_remote_port_start > self.settings.isolated_tunnel_remote_port_end:
             raise RuntimeError("ISOLATED_TUNNEL_REMOTE_PORT_START must be <= ISOLATED_TUNNEL_REMOTE_PORT_END")
 
     @staticmethod
@@ -358,4 +351,3 @@ class IsolatedSessionTunnelBroker:
         if not text:
             return None
         return text[-max_chars:]
-

--- a/controller/app/startup/extensions.py
+++ b/controller/app/startup/extensions.py
@@ -5,6 +5,7 @@ Call register_extensions(app) from main.py after app creation.
 All clients are initialized from environment variables.
 Missing credentials = subsystem disabled with a warning (never crash on startup).
 """
+
 from __future__ import annotations
 
 import logging
@@ -41,10 +42,12 @@ def register_extensions(app) -> None:
 # Skills Curator adapter
 # ---------------------------------------------------------------------------
 
+
 def _init_curator(app) -> None:
     """Initialize the Skills Curator LLM adapter. None when no API key is set."""
     try:
         from app.curator_llm import build_curator_adapter
+
         adapter = build_curator_adapter()
         app.state.curator_adapter = adapter
         if adapter is not None and adapter.ready:
@@ -59,6 +62,7 @@ def _init_curator(app) -> None:
 # ---------------------------------------------------------------------------
 # Mesh
 # ---------------------------------------------------------------------------
+
 
 def _init_mesh(app) -> None:
     mesh_enabled = os.environ.get("MESH_ENABLED", "false").lower() == "true"
@@ -101,6 +105,7 @@ def _init_mesh(app) -> None:
 # ---------------------------------------------------------------------------
 # Convergence harness
 # ---------------------------------------------------------------------------
+
 
 def _init_harness(app) -> None:
     try:
@@ -159,9 +164,10 @@ def _harness_model_tiers(settings) -> dict[str, str]:
 # Network / CDP stores (populated per-session by session manager)
 # ---------------------------------------------------------------------------
 
+
 def _init_network_stores(app) -> None:
-    app.state.network_inspectors = {}   # session_id → NetworkInspector
-    app.state.cdp_sessions = {}         # session_id → CDPPassthrough
+    app.state.network_inspectors = {}  # session_id → NetworkInspector
+    app.state.cdp_sessions = {}  # session_id → CDPPassthrough
     logger.debug("startup.extensions: network/CDP stores initialized")
 
 
@@ -198,8 +204,10 @@ def _build_mesh_tool_gateway(app):
 # Workflow engine
 # ---------------------------------------------------------------------------
 
+
 def _init_workflow_engine(app) -> None:
     from app.workflow.engine import WorkflowEngine
+
     wf_root = Path(os.environ.get("WORKFLOWS_ROOT", "/data/workflows"))
     engine = WorkflowEngine(workflows_root=wf_root)
     app.state.workflow_engine = engine
@@ -209,6 +217,7 @@ def _init_workflow_engine(app) -> None:
 # ---------------------------------------------------------------------------
 # Extracted social/Veo3 state
 # ---------------------------------------------------------------------------
+
 
 def _disable_extracted_social_state(app) -> None:
     """Keep removed social/Veo3 app.state names inert for old extensions/tests."""
@@ -240,6 +249,7 @@ def _register_session_hooks(app) -> None:
 # Session lifecycle hooks (called by browser manager)
 # ---------------------------------------------------------------------------
 
+
 async def on_session_created(app, session_id: str, page) -> None:
     """
     Called when a new browser session is created.
@@ -262,6 +272,7 @@ async def on_session_created(app, session_id: str, page) -> None:
         stealth_profile = os.environ.get("STEALTH_PROFILE", "off")
         if getattr(settings, "stealth_enabled", False) and stealth_profile != "off":
             from app.stealth.fingerprint import FingerprintConfig, apply_fingerprint
+
             config = FingerprintConfig(session_id, stealth_profile)
             await apply_fingerprint(page.context, config)
             logger.debug("on_session_created: stealth profile=%s applied", stealth_profile)
@@ -280,6 +291,7 @@ async def on_session_closed(app, session_id: str) -> None:
         curator = getattr(app.state, "curator_adapter", None)
         if curator is not None and getattr(curator, "ready", False):
             from ..utils import spawn_background_task
+
             spawn_background_task(_curator_review_session(app, session_id, curator))
     except Exception as exc:
         logger.debug("on_session_closed: curator review skipped — %s", exc)
@@ -293,6 +305,7 @@ async def _curator_review_session(app, session_id: str, curator) -> None:
     """
     try:
         from pathlib import Path
+
         staging = Path(os.environ.get("SKILLS_STAGING_ROOT", "/data/skills-staging")) / session_id
         staging.mkdir(parents=True, exist_ok=True)
         # Build a lightweight transcript stub — callers that wire a richer

--- a/controller/app/stealth/__init__.py
+++ b/controller/app/stealth/__init__.py
@@ -1,4 +1,5 @@
 """auto-browser stealth — humanization and fingerprint profiles."""
+
 from .fingerprint import FingerprintConfig, apply_fingerprint
 from .humanizer import PROFILES, Humanizer, HumanProfile
 

--- a/controller/app/stealth/fingerprint.py
+++ b/controller/app/stealth/fingerprint.py
@@ -5,6 +5,7 @@ Applied via Playwright's add_init_script() so it runs before any page JS.
 Covers: webdriver flag, canvas noise, WebGL noise, user-agent cycling,
 timezone/locale consistency per session.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -56,6 +57,7 @@ _LOCALES = ["en-US", "en-GB", "en-CA", "en-AU", "de-DE", "fr-FR"]
 # Session-stable fingerprint seed
 # ---------------------------------------------------------------------------
 
+
 def _session_seed(session_id: str) -> int:
     """Derive a stable integer seed from a session ID so fingerprint is consistent
     within a session but differs across sessions."""
@@ -65,6 +67,7 @@ def _session_seed(session_id: str) -> int:
 # ---------------------------------------------------------------------------
 # Fingerprint config
 # ---------------------------------------------------------------------------
+
 
 class FingerprintConfig:
     """Per-session fingerprint configuration."""
@@ -150,6 +153,7 @@ class FingerprintConfig:
 # ---------------------------------------------------------------------------
 # Apply fingerprint to a Playwright BrowserContext
 # ---------------------------------------------------------------------------
+
 
 async def apply_fingerprint(context: "BrowserContext", config: FingerprintConfig) -> None:  # noqa: F821
     """Inject the fingerprint init script into a Playwright BrowserContext."""

--- a/controller/app/stealth/humanizer.py
+++ b/controller/app/stealth/humanizer.py
@@ -6,6 +6,7 @@ Three profiles:
   light   — timing jitter + Bézier mouse (default for 1.0)
   aggressive — full fingerprint noise + tighter human mimicry
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -20,9 +21,11 @@ logger = logging.getLogger(__name__)
 # Config
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class HumanProfile:
     """Timing and movement parameters."""
+
     # Click/keystroke timing (ms)
     click_mean_ms: float = 180.0
     click_sigma_ms: float = 55.0
@@ -36,9 +39,9 @@ class HumanProfile:
     key_max_ms: float = 300.0
 
     # Mouse movement — Bézier segments
-    mouse_steps: int = 25       # points along the curve
+    mouse_steps: int = 25  # points along the curve
     mouse_step_ms: float = 8.0  # ms between steps
-    mouse_sigma: float = 12.0   # control-point jitter (px)
+    mouse_sigma: float = 12.0  # control-point jitter (px)
 
     # Scroll
     scroll_step_px: int = 80
@@ -69,6 +72,7 @@ PROFILES: dict[str, Optional[HumanProfile]] = {
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _clamp(val: float, lo: float, hi: float) -> float:
     return max(lo, min(hi, val))
 
@@ -79,9 +83,7 @@ def _gaussian_delay(mean_ms: float, sigma_ms: float, lo: float, hi: float) -> fl
     return ms / 1000.0
 
 
-def _bezier_points(
-    x0: float, y0: float, x1: float, y1: float, steps: int, jitter: float
-) -> list[Tuple[float, float]]:
+def _bezier_points(x0: float, y0: float, x1: float, y1: float, steps: int, jitter: float) -> list[Tuple[float, float]]:
     """
     Generate a list of (x, y) waypoints along a cubic Bézier curve between
     two points.  The two control points are jittered to create natural curves.
@@ -104,6 +106,7 @@ def _bezier_points(
 # ---------------------------------------------------------------------------
 # Main humanizer class
 # ---------------------------------------------------------------------------
+
 
 class Humanizer:
     """

--- a/controller/app/tool_gateway/gateway.py
+++ b/controller/app/tool_gateway/gateway.py
@@ -226,9 +226,7 @@ class McpToolGateway:
             # Invalid tool arguments — report the field errors so the calling
             # agent can fix its call, instead of "Tool execution failed".
             details = "; ".join(
-                f"{'.'.join(str(part) for part in err['loc'])}: {err['msg']}"
-                if err.get("loc")
-                else err["msg"]
+                f"{'.'.join(str(part) for part in err['loc'])}: {err['msg']}" if err.get("loc") else err["msg"]
                 for err in exc.errors()
             )
             return self._error_response(f"Invalid arguments for {payload.name}: {details}")
@@ -573,9 +571,7 @@ class McpToolGateway:
     async def _get_html(self, payload: GetPageHtmlInput) -> dict[str, Any]:
         session = await self.manager.get_session(payload.session_id)
         if payload.text_only:
-            text = await session.page.evaluate(
-                "() => document.body ? document.body.innerText : ''"
-            )
+            text = await session.page.evaluate("() => document.body ? document.body.innerText : ''")
             return {"session_id": payload.session_id, "content": text, "type": "text"}
         html = await session.page.content()
         return {"session_id": payload.session_id, "content": html, "type": "html"}
@@ -634,9 +630,7 @@ class McpToolGateway:
                 [payload.query, payload.regex, payload.context, payload.limit],
             )
             try:
-                elements = await asyncio.wait_for(
-                    evaluate, timeout=FIND_ELEMENTS_QUERY_TIMEOUT_SECONDS
-                )
+                elements = await asyncio.wait_for(evaluate, timeout=FIND_ELEMENTS_QUERY_TIMEOUT_SECONDS)
             except asyncio.TimeoutError:
                 raise BrowserActionError(
                     f"find_elements query timed out after "
@@ -745,6 +739,7 @@ class McpToolGateway:
 
     async def _export_script(self, payload: ExportScriptInput) -> dict[str, Any]:
         from .playwright_export import export_session_script
+
         session = await self.manager.get_session(payload.session_id)
         start_url = session.page.url
         return await export_session_script(
@@ -760,9 +755,7 @@ class McpToolGateway:
 
     async def _find_by_vision(self, payload: VisionFindInput) -> dict[str, Any]:
         if self.vision_targeter is None:
-            raise RuntimeError(
-                "Vision targeting is not available — set ANTHROPIC_API_KEY to enable it."
-            )
+            raise RuntimeError("Vision targeting is not available — set ANTHROPIC_API_KEY to enable it.")
         session = await self.manager.get_session(payload.session_id)
         if payload.take_screenshot:
             screenshot = await self.manager.capture_screenshot(payload.session_id, label="vision")

--- a/controller/app/tool_gateway/packs/core.py
+++ b/controller/app/tool_gateway/packs/core.py
@@ -305,4 +305,3 @@ def register(registry, gateway):
         ),
     ]:
         registry.register(spec)
-

--- a/controller/app/tool_gateway/packs/harness.py
+++ b/controller/app/tool_gateway/packs/harness.py
@@ -83,8 +83,7 @@ def register(registry, gateway):
         ToolSpec(
             name="harness.graduate",
             description=(
-                "Return the staged candidate for a converged run. "
-                "This does not promote it into production skills."
+                "Return the staged candidate for a converged run. This does not promote it into production skills."
             ),
             input_model=HarnessGraduateInput,
             handler=gateway._harness_graduate,

--- a/controller/app/tool_gateway/packs/storage.py
+++ b/controller/app/tool_gateway/packs/storage.py
@@ -8,10 +8,7 @@ def register(registry, gateway):
     for spec in [
         ToolSpec(
             name="browser.get_cookies",
-            description=(
-                "Get all cookies for the current session context. "
-                "Optionally filter by URL(s)."
-            ),
+            description=("Get all cookies for the current session context. Optionally filter by URL(s)."),
             input_model=GetCookiesInput,
             handler=gateway._get_cookies,
             profiles=("full",),
@@ -29,20 +26,14 @@ def register(registry, gateway):
         ),
         ToolSpec(
             name="browser.get_local_storage",
-            description=(
-                "Read a key (or all keys) from localStorage or sessionStorage "
-                "in the current page context."
-            ),
+            description=("Read a key (or all keys) from localStorage or sessionStorage in the current page context."),
             input_model=GetStorageInput,
             handler=gateway._get_local_storage,
             profiles=("full",),
         ),
         ToolSpec(
             name="browser.set_local_storage",
-            description=(
-                "Write a key-value pair to localStorage or sessionStorage "
-                "in the current page context."
-            ),
+            description=("Write a key-value pair to localStorage or sessionStorage in the current page context."),
             input_model=SetStorageInput,
             handler=gateway._set_local_storage,
             profiles=("full",),

--- a/controller/app/tool_inputs.py
+++ b/controller/app/tool_inputs.py
@@ -4,6 +4,7 @@ tool_inputs.py — Pydantic input models for McpToolGateway tool handlers.
 Kept in a separate module so tool_gateway.py stays focused on dispatch
 logic rather than schema definitions.
 """
+
 from __future__ import annotations
 
 from typing import Any, Literal
@@ -109,8 +110,7 @@ class HarnessGetStatusInput(StrictInputModel):
         min_length=1,
         max_length=120,
         description=(
-            "ID of the convergence run, as returned by harness.start_convergence "
-            "or listed by harness.list_runs."
+            "ID of the convergence run, as returned by harness.start_convergence or listed by harness.list_runs."
         ),
     )
 
@@ -217,10 +217,7 @@ class AuthProfileNameInput(StrictInputModel):
     profile_name: str = Field(
         min_length=1,
         max_length=120,
-        description=(
-            "Name of the saved auth profile to inspect, as listed by "
-            "browser.list_auth_profiles."
-        ),
+        description=("Name of the saved auth profile to inspect, as listed by browser.list_auth_profiles."),
     )
 
 
@@ -243,9 +240,7 @@ class ListTabsInput(SessionIdInput):
 class TabActionInput(SessionIdInput):
     index: int = Field(
         ge=0,
-        description=(
-            "Zero-based index of the target tab, as reported by browser.list_tabs."
-        ),
+        description=("Zero-based index of the target tab, as reported by browser.list_tabs."),
     )
 
 

--- a/controller/app/version.py
+++ b/controller/app/version.py
@@ -3,4 +3,5 @@
 Bump together with the package versions in */pyproject.toml and
 browser-node/package.json during release prep.
 """
+
 __version__ = "1.5.0"

--- a/controller/app/vision_target.py
+++ b/controller/app/vision_target.py
@@ -150,7 +150,10 @@ class VisionTargeter:
         except (json.JSONDecodeError, IndexError) as exc:
             logger.warning("vision targeting: failed to parse response %r: %s", raw_text, exc)
             return {
-                "x": 0, "y": 0, "found": False, "confidence": 0.0,
+                "x": 0,
+                "y": 0,
+                "found": False,
+                "confidence": 0.0,
                 "description": f"parse error: {exc}",
                 "selector_hint": None,
                 "raw_response": raw_text,

--- a/controller/app/webhooks.py
+++ b/controller/app/webhooks.py
@@ -8,6 +8,7 @@ Signature: X-Webhook-Signature: sha256=<hex>
 The signature covers the raw request body using HMAC-SHA256 with
 APPROVAL_WEBHOOK_SECRET as the key (Slack-compatible format).
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -41,14 +42,7 @@ def _is_disallowed_webhook_host(host: str) -> bool:
         ip = ipaddress.ip_address(normalized)
     except ValueError:
         return False
-    return (
-        ip.is_loopback
-        or ip.is_private
-        or ip.is_link_local
-        or ip.is_unspecified
-        or ip.is_multicast
-        or ip.is_reserved
-    )
+    return ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_unspecified or ip.is_multicast or ip.is_reserved
 
 
 def _is_disallowed_webhook_url(webhook_url: str) -> bool:

--- a/controller/app/witness.py
+++ b/controller/app/witness.py
@@ -481,6 +481,4 @@ class WitnessRemoteClient:
         except Exception:
             payload = response.text
         detail = payload.get("detail") if isinstance(payload, dict) else str(payload)
-        raise RuntimeError(
-            f"Witness remote {operation} failed with HTTP {response.status_code}: {detail}"
-        )
+        raise RuntimeError(f"Witness remote {operation} failed with HTTP {response.status_code}: {detail}")

--- a/controller/app/workflow/engine.py
+++ b/controller/app/workflow/engine.py
@@ -8,6 +8,7 @@ Features:
   - Disk persistence under /data/workflows/
   - Async execution
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -30,6 +31,7 @@ _DEFAULT_WORKFLOWS_ROOT = Path("/data/workflows")
 # Step / Workflow definitions
 # ---------------------------------------------------------------------------
 
+
 class StepStatus(str, Enum):
     PENDING = "pending"
     RUNNING = "running"
@@ -41,13 +43,13 @@ class StepStatus(str, Enum):
 @dataclass
 class WorkflowStep:
     id: str
-    action: str                         # e.g. "browser.observe" or "approval.request"
+    action: str  # e.g. "browser.observe" or "approval.request"
     params: dict[str, Any] = field(default_factory=dict)
     depends_on: list[str] = field(default_factory=list)
     retry_max: int = 2
     retry_backoff_seconds: float = 3.0
     timeout_seconds: float = 120.0
-    condition: str = ""                 # Python-like expression (not eval'd; reserved for future)
+    condition: str = ""  # Python-like expression (not eval'd; reserved for future)
 
 
 @dataclass
@@ -79,6 +81,7 @@ _TEMPLATE_RE = re.compile(r"\{\{\s*context\.(\w+(?:\.\w+)*)\s*\}\}")
 def _resolve_templates(value: Any, context: dict[str, Any]) -> Any:
     """Recursively replace {{ context.key }} in strings."""
     if isinstance(value, str):
+
         def replacer(m: re.Match) -> str:
             key_path = m.group(1).split(".")
             v = context
@@ -88,6 +91,7 @@ def _resolve_templates(value: Any, context: dict[str, Any]) -> Any:
                 else:
                     return ""
             return str(v)
+
         return _TEMPLATE_RE.sub(replacer, value)
     if isinstance(value, dict):
         return {k: _resolve_templates(v, context) for k, v in value.items()}
@@ -99,6 +103,7 @@ def _resolve_templates(value: Any, context: dict[str, Any]) -> Any:
 # ---------------------------------------------------------------------------
 # Workflow engine
 # ---------------------------------------------------------------------------
+
 
 class WorkflowEngine:
     """
@@ -191,10 +196,7 @@ class WorkflowEngine:
                 break
 
         if failed:
-            raise RuntimeError(
-                f"Workflow {run.workflow_id!r}: steps failed: {sorted(failed)}"
-            )
-
+            raise RuntimeError(f"Workflow {run.workflow_id!r}: steps failed: {sorted(failed)}")
 
     async def _run_step(self, step: WorkflowStep, run: WorkflowRun) -> None:
         run.step_statuses[step.id] = StepStatus.RUNNING
@@ -223,19 +225,24 @@ class WorkflowEngine:
                 last_exc = TimeoutError(f"Step {step.id!r} timed out after {step.timeout_seconds}s")
                 logger.warning(
                     "workflow.step %r attempt %d/%d timed out",
-                    step.id, attempt + 1, step.retry_max + 1,
+                    step.id,
+                    attempt + 1,
+                    step.retry_max + 1,
                 )
                 if attempt < step.retry_max:
-                    backoff = step.retry_backoff_seconds * (2 ** attempt)
+                    backoff = step.retry_backoff_seconds * (2**attempt)
                     await asyncio.sleep(backoff)
             except Exception as exc:
                 last_exc = exc
                 logger.warning(
                     "workflow.step %r attempt %d/%d failed: %s",
-                    step.id, attempt + 1, step.retry_max + 1, exc,
+                    step.id,
+                    attempt + 1,
+                    step.retry_max + 1,
+                    exc,
                 )
                 if attempt < step.retry_max:
-                    backoff = step.retry_backoff_seconds * (2 ** attempt)
+                    backoff = step.retry_backoff_seconds * (2**attempt)
                     await asyncio.sleep(backoff)
 
         run.step_statuses[step.id] = StepStatus.FAILED

--- a/controller/conftest.py
+++ b/controller/conftest.py
@@ -1,4 +1,5 @@
 """pytest configuration — ensure app package is importable from tests."""
+
 import sys
 from pathlib import Path
 

--- a/controller/tests/test_1_0.py
+++ b/controller/tests/test_1_0.py
@@ -7,6 +7,7 @@ Covers: mesh (identity, peers, policy, transport, delegation),
 
 Run with: pytest tests/test_1_0.py -v
 """
+
 from __future__ import annotations
 
 import json
@@ -25,15 +26,18 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Mesh — Identity
 # ===========================================================================
 
+
 class TestMeshIdentity:
     def test_generates_keypair(self, tmp_path):
         from app.mesh.identity import NodeIdentity
+
         ident = NodeIdentity(tmp_path / "identity")
         assert len(ident.node_id) == 64  # hex SHA-256
         assert len(ident.pubkey_b64) == 44  # base64 of 32 bytes
 
     def test_node_id_stable_across_loads(self, tmp_path):
         from app.mesh.identity import NodeIdentity
+
         d = tmp_path / "identity"
         i1 = NodeIdentity(d)
         i2 = NodeIdentity(d)
@@ -42,6 +46,7 @@ class TestMeshIdentity:
 
     def test_sign_verify_roundtrip(self, tmp_path):
         from app.mesh.identity import NodeIdentity
+
         ident = NodeIdentity(tmp_path / "identity")
         data = b"hello mesh"
         sig = ident.sign(data)
@@ -50,6 +55,7 @@ class TestMeshIdentity:
 
     def test_tamper_detection(self, tmp_path):
         from app.mesh.identity import NodeIdentity
+
         d = tmp_path / "identity"
         NodeIdentity(d)  # generate
         # Corrupt the meta file
@@ -60,6 +66,7 @@ class TestMeshIdentity:
 
     def test_sign_detects_tampering(self, tmp_path):
         from app.mesh.identity import NodeIdentity
+
         ident = NodeIdentity(tmp_path / "identity")
         data = b"hello"
         sig = ident.sign(data)
@@ -72,9 +79,11 @@ class TestMeshIdentity:
 # Mesh — Peers
 # ===========================================================================
 
+
 class TestMeshPeers:
     def _make_peer(self, node_id: str = "abc123"):
         from app.mesh.models import PeerRecord
+
         return PeerRecord(
             node_id=node_id,
             pubkey_b64="A" * 44,
@@ -83,6 +92,7 @@ class TestMeshPeers:
 
     def test_add_and_get(self, tmp_path):
         from app.mesh.peers import PeerRegistryFile
+
         reg = PeerRegistryFile(tmp_path / "peers.json")
         peer = self._make_peer()
         reg.add(peer)
@@ -90,17 +100,20 @@ class TestMeshPeers:
 
     def test_unknown_peer_raises(self, tmp_path):
         from app.mesh.peers import PeerRegistryFile
+
         reg = PeerRegistryFile(tmp_path / "peers.json")
         with pytest.raises(KeyError):
             reg.get("nonexistent")
 
     def test_get_optional_returns_none(self, tmp_path):
         from app.mesh.peers import PeerRegistryFile
+
         reg = PeerRegistryFile(tmp_path / "peers.json")
         assert reg.get_optional("nonexistent") is None
 
     def test_remove(self, tmp_path):
         from app.mesh.peers import PeerRegistryFile
+
         reg = PeerRegistryFile(tmp_path / "peers.json")
         peer = self._make_peer()
         reg.add(peer)
@@ -109,6 +122,7 @@ class TestMeshPeers:
 
     def test_persists_across_instances(self, tmp_path):
         from app.mesh.peers import PeerRegistryFile
+
         path = tmp_path / "peers.json"
         reg1 = PeerRegistryFile(path)
         reg1.add(self._make_peer("node1"))
@@ -118,6 +132,7 @@ class TestMeshPeers:
 
     def test_hot_reload(self, tmp_path):
         from app.mesh.peers import PeerRegistryFile
+
         path = tmp_path / "peers.json"
         reg1 = PeerRegistryFile(path)
         reg1.add(self._make_peer("node1"))
@@ -135,9 +150,11 @@ class TestMeshPeers:
 # Mesh — Policy
 # ===========================================================================
 
+
 class TestMeshPolicy:
     def _make_peer(self, grants=None):
         from app.mesh.models import PeerRecord
+
         return PeerRecord(
             node_id="peer1",
             pubkey_b64="A" * 44,
@@ -146,14 +163,17 @@ class TestMeshPolicy:
 
     def _make_request(self, capability="tool:browser.click", arguments=None):
         from app.mesh.models import DelegationRequest
+
         return DelegationRequest(capability=capability, arguments=arguments or {})
 
     def _make_grant(self, capability, **kwargs):
         from app.mesh.models import CapabilityGrant
+
         return CapabilityGrant(capability=capability, **kwargs)
 
     def test_default_deny_no_grants(self):
         from app.mesh.policy import PolicyDenied, PolicyEvaluator
+
         ev = PolicyEvaluator()
         peer = self._make_peer()
         with pytest.raises(PolicyDenied):
@@ -161,6 +181,7 @@ class TestMeshPolicy:
 
     def test_exact_match_permit(self):
         from app.mesh.policy import PolicyEvaluator
+
         grant = self._make_grant("tool:browser.click")
         peer = self._make_peer([grant])
         ev = PolicyEvaluator()
@@ -169,6 +190,7 @@ class TestMeshPolicy:
 
     def test_wildcard_match(self):
         from app.mesh.policy import PolicyEvaluator
+
         grant = self._make_grant("tool:*")
         peer = self._make_peer([grant])
         ev = PolicyEvaluator()
@@ -177,6 +199,7 @@ class TestMeshPolicy:
 
     def test_expires_at_rejected(self):
         from app.mesh.policy import PolicyEvaluator, PolicyExpired
+
         grant = self._make_grant("tool:*", expires_at=time.time() - 1)
         peer = self._make_peer([grant])
         ev = PolicyEvaluator()
@@ -185,6 +208,7 @@ class TestMeshPolicy:
 
     def test_expires_at_future_ok(self):
         from app.mesh.policy import PolicyEvaluator
+
         grant = self._make_grant("tool:*", expires_at=time.time() + 3600)
         peer = self._make_peer([grant])
         ev = PolicyEvaluator()
@@ -193,6 +217,7 @@ class TestMeshPolicy:
 
     def test_url_allowlist_permit(self):
         from app.mesh.policy import PolicyEvaluator
+
         grant = self._make_grant("tool:*", url_allowlist=["*example.com*"])
         peer = self._make_peer([grant])
         ev = PolicyEvaluator()
@@ -202,6 +227,7 @@ class TestMeshPolicy:
 
     def test_url_allowlist_deny(self):
         from app.mesh.policy import PolicyDenied, PolicyEvaluator
+
         grant = self._make_grant("tool:*", url_allowlist=["*example.com*"])
         peer = self._make_peer([grant])
         ev = PolicyEvaluator()
@@ -211,6 +237,7 @@ class TestMeshPolicy:
 
     def test_rate_limit_enforcement(self):
         from app.mesh.policy import PolicyEvaluator, PolicyRateLimited
+
         grant = self._make_grant("tool:limited", max_invocations_per_hour=2)
         peer = self._make_peer([grant])
         ev = PolicyEvaluator()
@@ -227,13 +254,16 @@ class TestMeshPolicy:
 # Mesh — Transport (envelope crypto)
 # ===========================================================================
 
+
 class TestMeshTransport:
     def _make_identity(self, tmp_path, subdir="id"):
         from app.mesh.identity import NodeIdentity
+
         return NodeIdentity(tmp_path / subdir)
 
     def _make_peer_from_identity(self, identity, endpoint="https://peer.example.com"):
         from app.mesh.models import PeerRecord
+
         return PeerRecord(
             node_id=identity.node_id,
             pubkey_b64=identity.pubkey_b64,
@@ -242,6 +272,7 @@ class TestMeshTransport:
 
     def test_make_and_verify_envelope(self, tmp_path):
         from app.mesh.transport import make_envelope, verify_envelope
+
         ident = self._make_identity(tmp_path)
         peer = self._make_peer_from_identity(ident)
         env = make_envelope(ident, {"action": "test"}, recipient_node_id="other")
@@ -250,6 +281,7 @@ class TestMeshTransport:
 
     def test_tampered_payload_rejected(self, tmp_path):
         from app.mesh.transport import EnvelopeVerificationError, make_envelope, verify_envelope
+
         ident = self._make_identity(tmp_path)
         peer = self._make_peer_from_identity(ident)
         env = make_envelope(ident, {"action": "test"})
@@ -260,6 +292,7 @@ class TestMeshTransport:
     def test_wrong_sender_rejected(self, tmp_path):
         from app.mesh.models import PeerRecord
         from app.mesh.transport import EnvelopeVerificationError, make_envelope, verify_envelope
+
         ident = self._make_identity(tmp_path)
         env = make_envelope(ident, {"action": "test"})
         wrong_peer = PeerRecord(node_id="wrong", pubkey_b64="A" * 44)
@@ -277,6 +310,7 @@ class TestMeshTransport:
 
     def test_truncated_signature_rejected(self, tmp_path):
         from app.mesh.transport import EnvelopeVerificationError, make_envelope, verify_envelope
+
         ident = self._make_identity(tmp_path)
         peer = self._make_peer_from_identity(ident)
         env = make_envelope(ident, {"x": 1})
@@ -288,6 +322,7 @@ class TestMeshTransport:
 # ===========================================================================
 # Mesh — Delegation
 # ===========================================================================
+
 
 class TestMeshDelegation:
     def _setup(self, tmp_path):
@@ -382,32 +417,39 @@ class TestMeshDelegation:
 # Stealth — Humanizer
 # ===========================================================================
 
+
 class TestStealth:
     def test_profile_off_is_none(self):
         from app.stealth.humanizer import PROFILES
+
         assert PROFILES["off"] is None
 
     def test_profile_light_is_human_profile(self):
         from app.stealth.humanizer import PROFILES, HumanProfile
+
         assert isinstance(PROFILES["light"], HumanProfile)
 
     def test_humanizer_inactive_when_off(self):
         from app.stealth.humanizer import Humanizer
+
         h = Humanizer("off")
         assert not h.active
 
     def test_humanizer_active_when_light(self):
         from app.stealth.humanizer import Humanizer
+
         h = Humanizer("light")
         assert h.active
 
     def test_bezier_points_count(self):
         from app.stealth.humanizer import _bezier_points
+
         pts = _bezier_points(0, 0, 100, 100, steps=20, jitter=5)
         assert len(pts) == 21  # steps + 1
 
     def test_bezier_starts_and_ends_near_target(self):
         from app.stealth.humanizer import _bezier_points
+
         pts = _bezier_points(0.0, 0.0, 100.0, 100.0, steps=30, jitter=0)
         # With zero jitter, start and end should be exact
         assert abs(pts[0][0]) < 1.0
@@ -415,6 +457,7 @@ class TestStealth:
 
     def test_fingerprint_stable_within_session(self):
         from app.stealth.fingerprint import FingerprintConfig
+
         c1 = FingerprintConfig("session-abc", "light")
         c2 = FingerprintConfig("session-abc", "light")
         assert c1.user_agent == c2.user_agent
@@ -422,12 +465,14 @@ class TestStealth:
 
     def test_fingerprint_differs_across_sessions(self):
         from app.stealth.fingerprint import FingerprintConfig
+
         configs = [FingerprintConfig(f"session-{i}", "light") for i in range(10)]
         ua_set = {c.user_agent for c in configs}
         assert len(ua_set) > 1  # should vary
 
     def test_init_script_contains_webdriver_mask(self):
         from app.stealth.fingerprint import FingerprintConfig
+
         c = FingerprintConfig("test-session")
         script = c.init_script()
         assert "webdriver" in script
@@ -439,20 +484,24 @@ class TestStealth:
 # with hook registration grafted on in v1.0)
 # ===========================================================================
 
+
 class TestNetworkInspector:
     def test_empty_buffer(self):
         from app.network_inspector import NetworkInspector
+
         insp = NetworkInspector(session_id="s1")
         assert insp.entries() == []
 
     def test_register_and_list_hooks(self):
         from app.network_inspector import NetworkInspector
+
         insp = NetworkInspector(session_id="s1")
         insp.register_hook("*api*", AsyncMock())
         assert "*api*" in insp.list_hooks()
 
     def test_remove_hook(self):
         from app.network_inspector import NetworkInspector
+
         insp = NetworkInspector(session_id="s1")
         insp.register_hook("*api*", AsyncMock())
         assert insp.remove_hook("*api*")
@@ -460,6 +509,7 @@ class TestNetworkInspector:
 
     def test_clear(self):
         from app.network_inspector import NetworkInspector
+
         insp = NetworkInspector(session_id="s1")
         insp.clear()
         assert insp.entries() == []
@@ -469,15 +519,16 @@ class TestNetworkInspector:
 # DOM Pruner
 # ===========================================================================
 
+
 class TestDOMPruner:
     def _make_elements(self, n: int) -> list[dict]:
         return [
-            {"element_id": f"el-{i}", "role": "button", "text": f"Button {i}", "is_visible": True}
-            for i in range(n)
+            {"element_id": f"el-{i}", "role": "button", "text": f"Button {i}", "is_visible": True} for i in range(n)
         ]
 
     def test_prune_returns_limit(self):
         from app.browser.dom_pruner import DOMPruner
+
         pruner = DOMPruner(max_elements=10)
         elements = self._make_elements(50)
         pruned = pruner.prune(elements, task_goal="click the submit button")
@@ -485,11 +536,13 @@ class TestDOMPruner:
 
     def test_prune_empty_input(self):
         from app.browser.dom_pruner import DOMPruner
+
         pruner = DOMPruner(max_elements=10)
         assert pruner.prune([]) == []
 
     def test_prune_under_limit_unchanged(self):
         from app.browser.dom_pruner import DOMPruner
+
         pruner = DOMPruner(max_elements=20)
         elements = self._make_elements(5)
         pruned = pruner.prune(elements)
@@ -497,6 +550,7 @@ class TestDOMPruner:
 
     def test_keyword_match_boosts_rank(self):
         from app.browser.dom_pruner import DOMPruner
+
         pruner = DOMPruner(max_elements=3)
         elements = [
             {"element_id": "login-btn", "role": "button", "text": "Login", "is_visible": True},
@@ -509,6 +563,7 @@ class TestDOMPruner:
 
     def test_hidden_elements_deprioritized(self):
         from app.browser.dom_pruner import DOMPruner
+
         pruner = DOMPruner(max_elements=1)
         elements = [
             {"element_id": "hidden", "role": "button", "text": "Hidden", "is_visible": False},
@@ -519,6 +574,7 @@ class TestDOMPruner:
 
     def test_recency_boost(self):
         from app.browser.dom_pruner import DOMPruner
+
         pruner = DOMPruner(max_elements=1)
         elements = [
             {"element_id": "recent", "role": "link", "text": "Link"},
@@ -530,6 +586,7 @@ class TestDOMPruner:
 
     def test_prune_observation(self):
         from app.browser.dom_pruner import DOMPruner
+
         pruner = DOMPruner(max_elements=5)
         obs = {"interactable_elements": self._make_elements(30), "url": "https://example.com"}
         result = pruner.prune_observation(obs, task_goal="submit form")
@@ -541,6 +598,7 @@ class TestDOMPruner:
 # ===========================================================================
 # Workflow Engine
 # ===========================================================================
+
 
 class TestWorkflowEngine:
     async def test_simple_workflow(self, tmp_path):
@@ -556,8 +614,7 @@ class TestWorkflowEngine:
         engine.register_action("test.step", handler)
 
         steps = [{"id": "s1", "action": "test.step", "params": {"key": "value"}}]
-        run = await engine.run("test_wf", steps, {"initial": "ctx"}
-        )
+        run = await engine.run("test_wf", steps, {"initial": "ctx"})
         assert run.status.value == "completed"
         assert run.step_statuses["s1"].value == "completed"
 
@@ -571,6 +628,7 @@ class TestWorkflowEngine:
 
     async def test_dependency_ordering(self, tmp_path):
         from app.workflow.engine import WorkflowEngine
+
         order = []
 
         async def handler(action: str, params: dict, ctx: dict) -> dict:
@@ -590,6 +648,7 @@ class TestWorkflowEngine:
 
     async def test_missing_action_fails_run(self, tmp_path):
         from app.workflow.engine import WorkflowEngine
+
         engine = WorkflowEngine(workflows_root=tmp_path / "workflows")
         steps = [{"id": "x", "action": "unregistered.action"}]
         run = await engine.run("fail_test", steps)
@@ -597,6 +656,7 @@ class TestWorkflowEngine:
 
     async def test_retry_on_transient_failure(self, tmp_path):
         from app.workflow.engine import WorkflowEngine
+
         call_count = [0]
 
         async def flaky(action, params, ctx):
@@ -614,6 +674,7 @@ class TestWorkflowEngine:
 
     async def test_persists_to_disk(self, tmp_path):
         from app.workflow.engine import WorkflowEngine
+
         engine = WorkflowEngine(workflows_root=tmp_path / "wf")
         engine.register_action("x", AsyncMock(return_value={}))
         steps = [{"id": "s", "action": "x"}]
@@ -626,39 +687,46 @@ class TestWorkflowEngine:
 # Skills Curator LLM adapter
 # ===========================================================================
 
+
 class TestCuratorLLMAdapter:
     def test_invalid_provider_rejected(self):
         import pytest
 
         from app.curator_llm import CuratorLLMAdapter
+
         with pytest.raises(ValueError):
             CuratorLLMAdapter("nonsense")
 
     def test_ready_false_without_api_key(self, monkeypatch):
         from app.curator_llm import CuratorLLMAdapter
+
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         adapter = CuratorLLMAdapter("claude")
         assert adapter.ready is False
 
     def test_ready_true_with_api_key(self, monkeypatch):
         from app.curator_llm import CuratorLLMAdapter
+
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         adapter = CuratorLLMAdapter("claude")
         assert adapter.ready is True
 
     def test_default_models_per_provider(self):
         from app.curator_llm import CuratorLLMAdapter
+
         assert CuratorLLMAdapter("claude").model.startswith("claude")
         assert CuratorLLMAdapter("openai").model.startswith("gpt")
         assert CuratorLLMAdapter("gemini").model.startswith("gemini")
 
     def test_api_key_env_override(self):
         from app.curator_llm import CuratorLLMAdapter
+
         adapter = CuratorLLMAdapter("claude", api_key_env="CUSTOM_KEY")
         assert adapter._api_key_env() == "CUSTOM_KEY"
 
     def test_build_curator_adapter_returns_none_without_key(self, monkeypatch):
         from app.curator_llm import build_curator_adapter
+
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)

--- a/controller/tests/test_agent_eval.py
+++ b/controller/tests/test_agent_eval.py
@@ -62,7 +62,9 @@ class AgentEvalTests(unittest.TestCase):
             self.assertEqual(score.score, 1.0)
             self.assertEqual(summary["openai/fast"]["successes"], 1)
             self.assertEqual(plan_payload(matrix)["runs"][0]["result_file"], "case-1__openai__fast.json")
-            self.assertIn("| case-1 | openai | fast | PASS | 1.0000 | - |", render_markdown_report(matrix, scores=[score]))
+            self.assertIn(
+                "| case-1 | openai | fast | PASS | 1.0000 | - |", render_markdown_report(matrix, scores=[score])
+            )
             self.assertIn("Planned runs: 2", render_markdown_report(matrix))
 
     def test_score_from_result_dir_marks_missing_results_failed(self) -> None:

--- a/controller/tests/test_agent_http.py
+++ b/controller/tests/test_agent_http.py
@@ -123,7 +123,14 @@ class AgentHttpTests(unittest.TestCase):
         self.assertEqual(
             response.json(),
             [
-                {"provider": "openai", "configured": True, "model": "gpt-4.1-mini", "auth_mode": "api", "detail": None, "login_command": None},
+                {
+                    "provider": "openai",
+                    "configured": True,
+                    "model": "gpt-4.1-mini",
+                    "auth_mode": "api",
+                    "detail": None,
+                    "login_command": None,
+                },
                 {
                     "provider": "claude",
                     "configured": False,
@@ -294,7 +301,9 @@ class AgentHttpTests(unittest.TestCase):
                 "approve": {"id": "approval-1", "status": "approved"},
                 "reject": {"id": "approval-1", "status": "rejected"},
                 "execute_approval": {"id": "approval-1", "status": "executed"},
-                "get_session": SimpleNamespace(page=SimpleNamespace(url="https://example.com"), trace_path=Path("missing.zip")),
+                "get_session": SimpleNamespace(
+                    page=SimpleNamespace(url="https://example.com"), trace_path=Path("missing.zip")
+                ),
                 "get_network_log": {"entries": []},
                 "fork_session": {"id": "fork-1"},
                 "enable_shadow_browse": {"enabled": True},
@@ -323,10 +332,20 @@ class AgentHttpTests(unittest.TestCase):
             for target, methods in async_methods.items():
                 for name, result in methods.items():
                     stack.enter_context(patch.object(target, name, new=AsyncMock(return_value=result)))
-            stack.enter_context(patch.object(main_module.manager, "get_remote_access_info", return_value={"active": False}))
-            stack.enter_context(patch.object(main_module.manager, "get_pii_scrubber_status", return_value={"enabled": True}))
-            stack.enter_context(patch.object(main_module.share_manager, "create_token", return_value={"token": "share"}))
-            stack.enter_context(patch.object(main_module.share_manager, "token_info", return_value={"valid": True, "session_id": "session-1"}))
+            stack.enter_context(
+                patch.object(main_module.manager, "get_remote_access_info", return_value={"active": False})
+            )
+            stack.enter_context(
+                patch.object(main_module.manager, "get_pii_scrubber_status", return_value={"enabled": True})
+            )
+            stack.enter_context(
+                patch.object(main_module.share_manager, "create_token", return_value={"token": "share"})
+            )
+            stack.enter_context(
+                patch.object(
+                    main_module.share_manager, "token_info", return_value={"valid": True, "session_id": "session-1"}
+                )
+            )
             stack.enter_context(patch.object(main_module.proxy_store, "list_personas", return_value=[]))
             stack.enter_context(patch.object(main_module.proxy_store, "set_persona", return_value={"name": "us-east"}))
             stack.enter_context(patch.object(main_module.proxy_store, "get_persona", return_value={"name": "us-east"}))
@@ -406,7 +425,11 @@ class AgentHttpTests(unittest.TestCase):
 
             for method, path, payload in requests:
                 with self.subTest(path=path):
-                    response = getattr(self.client, method)(path, json=payload) if payload is not None else getattr(self.client, method)(path)
+                    response = (
+                        getattr(self.client, method)(path, json=payload)
+                        if payload is not None
+                        else getattr(self.client, method)(path)
+                    )
                     self.assertLess(response.status_code, 400, response.text)
 
     def test_replay_export_and_public_error_edges(self) -> None:
@@ -458,21 +481,69 @@ class AgentHttpTests(unittest.TestCase):
     def test_http_error_mappings_are_stable(self) -> None:
         cases = [
             (main_module.manager, "ensure_browser", Exception("down"), "get", "/readyz", None, 503),
-            (main_module.manager, "get_session_record", KeyError("missing"), "get", "/remote-access?session_id=missing", None, 404),
-            (main_module.manager, "approve", PermissionError("conflict"), "post", "/approvals/a/approve", {"comment": "ok"}, 409),
-            (main_module.manager, "reject", PermissionError("conflict"), "post", "/approvals/a/reject", {"comment": "no"}, 409),
-            (main_module.manager, "execute_approval", PermissionError("conflict"), "post", "/approvals/a/execute", None, 409),
+            (
+                main_module.manager,
+                "get_session_record",
+                KeyError("missing"),
+                "get",
+                "/remote-access?session_id=missing",
+                None,
+                404,
+            ),
+            (
+                main_module.manager,
+                "approve",
+                PermissionError("conflict"),
+                "post",
+                "/approvals/a/approve",
+                {"comment": "ok"},
+                409,
+            ),
+            (
+                main_module.manager,
+                "reject",
+                PermissionError("conflict"),
+                "post",
+                "/approvals/a/reject",
+                {"comment": "no"},
+                409,
+            ),
+            (
+                main_module.manager,
+                "execute_approval",
+                PermissionError("conflict"),
+                "post",
+                "/approvals/a/execute",
+                None,
+                409,
+            ),
             (main_module.manager, "execute_approval", ValueError("bad"), "post", "/approvals/a/execute", None, 400),
             (main_module.manager, "execute_approval", Exception("boom"), "post", "/approvals/a/execute", None, 500),
             (main_module.manager, "create_session", ValueError("bad"), "post", "/sessions", {"name": "s"}, 400),
-            (main_module.manager, "create_session", FileNotFoundError("missing"), "post", "/sessions", {"name": "s"}, 404),
+            (
+                main_module.manager,
+                "create_session",
+                FileNotFoundError("missing"),
+                "post",
+                "/sessions",
+                {"name": "s"},
+                404,
+            ),
             (main_module.manager, "create_session", PermissionError("no"), "post", "/sessions", {"name": "s"}, 403),
             (main_module.manager, "create_session", RuntimeError("busy"), "post", "/sessions", {"name": "s"}, 409),
             (main_module.manager, "create_session", Exception("boom"), "post", "/sessions", {"name": "s"}, 500),
             (main_module.manager, "get_auth_profile", ValueError("bad"), "get", "/auth-profiles/bad", None, 400),
             (main_module.manager, "observe", KeyError("missing"), "get", "/sessions/s/observe", None, 404),
             (main_module.manager, "observe", Exception("boom"), "post", "/sessions/s/observe", {"limit": 1}, 500),
-            (main_module.manager, "activate_tab", ValueError("bad"), "post", "/sessions/s/tabs/activate", {"index": 99}, 400),
+            (
+                main_module.manager,
+                "activate_tab",
+                ValueError("bad"),
+                "post",
+                "/sessions/s/tabs/activate",
+                {"index": 99},
+                400,
+            ),
             (main_module.manager, "close_tab", ValueError("bad"), "post", "/sessions/s/tabs/close", {"index": 99}, 400),
             (
                 main_module.manager,
@@ -501,7 +572,15 @@ class AgentHttpTests(unittest.TestCase):
                 {"url": "https://example.com"},
                 500,
             ),
-            (main_module.manager, "click", ValueError("bad"), "post", "/sessions/s/actions/click", {"selector": "button"}, 400),
+            (
+                main_module.manager,
+                "click",
+                ValueError("bad"),
+                "post",
+                "/sessions/s/actions/click",
+                {"selector": "button"},
+                400,
+            ),
             (
                 main_module.manager,
                 "click",
@@ -511,7 +590,15 @@ class AgentHttpTests(unittest.TestCase):
                 {"selector": "button"},
                 403,
             ),
-            (main_module.manager, "click", Exception("boom"), "post", "/sessions/s/actions/click", {"selector": "button"}, 500),
+            (
+                main_module.manager,
+                "click",
+                Exception("boom"),
+                "post",
+                "/sessions/s/actions/click",
+                {"selector": "button"},
+                500,
+            ),
             (
                 main_module.manager,
                 "type",
@@ -539,10 +626,42 @@ class AgentHttpTests(unittest.TestCase):
                 {"selector": "input", "text": "hi"},
                 500,
             ),
-            (main_module.manager, "press", PermissionError("no"), "post", "/sessions/s/actions/press", {"key": "Enter"}, 403),
-            (main_module.manager, "press", Exception("boom"), "post", "/sessions/s/actions/press", {"key": "Enter"}, 500),
-            (main_module.manager, "scroll", PermissionError("no"), "post", "/sessions/s/actions/scroll", {"delta_y": 1}, 403),
-            (main_module.manager, "scroll", Exception("boom"), "post", "/sessions/s/actions/scroll", {"delta_y": 1}, 500),
+            (
+                main_module.manager,
+                "press",
+                PermissionError("no"),
+                "post",
+                "/sessions/s/actions/press",
+                {"key": "Enter"},
+                403,
+            ),
+            (
+                main_module.manager,
+                "press",
+                Exception("boom"),
+                "post",
+                "/sessions/s/actions/press",
+                {"key": "Enter"},
+                500,
+            ),
+            (
+                main_module.manager,
+                "scroll",
+                PermissionError("no"),
+                "post",
+                "/sessions/s/actions/scroll",
+                {"delta_y": 1},
+                403,
+            ),
+            (
+                main_module.manager,
+                "scroll",
+                Exception("boom"),
+                "post",
+                "/sessions/s/actions/scroll",
+                {"delta_y": 1},
+                500,
+            ),
             (
                 main_module.manager,
                 "execute_decision",
@@ -606,7 +725,15 @@ class AgentHttpTests(unittest.TestCase):
                 {"selector": "input", "file_path": "missing.txt"},
                 500,
             ),
-            (main_module.manager, "hover", ValueError("bad"), "post", "/sessions/s/actions/hover", {"selector": "button"}, 400),
+            (
+                main_module.manager,
+                "hover",
+                ValueError("bad"),
+                "post",
+                "/sessions/s/actions/hover",
+                {"selector": "button"},
+                400,
+            ),
             (
                 main_module.manager,
                 "hover",
@@ -616,7 +743,15 @@ class AgentHttpTests(unittest.TestCase):
                 {"selector": "button"},
                 403,
             ),
-            (main_module.manager, "hover", Exception("boom"), "post", "/sessions/s/actions/hover", {"selector": "button"}, 500),
+            (
+                main_module.manager,
+                "hover",
+                Exception("boom"),
+                "post",
+                "/sessions/s/actions/hover",
+                {"selector": "button"},
+                500,
+            ),
             (
                 main_module.manager,
                 "select_option",
@@ -650,7 +785,15 @@ class AgentHttpTests(unittest.TestCase):
             (main_module.manager, "reload", Exception("boom"), "post", "/sessions/s/actions/reload", None, 500),
             (main_module.manager, "go_back", PermissionError("no"), "post", "/sessions/s/actions/go-back", None, 403),
             (main_module.manager, "go_back", Exception("boom"), "post", "/sessions/s/actions/go-back", None, 500),
-            (main_module.manager, "go_forward", PermissionError("no"), "post", "/sessions/s/actions/go-forward", None, 403),
+            (
+                main_module.manager,
+                "go_forward",
+                PermissionError("no"),
+                "post",
+                "/sessions/s/actions/go-forward",
+                None,
+                403,
+            ),
             (main_module.manager, "go_forward", Exception("boom"), "post", "/sessions/s/actions/go-forward", None, 500),
             (
                 main_module.manager,
@@ -680,7 +823,15 @@ class AgentHttpTests(unittest.TestCase):
                 403,
             ),
             (main_module.manager, "fork_session", RuntimeError("busy"), "post", "/sessions/s/fork", None, 409),
-            (main_module.manager, "enable_shadow_browse", RuntimeError("bad"), "post", "/sessions/s/shadow-browse", None, 400),
+            (
+                main_module.manager,
+                "enable_shadow_browse",
+                RuntimeError("bad"),
+                "post",
+                "/sessions/s/shadow-browse",
+                None,
+                400,
+            ),
         ]
 
         with patch.object(main_module, "rate_limiter", None):
@@ -808,7 +959,11 @@ class AgentHttpTests(unittest.TestCase):
 
         for method, path, body in endpoints:
             with self.subTest(path=path):
-                response = getattr(self.client, method)(path, json=body) if body is not None else getattr(self.client, method)(path)
+                response = (
+                    getattr(self.client, method)(path, json=body)
+                    if body is not None
+                    else getattr(self.client, method)(path)
+                )
                 self.assertEqual(response.status_code, 404)
 
 

--- a/controller/tests/test_approvals.py
+++ b/controller/tests/test_approvals.py
@@ -143,6 +143,7 @@ class ApprovalQueueTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(approved.id, approval.id)
 
+
 class ApprovalStoreSQLiteTests(unittest.IsolatedAsyncioTestCase):
     async def test_sqlite_store_persists_and_filters_records(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/controller/tests/test_auth_profile_security.py
+++ b/controller/tests/test_auth_profile_security.py
@@ -10,6 +10,7 @@ These tests pin the *rejection* behaviour, which is the part that matters: a
 guard that stops rejecting still passes every happy-path test. Each test names
 the attack it prevents.
 """
+
 from __future__ import annotations
 
 import io

--- a/controller/tests/test_auth_state.py
+++ b/controller/tests/test_auth_state.py
@@ -60,6 +60,7 @@ class AuthStateManagerTests(unittest.IsolatedAsyncioTestCase):
 
             old_timestamp = state_path.stat().st_mtime - 3600
             import os
+
             os.utime(state_path, (old_timestamp, old_timestamp))
 
             info = manager.inspect(state_path)

--- a/controller/tests/test_browser_manager_create_session.py
+++ b/controller/tests/test_browser_manager_create_session.py
@@ -112,7 +112,9 @@ class BrowserManagerCreateSessionTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             await self.manager.create_session(storage_state_path="state.json", auth_profile="ops")
         with self.assertRaises(ValueError):
-            await self.manager.create_session(proxy_persona="east", request_proxy_server="http://proxy.example.com:8080")
+            await self.manager.create_session(
+                proxy_persona="east", request_proxy_server="http://proxy.example.com:8080"
+            )
 
     async def test_session_limit_message_mentions_shared_browser_mode(self) -> None:
         self.manager.settings.max_sessions = 1

--- a/controller/tests/test_curator_llm.py
+++ b/controller/tests/test_curator_llm.py
@@ -56,9 +56,7 @@ class CuratorLLMAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("OPENAI_API_KEY", joined)
 
     async def test_complete_builds_claude_request_and_extracts_text(self) -> None:
-        fake_client = _FakeAsyncClient(
-            _FakeResponse({"content": [{"type": "text", "text": "claude-output"}]})
-        )
+        fake_client = _FakeAsyncClient(_FakeResponse({"content": [{"type": "text", "text": "claude-output"}]}))
         adapter = CuratorLLMAdapter("claude", model="claude-test")
 
         with (
@@ -75,9 +73,7 @@ class CuratorLLMAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(body["messages"][0]["content"], "summarize this")
 
     async def test_complete_builds_openai_request_and_extracts_text(self) -> None:
-        fake_client = _FakeAsyncClient(
-            _FakeResponse({"choices": [{"message": {"content": "openai-output"}}]})
-        )
+        fake_client = _FakeAsyncClient(_FakeResponse({"choices": [{"message": {"content": "openai-output"}}]}))
         adapter = CuratorLLMAdapter("openai", model="gpt-test")
 
         with (

--- a/controller/tests/test_dashboard_security.py
+++ b/controller/tests/test_dashboard_security.py
@@ -14,7 +14,7 @@ class DashboardSecurityTests(unittest.TestCase):
         self.assertIn("discardAgentJob", _DASHBOARD_HTML)
         self.assertIn("cancelAgentJob", _DASHBOARD_HTML)
         self.assertNotIn("innerHTML", _DASHBOARD_HTML)
-        self.assertNotIn("onclick=\"removePeer", _DASHBOARD_HTML)
+        self.assertNotIn('onclick="removePeer', _DASHBOARD_HTML)
 
     def test_replay_view_present_and_renders_safely(self) -> None:
         # Panel + wiring exist.

--- a/controller/tests/test_downloads.py
+++ b/controller/tests/test_downloads.py
@@ -41,8 +41,7 @@ class DownloadCaptureServiceTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(len(session.downloads), 2)
 
             records = [
-                json.loads(line)
-                for line in (artifact_dir / "downloads.jsonl").read_text(encoding="utf-8").splitlines()
+                json.loads(line) for line in (artifact_dir / "downloads.jsonl").read_text(encoding="utf-8").splitlines()
             ]
             self.assertEqual([record["filename"] for record in records], [first["filename"], second["filename"]])
 

--- a/controller/tests/test_events_webhooks.py
+++ b/controller/tests/test_events_webhooks.py
@@ -83,7 +83,10 @@ class WebhookTests(unittest.IsolatedAsyncioTestCase):
         client = Mock()
         client.post = AsyncMock(return_value=Mock(status_code=200))
 
-        with patch.object(webhooks, "get_client", return_value=client), patch.object(webhooks.logger, "warning") as mock_warning:
+        with (
+            patch.object(webhooks, "get_client", return_value=client),
+            patch.object(webhooks.logger, "warning") as mock_warning,
+        ):
             blocked_urls = [
                 "http://127.0.0.1:8080/approval",
                 "http://[::1]/approval",
@@ -99,7 +102,6 @@ class WebhookTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(client.post.await_count, 0)
         self.assertEqual(mock_warning.call_count, len(blocked_urls))
-
 
 
 if __name__ == "__main__":

--- a/controller/tests/test_extended_features.py
+++ b/controller/tests/test_extended_features.py
@@ -8,6 +8,7 @@ Covers:
 - New config settings
 - New models (ObserveRequest, ImportAuthProfileRequest, ScreenshotDiffResponse)
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -31,6 +32,7 @@ from app.models import (
 from app.webhooks import _sign
 
 # ── Perception Preset Models ─────────────────────────────────────────────────
+
 
 class TestObserveRequest(unittest.TestCase):
     def test_default_preset_is_unset(self) -> None:
@@ -65,11 +67,13 @@ class TestObserveRequest(unittest.TestCase):
 
     def test_limit_too_large_raises(self) -> None:
         from pydantic import ValidationError
+
         with self.assertRaises(ValidationError):
             ObserveRequest(limit=201)
 
     def test_invalid_preset_raises(self) -> None:
         from pydantic import ValidationError
+
         with self.assertRaises(ValidationError):
             ObserveRequest(preset="turbo")  # type: ignore[arg-type]
 
@@ -102,6 +106,7 @@ class TestScreenshotDiffResponse(unittest.TestCase):
 
 
 # ── SSE Event Bus ─────────────────────────────────────────────────────────────
+
 
 class TestEventBus(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
@@ -165,6 +170,7 @@ class TestEventBus(unittest.IsolatedAsyncioTestCase):
 
 # ── Webhook Signing ────────────────────────────────────────────────────────────
 
+
 class TestWebhookSigning(unittest.TestCase):
     def test_sign_produces_sha256_prefix(self) -> None:
         sig = _sign(b'{"test":1}', "secret123")
@@ -183,13 +189,14 @@ class TestWebhookSigning(unittest.TestCase):
         self.assertNotEqual(sig1, sig2)
 
     def test_sign_matches_manual_hmac(self) -> None:
-        payload = b'hello'
+        payload = b"hello"
         secret = "webhook-secret"
         expected = "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
         self.assertEqual(_sign(payload, secret), expected)
 
 
 # ── Config: New Settings ─────────────────────────────────────────────────────
+
 
 class TestNewConfigSettings(unittest.TestCase):
     def test_approval_webhook_url_default_none(self) -> None:
@@ -234,6 +241,7 @@ class TestNewConfigSettings(unittest.TestCase):
 
 # ── Auth Export / Import ─────────────────────────────────────────────────────
 
+
 class TestAuthExportImport(unittest.TestCase):
     def test_export_creates_tar_gz(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -269,10 +277,12 @@ class TestAuthExportImport(unittest.TestCase):
 
 # ── Screenshot Diff ────────────────────────────────────────────────────────────
 
+
 class TestScreenshotDiff(unittest.TestCase):
     def _make_png(self, path: Path, color: tuple[int, int, int] = (0, 0, 0)) -> None:
         try:
             from PIL import Image
+
             img = Image.new("RGB", (100, 100), color=color)
             img.save(str(path))
         except ImportError:
@@ -283,9 +293,7 @@ class TestScreenshotDiff(unittest.TestCase):
             d = Path(tmp)
             self._make_png(d / "a.png", color=(0, 128, 255))
             self._make_png(d / "b.png", color=(0, 128, 255))
-            result = BrowserDiagnosticsService.compute_diff(
-                str(d / "a.png"), str(d / "b.png"), "/a.png", "/b.png", d
-            )
+            result = BrowserDiagnosticsService.compute_diff(str(d / "a.png"), str(d / "b.png"), "/a.png", "/b.png", d)
             self.assertEqual(result["changed_pixels"], 0)
             self.assertEqual(result["changed_pct"], 0.0)
 
@@ -294,9 +302,7 @@ class TestScreenshotDiff(unittest.TestCase):
             d = Path(tmp)
             self._make_png(d / "a.png", color=(0, 0, 0))
             self._make_png(d / "b.png", color=(255, 255, 255))
-            result = BrowserDiagnosticsService.compute_diff(
-                str(d / "a.png"), str(d / "b.png"), "/a.png", "/b.png", d
-            )
+            result = BrowserDiagnosticsService.compute_diff(str(d / "a.png"), str(d / "b.png"), "/a.png", "/b.png", d)
             self.assertGreater(result["changed_pixels"], 0)
             self.assertGreater(result["changed_pct"], 0.0)
             self.assertIsNotNone(result["diff_url"])

--- a/controller/tests/test_harness_contracts.py
+++ b/controller/tests/test_harness_contracts.py
@@ -76,10 +76,13 @@ class ProgrammaticVerifierTests(unittest.IsolatedAsyncioTestCase):
         result = await ProgrammaticVerifier().verify(contract, trace)
 
         self.assertTrue(result.passed)
-        self.assertEqual(result.satisfied_postconditions, [
-            "postcondition[0]:url_contains:example.com/checkout",
-            "postcondition[1]:text_contains:Order confirmed",
-        ])
+        self.assertEqual(
+            result.satisfied_postconditions,
+            [
+                "postcondition[0]:url_contains:example.com/checkout",
+                "postcondition[1]:text_contains:Order confirmed",
+            ],
+        )
         self.assertEqual(result.missing_evidence, [])
 
     async def test_programmatic_dom_condition_and_url_matches(self) -> None:
@@ -202,7 +205,9 @@ class UniversalVerifierAdapterTests(unittest.IsolatedAsyncioTestCase):
             postconditions=[{"kind": "url_contains", "value": "example.com"}],
             evidence_required=[EvidenceRequirement(kind="trace")],
         )
-        result = await UniversalVerifierAdapter().verify(contract, {"final_observation": {"url": "https://example.com"}})
+        result = await UniversalVerifierAdapter().verify(
+            contract, {"final_observation": {"url": "https://example.com"}}
+        )
 
         self.assertIsNone(result.passed)
         self.assertEqual(result.backend, "uv")

--- a/controller/tests/test_harness_run_cli.py
+++ b/controller/tests/test_harness_run_cli.py
@@ -4,6 +4,7 @@ The mock-observation flags are what make a convergence run deterministic
 offline, so their parsing is the difference between a reproducible local run
 and one that silently drops the operator's input.
 """
+
 from __future__ import annotations
 
 import argparse

--- a/controller/tests/test_harness_trace_induction.py
+++ b/controller/tests/test_harness_trace_induction.py
@@ -48,9 +48,7 @@ class TraceRecorderTests(unittest.TestCase):
             with closing(sqlite3.connect(Path(tmp) / "trace-index.sqlite3")) as conn:
                 indexes = {
                     row[1]
-                    for row in conn.execute(
-                        "SELECT type, name FROM sqlite_master WHERE type = 'index'"
-                    ).fetchall()
+                    for row in conn.execute("SELECT type, name FROM sqlite_master WHERE type = 'index'").fetchall()
                 }
             self.assertIn("idx_trace_events_run", indexes)
             self.assertIn("idx_trace_events_type", indexes)
@@ -88,7 +86,7 @@ class TraceRecorderTests(unittest.TestCase):
 
         self.assertNotIn("secret-token", payload_text)
         self.assertNotIn("session=secret", payload_text)
-        self.assertNotIn("api_key\": \"secret", payload_text)
+        self.assertNotIn('api_key": "secret', payload_text)
         self.assertIn("[REDACTED]", payload_text)
 
 
@@ -202,7 +200,9 @@ class SkillInducerTests(unittest.TestCase):
             self.assertIsNotNone(result.verification)
             assert result.verification is not None
             self.assertFalse(result.verification.passed)
-            drift = json.loads(Path(candidate.files["candidate.json"]).with_name("drift.json").read_text(encoding="utf-8"))
+            drift = json.loads(
+                Path(candidate.files["candidate.json"]).with_name("drift.json").read_text(encoding="utf-8")
+            )
             self.assertEqual(drift["status"], "degraded")
 
     def test_drift_monitor_ignores_tampered_recorded_artifact_paths(self) -> None:

--- a/controller/tests/test_mcp_resources_doc.py
+++ b/controller/tests/test_mcp_resources_doc.py
@@ -24,14 +24,19 @@ class McpResourcesDocTests(unittest.TestCase):
 
     def test_documented_resource_schemes_exist_in_code(self) -> None:
         for suffix in ("screenshot", "dom", "console", "network"):
-            self.assertIn(f'browser://{{session_id}}/{suffix}', self.transport, suffix)
+            self.assertIn(f"browser://{{session_id}}/{suffix}", self.transport, suffix)
             self.assertIn(f"browser://<session-id>/{suffix}", self.doc, suffix)
         self.assertIn('"browser://sessions"', self.transport)
         self.assertIn("browser://sessions", self.doc)
 
     def test_documented_methods_exist_in_code(self) -> None:
-        for method in ("resources/list", "resources/read", "resources/subscribe",
-                       "resources/unsubscribe", "notifications/resources/updated"):
+        for method in (
+            "resources/list",
+            "resources/read",
+            "resources/subscribe",
+            "resources/unsubscribe",
+            "notifications/resources/updated",
+        ):
             self.assertIn(method, self.transport, method)
             self.assertIn(method, self.doc, method)
 

--- a/controller/tests/test_observation_text_preset.py
+++ b/controller/tests/test_observation_text_preset.py
@@ -7,6 +7,7 @@ Covers:
   content AND screenshot PII scrubbing is not active
 - OCR is never skipped while PII scrubbing is active, regardless of the config knob
 """
+
 from __future__ import annotations
 
 import unittest

--- a/controller/tests/test_openai_compatible_provider.py
+++ b/controller/tests/test_openai_compatible_provider.py
@@ -61,7 +61,11 @@ def _tool_call_response(arguments: dict) -> FakeResponse:
         {
             "model": "test-model",
             "choices": [
-                {"message": {"tool_calls": [{"function": {"name": "browser_action", "arguments": json.dumps(arguments)}}]}}
+                {
+                    "message": {
+                        "tool_calls": [{"function": {"name": "browser_action", "arguments": json.dumps(arguments)}}]
+                    }
+                }
             ],
             "usage": {"total_tokens": 5},
         }
@@ -122,9 +126,7 @@ class OpenAICompatibleProviderTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(fake.calls[0]["url"], "https://api.minimax.io/v1/chat/completions")
 
     async def test_decide_falls_back_to_content_when_no_tool_call(self):
-        adapter = self._adapter(
-            "openrouter", openrouter_api_key="k", openrouter_model="anthropic/claude-3.7-sonnet"
-        )
+        adapter = self._adapter("openrouter", openrouter_api_key="k", openrouter_model="anthropic/claude-3.7-sonnet")
         fake = FakeAsyncClient(_content_response(json.dumps({"action": "done", "reason": "ok"})))
         with patch("app.providers.base.httpx.AsyncClient", return_value=fake):
             decision = await adapter.decide(goal="g", observation=self._observation())

--- a/controller/tests/test_playwright_export.py
+++ b/controller/tests/test_playwright_export.py
@@ -45,9 +45,7 @@ class PlaywrightExportHelperTests(unittest.TestCase):
             (
                 "open_tab",
                 {"url": "https://example.com/new"},
-                "tab = context.new_page()\n"
-                "tab.goto('https://example.com/new')\n"
-                "page = tab\n",
+                "tab = context.new_page()\ntab.goto('https://example.com/new')\npage = tab\n",
             ),
             ("open_tab", {}, "page = context.new_page()\n"),
             (

--- a/controller/tests/test_provider_base.py
+++ b/controller/tests/test_provider_base.py
@@ -22,8 +22,7 @@ from app.providers.openai_adapter import OpenAIAdapter
 
 def _decision_json(element_id: str = "e1") -> str:
     return (
-        '{"action": "click", "reason": "advance the task", '
-        f'"element_id": "{element_id}", "risk_category": "write"}}'
+        f'{{"action": "click", "reason": "advance the task", "element_id": "{element_id}", "risk_category": "write"}}'
     )
 
 
@@ -45,9 +44,7 @@ class ProviderReadinessHelperTests(unittest.TestCase):
         self.assertFalse(no_path[0])
         self.assertIn("not configured", no_path[1])
 
-        missing = BaseProviderAdapter.describe_socket_readiness(
-            socket_path="/nonexistent/socket.sock", label="bridge"
-        )
+        missing = BaseProviderAdapter.describe_socket_readiness(socket_path="/nonexistent/socket.sock", label="bridge")
         self.assertFalse(missing[0])
         self.assertIn("does not exist", missing[1])
 
@@ -90,9 +87,7 @@ class ProviderObservationPromptTests(unittest.TestCase):
             "session": "s1",
             "url": "https://example.com",
             "title": "Example",
-            "interactables": [
-                {"element_id": "e1", "label": "Submit", "role": "button", "extra": "dropme"}
-            ],
+            "interactables": [{"element_id": "e1", "label": "Submit", "role": "button", "extra": "dropme"}],
             "unexpected_top_level": "dropme",
         }
         compact = self.adapter.compact_observation(observation)

--- a/controller/tests/test_provider_cli.py
+++ b/controller/tests/test_provider_cli.py
@@ -26,7 +26,7 @@ class HealthzUnixSocketServer:
                 b"Content-Type: application/json\r\n"
                 b"Content-Length: 15\r\n"
                 b"Connection: close\r\n\r\n"
-                b"{\"status\":\"ok\"}"
+                b'{"status":"ok"}'
             )
 
     def __init__(self, socket_path: Path) -> None:
@@ -301,19 +301,13 @@ class ProviderCLITests(unittest.IsolatedAsyncioTestCase):
         self.touch(".gemini/config.json")
         with patch("app.providers.base.which", return_value="/usr/bin/fake"):
             self.assertTrue(
-                OpenAIAdapter(
-                    Settings(_env_file=None, OPENAI_AUTH_MODE="cli", CLI_HOME=self.tempdir.name)
-                ).configured
+                OpenAIAdapter(Settings(_env_file=None, OPENAI_AUTH_MODE="cli", CLI_HOME=self.tempdir.name)).configured
             )
             self.assertTrue(
-                ClaudeAdapter(
-                    Settings(_env_file=None, CLAUDE_AUTH_MODE="cli", CLI_HOME=self.tempdir.name)
-                ).configured
+                ClaudeAdapter(Settings(_env_file=None, CLAUDE_AUTH_MODE="cli", CLI_HOME=self.tempdir.name)).configured
             )
             self.assertTrue(
-                GeminiAdapter(
-                    Settings(_env_file=None, GEMINI_AUTH_MODE="cli", CLI_HOME=self.tempdir.name)
-                ).configured
+                GeminiAdapter(Settings(_env_file=None, GEMINI_AUTH_MODE="cli", CLI_HOME=self.tempdir.name)).configured
             )
 
     def test_cli_configured_requires_auth_state_when_cli_home_is_set(self) -> None:

--- a/controller/tests/test_readiness.py
+++ b/controller/tests/test_readiness.py
@@ -49,9 +49,7 @@ def test_warn_no_bearer() -> None:
 
 
 def test_fail_encryption_required_not_set() -> None:
-    report = run_readiness_checks(
-        _settings(auth_state_encryption_key=None, require_auth_state_encryption=True)
-    )
+    report = run_readiness_checks(_settings(auth_state_encryption_key=None, require_auth_state_encryption=True))
 
     assert report.overall == "fail"
 

--- a/controller/tests/test_remote_access.py
+++ b/controller/tests/test_remote_access.py
@@ -120,9 +120,7 @@ class RemoteAccessInfoTests(unittest.TestCase):
             json.dumps(
                 {
                     "status": "active",
-                    "updated_at": (
-                        datetime.now(UTC) - timedelta(seconds=90)
-                    ).isoformat().replace("+00:00", "Z"),
+                    "updated_at": (datetime.now(UTC) - timedelta(seconds=90)).isoformat().replace("+00:00", "Z"),
                     "stale_after_seconds": 10,
                     "public_api_url": "http://bastion.example.com:18000",
                     "public_takeover_url": "http://bastion.example.com:16080/vnc.html",

--- a/controller/tests/test_route_presence.py
+++ b/controller/tests/test_route_presence.py
@@ -18,6 +18,7 @@ Layer 3 matters on its own: since FastAPI 0.137 ``app.routes`` holds
 introspection and dispatch can diverge. Never enumerate ``app.routes`` expecting
 a ``.path`` attribute — use ``app.openapi()`` (layer 1) or a request (layer 3).
 """
+
 from __future__ import annotations
 
 import atexit

--- a/controller/tests/test_routes_extensions.py
+++ b/controller/tests/test_routes_extensions.py
@@ -134,8 +134,12 @@ class RoutesExtensionsTests(unittest.TestCase):
         self.assertEqual(client.get("/mesh/identity").json()["node_id"], "node-1")
 
         self.assertEqual(client.get("/sessions/session-1/cdp/element?selector=button").json()["selector"], "button")
-        self.assertEqual(client.post("/sessions/session-1/cdp/raw", json={"method": "Runtime.evaluate"}).status_code, 200)
-        self.assertEqual(client.post("/sessions/session-1/cdp/raw", json={"method": "Forbidden.command"}).status_code, 403)
+        self.assertEqual(
+            client.post("/sessions/session-1/cdp/raw", json={"method": "Runtime.evaluate"}).status_code, 200
+        )
+        self.assertEqual(
+            client.post("/sessions/session-1/cdp/raw", json={"method": "Forbidden.command"}).status_code, 403
+        )
 
         run = client.post("/workflows/run", json={"workflow_id": "fixture", "steps": []}).json()
         self.assertEqual(run["status"], "completed")

--- a/controller/tests/test_runtime_policy.py
+++ b/controller/tests/test_runtime_policy.py
@@ -20,7 +20,7 @@ class HealthzUnixSocketServer:
                 b"Content-Type: application/json\r\n"
                 b"Content-Length: 15\r\n"
                 b"Connection: close\r\n\r\n"
-                b"{\"status\":\"ok\"}"
+                b'{"status":"ok"}'
             )
 
     def __init__(self, socket_path: Path) -> None:
@@ -64,9 +64,7 @@ class RuntimePolicyTests(unittest.TestCase):
         )
 
     def test_development_no_bearer_warning_when_token_set(self) -> None:
-        settings = Settings(
-            _env_file=None, APP_ENV="development", API_BEARER_TOKEN="dev-token"
-        )
+        settings = Settings(_env_file=None, APP_ENV="development", API_BEARER_TOKEN="dev-token")
 
         report = validate_runtime_policy(settings)
 

--- a/controller/tests/test_session_share_proxy_store.py
+++ b/controller/tests/test_session_share_proxy_store.py
@@ -148,8 +148,9 @@ class ShareHttpTests(unittest.TestCase):
         get_session = AsyncMock(return_value=SimpleNamespace(id="session-1"))
         create_token = Mock(return_value={"token": "tok", "session_id": "session-1"})
 
-        with patch.object(main_module.manager, "get_session", get_session), patch.object(
-            main_module.share_manager, "create_token", create_token
+        with (
+            patch.object(main_module.manager, "get_session", get_session),
+            patch.object(main_module.share_manager, "create_token", create_token),
         ):
             response = self.client.post("/sessions/session-1/share")
 
@@ -169,8 +170,9 @@ class ShareHttpTests(unittest.TestCase):
         token_info = Mock(return_value={"valid": True, "session_id": "missing", "scope": SCOPE_OBSERVE})
         observe = AsyncMock(side_effect=KeyError("missing"))
 
-        with patch.object(main_module.share_manager, "token_info", token_info), patch.object(
-            main_module.manager, "observe", observe
+        with (
+            patch.object(main_module.share_manager, "token_info", token_info),
+            patch.object(main_module.manager, "observe", observe),
         ):
             response = self.client.get("/share/fake-token/observe")
 
@@ -190,8 +192,9 @@ class ShareHttpTests(unittest.TestCase):
         token_info = Mock(return_value={"valid": True, "session_id": "session-1", "scope": SCOPE_OBSERVE})
         get_session = AsyncMock(return_value=SimpleNamespace(id="session-1"))
 
-        with patch.object(main_module.share_manager, "token_info", token_info), patch.object(
-            main_module.manager, "get_session", get_session
+        with (
+            patch.object(main_module.share_manager, "token_info", token_info),
+            patch.object(main_module.manager, "get_session", get_session),
         ):
             response = self.client.get("/share/fake-token")
 
@@ -205,8 +208,9 @@ class ShareHttpTests(unittest.TestCase):
         token_info = Mock(return_value={"valid": True, "session_id": "missing", "scope": SCOPE_OBSERVE})
         get_session = AsyncMock(side_effect=KeyError("missing"))
 
-        with patch.object(main_module.share_manager, "token_info", token_info), patch.object(
-            main_module.manager, "get_session", get_session
+        with (
+            patch.object(main_module.share_manager, "token_info", token_info),
+            patch.object(main_module.manager, "get_session", get_session),
         ):
             response = self.client.get("/share/fake-token")
 

--- a/controller/tests/test_startup_extensions.py
+++ b/controller/tests/test_startup_extensions.py
@@ -39,7 +39,9 @@ class StartupExtensionsTests(unittest.IsolatedAsyncioTestCase):
         app = SimpleNamespace(
             state=SimpleNamespace(
                 browser_manager=FakeManager(),
-                settings=SimpleNamespace(stealth_enabled=False, harness_root=os.path.join(self.temp_dir.name, "harness")),
+                settings=SimpleNamespace(
+                    stealth_enabled=False, harness_root=os.path.join(self.temp_dir.name, "harness")
+                ),
                 tool_gateway=gateway,
             )
         )

--- a/controller/tests/test_tool_gateway.py
+++ b/controller/tests/test_tool_gateway.py
@@ -785,7 +785,9 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
             def __init__(self) -> None:
                 self.url = "https://example.com"
                 self.mouse = FakeMouse()
-                self.evaluate = AsyncMock(side_effect=["eval-result", "plain text", [{"tag": "button"}], "stored", {"all": "items"}, None])
+                self.evaluate = AsyncMock(
+                    side_effect=["eval-result", "plain text", [{"tag": "button"}], "stored", {"all": "items"}, None]
+                )
                 self.wait_for_selector = AsyncMock()
                 self.content = AsyncMock(return_value="<html></html>")
                 self.set_viewport_size = AsyncMock()
@@ -851,7 +853,10 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
             ),
             ("browser.set_viewport", {"session_id": "session-1", "width": 800, "height": 600}),
             ("browser.get_cookies", {"session_id": "session-1", "urls": ["https://example.com"]}),
-            ("browser.set_cookies", {"session_id": "session-1", "cookies": [{"name": "sid", "value": "1", "url": "https://example.com"}]}),
+            (
+                "browser.set_cookies",
+                {"session_id": "session-1", "cookies": [{"name": "sid", "value": "1", "url": "https://example.com"}]},
+            ),
             ("browser.get_local_storage", {"session_id": "session-1", "key": "k"}),
             ("browser.get_local_storage", {"session_id": "session-1"}),
             ("browser.set_local_storage", {"session_id": "session-1", "key": "k", "value": "v"}),
@@ -942,9 +947,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
     async def test_omitted_session_id_resolves_to_single_live_session(self) -> None:
         self.manager.list_sessions = AsyncMock(return_value=[{"id": "session-42"}])
 
-        response = await self.full_gateway.call_tool(
-            McpToolCallRequest(name="browser.observe", arguments={})
-        )
+        response = await self.full_gateway.call_tool(McpToolCallRequest(name="browser.observe", arguments={}))
 
         self.assertFalse(response.isError)
         self.manager.observe.assert_awaited_once()
@@ -954,9 +957,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.manager.list_sessions = AsyncMock(return_value=[])
         self.manager.create_session = AsyncMock(return_value={"id": "session-new"})
 
-        response = await self.full_gateway.call_tool(
-            McpToolCallRequest(name="browser.observe", arguments={})
-        )
+        response = await self.full_gateway.call_tool(McpToolCallRequest(name="browser.observe", arguments={}))
 
         self.assertFalse(response.isError)
         self.manager.create_session.assert_awaited_once()
@@ -966,22 +967,16 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.manager.list_sessions = AsyncMock(return_value=[])
         self.manager.create_session = AsyncMock(return_value={"id": "session-new"})
 
-        response = await self.full_gateway.call_tool(
-            McpToolCallRequest(name="browser.get_console", arguments={})
-        )
+        response = await self.full_gateway.call_tool(McpToolCallRequest(name="browser.get_console", arguments={}))
 
         self.assertTrue(response.isError)
         self.assertEqual(response.structuredContent.get("code"), "no_session")
         self.manager.create_session.assert_not_awaited()
 
     async def test_omitted_session_id_errors_when_multiple_sessions_live(self) -> None:
-        self.manager.list_sessions = AsyncMock(
-            return_value=[{"id": "session-a"}, {"id": "session-b"}]
-        )
+        self.manager.list_sessions = AsyncMock(return_value=[{"id": "session-a"}, {"id": "session-b"}])
 
-        response = await self.full_gateway.call_tool(
-            McpToolCallRequest(name="browser.observe", arguments={})
-        )
+        response = await self.full_gateway.call_tool(McpToolCallRequest(name="browser.observe", arguments={}))
 
         self.assertTrue(response.isError)
         self.assertEqual(response.structuredContent.get("code"), "ambiguous_session")
@@ -1027,9 +1022,7 @@ class ToolGatewayTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("timed out", response.content[0].text)
 
     async def test_find_elements_invalid_regex_surfaces_structured_error(self) -> None:
-        page = SimpleNamespace(
-            evaluate=AsyncMock(return_value={"__invalid_regex": "Unterminated group"})
-        )
+        page = SimpleNamespace(evaluate=AsyncMock(return_value={"__invalid_regex": "Unterminated group"}))
         self.manager.get_session = AsyncMock(return_value=SimpleNamespace(page=page))
 
         response = await self.full_gateway.call_tool(

--- a/examples/workflows/social_empire.py
+++ b/examples/workflows/social_empire.py
@@ -9,6 +9,7 @@ Usage:
 
     httpx.post("http://localhost:8000/workflows/run", json=VIRAL_PIPELINE("tech gadgets", "My Channel"))
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -63,7 +64,7 @@ def VIRAL_PIPELINE(
                 "depends_on": ["research"],
                 "params": {
                     "prompt": "{{ context.research.veo3_prompt }}",
-                    "output_filename": "",   # engine uses uuid-based path
+                    "output_filename": "",  # engine uses uuid-based path
                     "duration_seconds": video_duration,
                     "aspect_ratio": aspect_ratio,
                 },
@@ -133,46 +134,52 @@ def SHORTS_BLITZ(
     steps = []
 
     # Single shared research step
-    steps.append({
-        "id": "research",
-        "action": "social.research.viral",
-        "params": {"niche": niche, "yt_results": 15},
-        "retry_max": 2,
-        "timeout_seconds": 60,
-    })
+    steps.append(
+        {
+            "id": "research",
+            "action": "social.research.viral",
+            "params": {"niche": niche, "yt_results": 15},
+            "retry_max": 2,
+            "timeout_seconds": 60,
+        }
+    )
 
     for i in range(count):
         gen_id = f"generate_{i}"
         upload_id = f"upload_{i}"
 
-        steps.append({
-            "id": gen_id,
-            "action": "social.veo3.generate",
-            "depends_on": ["research"],
-            "params": {
-                "prompt": "{{ context.research.veo3_prompt }}",
-                "duration_seconds": 30,   # Shorts are ≤60s
-                "aspect_ratio": "9:16",   # vertical for Shorts
-            },
-            "retry_max": 1,
-            "timeout_seconds": 240,
-        })
+        steps.append(
+            {
+                "id": gen_id,
+                "action": "social.veo3.generate",
+                "depends_on": ["research"],
+                "params": {
+                    "prompt": "{{ context.research.veo3_prompt }}",
+                    "duration_seconds": 30,  # Shorts are ≤60s
+                    "aspect_ratio": "9:16",  # vertical for Shorts
+                },
+                "retry_max": 1,
+                "timeout_seconds": 240,
+            }
+        )
 
-        steps.append({
-            "id": upload_id,
-            "action": "social.youtube.upload",
-            "depends_on": [gen_id],
-            "params": {
-                "file_path": "{{ context." + gen_id + ".path }}",
-                "title": f"#Shorts {{{{ context.research.trending_topics }}}} #{i + 1}",
-                "description": "#Shorts",
-                "tags": ["Shorts"],
-                "privacy": privacy,
-                "make_short": True,
-            },
-            "retry_max": 2,
-            "timeout_seconds": 300,
-        })
+        steps.append(
+            {
+                "id": upload_id,
+                "action": "social.youtube.upload",
+                "depends_on": [gen_id],
+                "params": {
+                    "file_path": "{{ context." + gen_id + ".path }}",
+                    "title": f"#Shorts {{{{ context.research.trending_topics }}}} #{i + 1}",
+                    "description": "#Shorts",
+                    "tags": ["Shorts"],
+                    "privacy": privacy,
+                    "make_short": True,
+                },
+                "retry_max": 2,
+                "timeout_seconds": 300,
+            }
+        )
 
     return {
         "workflow_id": "shorts_blitz",
@@ -193,16 +200,18 @@ def WARMUP_CHECK(
 
     steps = []
     for platform in platforms:
-        steps.append({
-            "id": f"check_{platform}",
-            "action": "social.auth.verify",
-            "params": {
-                "platform": platform,
-                "auth_profile": f"{platform}-default",
-            },
-            "retry_max": 1,
-            "timeout_seconds": 30,
-        })
+        steps.append(
+            {
+                "id": f"check_{platform}",
+                "action": "social.auth.verify",
+                "params": {
+                    "platform": platform,
+                    "auth_profile": f"{platform}-default",
+                },
+                "retry_max": 1,
+                "timeout_seconds": 30,
+            }
+        )
 
     return {
         "workflow_id": "warmup_check",

--- a/integrations/langchain/auto_browser_langchain/tool.py
+++ b/integrations/langchain/auto_browser_langchain/tool.py
@@ -19,6 +19,7 @@ except ImportError:
 
 
 if _LANGCHAIN_AVAILABLE:
+
     class AutoBrowserInput(BaseModel):
         action: str = PydanticField(description="MCP tool name, e.g. 'browser.observe'")
         arguments: dict[str, Any] = PydanticField(default_factory=dict, description="Tool arguments")

--- a/integrations/langchain/tests/test_langchain_integration.py
+++ b/integrations/langchain/tests/test_langchain_integration.py
@@ -6,6 +6,7 @@ small HTTP call plus response unwrapping — which is exactly where a silent
 shape change (``content[0].text`` moving, an error flag renamed) goes unnoticed
 until a user's agent starts returning empty strings.
 """
+
 from __future__ import annotations
 
 import json
@@ -40,9 +41,7 @@ class AutoBrowserToolTests(unittest.TestCase):
 
     @respx.mock
     def test_run_defaults_arguments_to_an_empty_object(self) -> None:
-        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
-            return_value=httpx.Response(200, json=_content("ok"))
-        )
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=_content("ok")))
 
         AutoBrowserTool(base_url=BASE_URL)._run("browser.observe")
 
@@ -52,9 +51,7 @@ class AutoBrowserToolTests(unittest.TestCase):
 class AutoBrowserToolAsyncTests(unittest.IsolatedAsyncioTestCase):
     @respx.mock
     async def test_arun_returns_the_first_content_text(self) -> None:
-        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
-            return_value=httpx.Response(200, json=_content("page title"))
-        )
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=_content("page title")))
 
         result = await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
 
@@ -81,9 +78,7 @@ class AutoBrowserToolAsyncTests(unittest.IsolatedAsyncioTestCase):
 
     @respx.mock
     async def test_arun_sends_the_action_and_arguments(self) -> None:
-        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
-            return_value=httpx.Response(200, json=_content("ok"))
-        )
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=_content("ok")))
 
         await AutoBrowserTool(base_url=BASE_URL)._arun("browser.click", {"selector": "#go"})
 
@@ -92,9 +87,7 @@ class AutoBrowserToolAsyncTests(unittest.IsolatedAsyncioTestCase):
 
     @respx.mock
     async def test_arun_sends_bearer_token_when_configured(self) -> None:
-        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
-            return_value=httpx.Response(200, json=_content("ok"))
-        )
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=_content("ok")))
 
         await AutoBrowserTool(base_url=BASE_URL, bearer_token="s3cret")._arun("browser.observe", {})
 
@@ -102,9 +95,7 @@ class AutoBrowserToolAsyncTests(unittest.IsolatedAsyncioTestCase):
 
     @respx.mock
     async def test_arun_omits_authorization_without_a_token(self) -> None:
-        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
-            return_value=httpx.Response(200, json=_content("ok"))
-        )
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=_content("ok")))
 
         await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
 
@@ -121,9 +112,7 @@ class AutoBrowserToolAsyncTests(unittest.IsolatedAsyncioTestCase):
 class AutoBrowserToolListToolsTests(unittest.TestCase):
     @respx.mock
     def test_list_tools_returns_the_catalogue(self) -> None:
-        respx.get(f"{BASE_URL}/mcp/tools").mock(
-            return_value=httpx.Response(200, json=[{"name": "browser.observe"}])
-        )
+        respx.get(f"{BASE_URL}/mcp/tools").mock(return_value=httpx.Response(200, json=[{"name": "browser.observe"}]))
 
         self.assertEqual(AutoBrowserTool.list_tools(base_url=BASE_URL), [{"name": "browser.observe"}])
 
@@ -154,9 +143,7 @@ class AutoBrowserNodeAsyncTests(unittest.IsolatedAsyncioTestCase):
 
     @respx.mock
     async def test_call_tool_posts_name_and_arguments(self) -> None:
-        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(
-            return_value=httpx.Response(200, json={"ok": True})
-        )
+        route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json={"ok": True}))
 
         result = await self.node.call_tool("browser.observe", {"session_id": "s1"})
 
@@ -249,9 +236,7 @@ class AutoBrowserNodeAsyncTests(unittest.IsolatedAsyncioTestCase):
 
     @respx.mock
     async def test_run_defaults_missing_observation_fields_to_empty_strings(self) -> None:
-        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
-            return_value=httpx.Response(200, json=_content(json.dumps({})))
-        )
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=_content(json.dumps({}))))
 
         state = await self.node.run({"session_id": "sess-1"})
 

--- a/scripts/agent_eval.py
+++ b/scripts/agent_eval.py
@@ -95,10 +95,7 @@ def _emit_scores(scores, *, json_output: bool) -> int:
         print(json.dumps(payload, indent=2))
     else:
         for key, summary in payload["summary"].items():
-            print(
-                f"{key}: {summary['successes']}/{summary['runs']} success, "
-                f"avg={summary['average_score']:.4f}"
-            )
+            print(f"{key}: {summary['successes']}/{summary['runs']} success, avg={summary['average_score']:.4f}")
         for score in payload["scores"]:
             status = "PASS" if score["success"] else "FAIL"
             print(f"- {status} {score['case_id']} {score['provider']}/{score['workflow_profile']}")

--- a/scripts/check_version_parity.py
+++ b/scripts/check_version_parity.py
@@ -97,8 +97,7 @@ def main() -> int:
         marker = "  " if version == expected else "->"
         print(f"{marker} {location:52} {version}", file=sys.stderr)
     print(
-        "\nAll of these must move together in a release commit. See "
-        "scripts/check_version_parity.py for why.",
+        "\nAll of these must move together in a release commit. See scripts/check_version_parity.py for why.",
         file=sys.stderr,
     )
     return 1

--- a/scripts/extract_changelog.py
+++ b/scripts/extract_changelog.py
@@ -5,6 +5,7 @@ Usage: python scripts/extract_changelog.py 1.2.1 [CHANGELOG.md]
 Exits non-zero if the version has no section, so a release with missing
 notes fails loudly instead of publishing empty.
 """
+
 from __future__ import annotations
 
 import re

--- a/scripts/fixture_live.py
+++ b/scripts/fixture_live.py
@@ -41,8 +41,10 @@ def _run_live(base_url: str, fixture: str, expect: str) -> int:
         from app.main import app
         from fastapi.testclient import TestClient
     except Exception as exc:  # noqa: BLE001 - controller not installed is a skip, not a failure
-        print(f"[fixture-live] SKIP: controller app not importable ({exc}). "
-              "Install it with `pip install -e ./controller[dev]`.")
+        print(
+            f"[fixture-live] SKIP: controller app not importable ({exc}). "
+            "Install it with `pip install -e ./controller[dev]`."
+        )
         return SKIPPED
 
     target = f"{base_url}/{fixture}"
@@ -53,8 +55,9 @@ def _run_live(base_url: str, fixture: str, expect: str) -> int:
         with TestClient(app) as client:
             created = client.post("/sessions", json={"name": "fixture-live"})
             if created.status_code >= 500:
-                print(f"[fixture-live] SKIP: session creation returned {created.status_code} "
-                      "(browser stack unavailable).")
+                print(
+                    f"[fixture-live] SKIP: session creation returned {created.status_code} (browser stack unavailable)."
+                )
                 return SKIPPED
             created.raise_for_status()
             session_id = created.json().get("id") or created.json().get("session_id")
@@ -67,8 +70,10 @@ def _run_live(base_url: str, fixture: str, expect: str) -> int:
             finally:
                 client.delete(f"/sessions/{session_id}")
     except Exception as exc:  # noqa: BLE001 - opt-in path: treat env failures as skip
-        print(f"[fixture-live] SKIP: live browser stack unavailable ({type(exc).__name__}: {exc}). "
-              "Run `python -m playwright install chromium`.")
+        print(
+            f"[fixture-live] SKIP: live browser stack unavailable ({type(exc).__name__}: {exc}). "
+            "Run `python -m playwright install chromium`."
+        )
         return SKIPPED
 
     if body is not None and expect in body:


### PR DESCRIPTION
Formatting only. No logic changes.

`ruff format` reported **108 files** drifting from the formatter this project already depends on. Nothing enforced it, so the drift accumulated silently.

### Why now, specifically

This touches 106 files, so it conflicts with anything in flight. The merge queue is currently **empty**, and a substantial fix campaign is about to start. Landing it against zero open PRs is the cheapest this will ever be; landing it afterward would collide with every fix branch. If you would rather not carry the churn at all, closing this is completely reasonable -- nothing else depends on it.

### Verified behaviour-neutral, not assumed

| check | result |
|---|---|
| controller suite | **637 passed, 2 skipped, 199 subtests, 0 failures** |
| `ruff check .` (E9,F,I) | clean |
| `check_bridge_parity.py` | still byte-identical |
| `check_version_parity.py` | 9/9 agree on 1.5.0 |
| `check_playwright_pins.py` | matched at 1.62.0 |

The bridge-parity check was the real risk and the reason I ran it before committing: `client/auto_browser_client/mcp_bridge.py` and `controller/app/mcp_stdio.py` must stay byte-identical, but they resolve to **different ruff configs** (root `ruff.toml` targets py311, `controller/pyproject.toml` targets py310). Had `target-version` changed the formatter's output, this PR would have silently broken that gate. It did not -- but the two configs disagreeing on `target-version` while CI tests 3.11 and 3.14 is worth reconciling separately.

### Note for a follow-up, not fixed here

There is no `.gitattributes` and `core.autocrlf` is enabled, so line-ending handling currently depends on each contributor's git config. Committed blobs are LF and this diff is ~14 changed lines per file (not whole-file rewrites), so nothing is wrong today -- but `browser-node/Dockerfile` already carries a `sed -i 's/\r$//'` workaround for exactly this class of problem, which suggests it has bitten before.