### PR TITLE
ci: run the full suite in the Docker job, not 89% of it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,15 @@ jobs:
         run: docker compose build controller
 
       - name: Run controller unit tests
-        run: docker compose run --no-deps --rm controller python -m unittest discover -s tests -v
+        # pytest, not `unittest discover`. unittest only collects unittest.TestCase
+        # subclasses, so it silently ran 566 of 637 tests -- skipping test_1_0.py
+        # (61: mesh Ed25519 identity/signing, peer registry, delegation policy,
+        # stealth, network inspector, CDP, workflow engine), test_pii_scrub.py (8)
+        # and test_readiness.py (4) because they are pytest-style. The one job that
+        # validates the shipped container was running zero PII and zero mesh-crypto
+        # tests, and any new pytest-style file was excluded with no warning.
+        # controller/Dockerfile installs requirements-dev.txt, so pytest is present.
+        run: docker compose run --no-deps --rm controller python -m pytest tests/ -q
 
   compose-smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`controller-tests` ran `unittest discover`, which only collects `unittest.TestCase` subclasses. Measured on this tree:

```
unittest discover           : Ran 566 tests -- OK
pytest tests/               : 637 passed, 2 skipped
unittest, test_pii_scrub.py : Ran 0 tests -- NO TESTS RAN
pytest,   test_pii_scrub.py : 8 passed
```

The 71-test delta is `test_1_0.py` (61 -- mesh Ed25519 identity/signing, peer registry, delegation policy, stealth, network inspector, CDP, workflow engine), `test_pii_scrub.py` (8), `test_readiness.py` (4). All pytest-style, all invisible to `unittest`.

**The one required check that validates the shipped container was running zero PII-scrubber and zero mesh-crypto tests** -- and any future pytest-style file would have been dropped from it with no warning.

The job keeps its actual value (environment parity with the image users run) because it still executes inside the built controller image. `controller/Dockerfile:21` installs `requirements-dev.txt`, so pytest is already present -- no image change needed.

Landing this first so the fixes queued behind it are genuinely exercised by the container check, not just the host jobs.