### PR TITLE
fix(pii): make the privacy controls actually do something

### DIFF
--- a/controller/app/browser/services/observation.py
+++ b/controller/app/browser/services/observation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -38,7 +39,7 @@ class BrowserObservationService:
     async def capture_screenshot(self, session_id: str, *, label: str = "manual") -> dict[str, Any]:
         session = await self.manager.get_session(session_id)
         async with session.lock:
-            screenshot = await self.manager._capture_screenshot(session, label)
+            screenshot = await self._capture_screenshot_redacted(session, label)
             return {
                 "session": await self.manager._session_summary(session),
                 "url": session.page.url,
@@ -71,7 +72,7 @@ class BrowserObservationService:
             preset = "normal"
 
         if preset == "fast":
-            screenshot = await self.manager._capture_screenshot(session, screenshot_label)
+            screenshot = await self._capture_screenshot_redacted(session, screenshot_label)
             title = await session.page.title()
             tabs = await self.manager.tabs.summaries(session)
             return {
@@ -173,8 +174,28 @@ class BrowserObservationService:
             return None
         return await self.manager.ocr.extract_from_image(screenshot["path"])
 
-    async def light_snapshot(self, session: "BrowserSession", *, label: str) -> dict[str, Any]:
+    async def _capture_screenshot_redacted(self, session: "BrowserSession", label: str) -> dict[str, str]:
+        """Capture a screenshot and redact PII pixels before it settles on disk.
+
+        The normal/rich observe path runs OCR for its own payload and redacts via
+        `_scrub_screenshot_if_needed`. Every *other* screenshot write — the `fast`
+        preset, manual captures, and the before/after snapshot taken on every
+        action — skipped redaction entirely, so `PII_SCRUB_SCREENSHOT=true` only
+        ever covered a fraction of the images written under /data/artifacts and
+        served over /artifacts/.
+
+        OCR here costs time, but it is gated on the operator having explicitly
+        asked for screenshot scrubbing; silently honouring that setting for some
+        screenshots and not others is the worse trade.
+        """
         screenshot = await self.manager._capture_screenshot(session, label)
+        if self.manager.pii_scrubber.screenshot_enabled:
+            ocr = await self.manager.ocr.extract_from_image(screenshot["path"])
+            await self._scrub_screenshot_if_needed(session, screenshot, ocr)
+        return screenshot
+
+    async def light_snapshot(self, session: "BrowserSession", *, label: str) -> dict[str, Any]:
+        screenshot = await self._capture_screenshot_redacted(session, label)
         summary = await self.page_summary(session.page)
         return {
             "url": session.page.url,
@@ -301,12 +322,21 @@ class BrowserObservationService:
         ocr: dict[str, Any] | None,
     ) -> None:
         pii_scrubber = self.manager.pii_scrubber
-        if not pii_scrubber.screenshot_enabled or not ocr or not ocr.get("blocks"):
+        if not pii_scrubber.screenshot_enabled or not ocr:
+            return
+        # Prefer the uncapped redaction list. `blocks` is truncated to
+        # ocr_max_blocks (default 20) for the model-facing payload, and since
+        # image_to_data emits one block per *word*, redacting from it covered
+        # only the first ~20 words of a page.
+        blocks = ocr.get("redaction_blocks") or ocr.get("blocks")
+        if not blocks:
             return
         try:
             scrubbed_path = Path(screenshot["path"])
             raw_bytes = scrubbed_path.read_bytes()
-            scrubbed_bytes, hits = pii_scrubber.screenshot(raw_bytes, ocr["blocks"])
+            # PIL decode/draw/encode is CPU-bound and this runs while holding
+            # session.lock; keep it off the event loop.
+            scrubbed_bytes, hits = await asyncio.to_thread(pii_scrubber.screenshot, raw_bytes, blocks)
             if hits:
                 scrubbed_path.write_bytes(scrubbed_bytes)
                 if pii_scrubber.audit_report:

--- a/controller/app/ocr.py
+++ b/controller/app/ocr.py
@@ -8,6 +8,15 @@ import pytesseract
 from PIL import Image
 from pytesseract import Output, TesseractNotFoundError
 
+# Tesseract confidence below this is treated as unreliable for the model-facing
+# excerpt. It deliberately does NOT gate `redaction_blocks` — see _extract_sync.
+_MIN_CONFIDENCE = 30
+
+# Safety ceiling on the redaction block list so a text-dense page cannot grow it
+# without bound. Two orders of magnitude above the model-facing cap, which is
+# what matters: redaction must not be starved by a token budget.
+_REDACTION_BLOCK_CAP = 5000
+
 
 class OCRExtractor:
     def __init__(self, *, enabled: bool, language: str, max_blocks: int, text_limit: int):
@@ -25,6 +34,7 @@ class OCRExtractor:
                 "language": self.language,
                 "text_excerpt": "",
                 "blocks": [],
+                "redaction_blocks": [],
             }
         return await asyncio.to_thread(self._extract_sync, Path(image_path))
 
@@ -43,6 +53,7 @@ class OCRExtractor:
             return self._error_payload(image_path, "ocr_extraction_failed")
 
         blocks: list[dict[str, Any]] = []
+        redaction_blocks: list[dict[str, Any]] = []
         parts: list[str] = []
         char_count = 0
         for idx, raw_text in enumerate(data.get("text", [])):
@@ -53,8 +64,6 @@ class OCRExtractor:
                 confidence = float(data.get("conf", [])[idx])
             except Exception:
                 confidence = -1.0
-            if confidence < 30:
-                continue
             block = {
                 "text": text,
                 "confidence": round(confidence, 2),
@@ -65,15 +74,27 @@ class OCRExtractor:
                     "height": int(data.get("height", [0])[idx]),
                 },
             }
-            blocks.append(block)
-            if char_count < self.text_limit:
-                remaining = self.text_limit - char_count
-                chunk = text[:remaining]
-                if chunk:
-                    parts.append(chunk)
-                    char_count += len(chunk) + 1
-            if len(blocks) >= self.max_blocks:
-                break
+
+            # Redaction sees every block, and deliberately ignores both the
+            # confidence floor and max_blocks. image_to_data returns one block
+            # per *word*, so capping this at ocr_max_blocks (default 20) meant
+            # only the first ~20 words of a page could ever be redacted — a nav
+            # bar exhausted the budget before reaching the page body. Dropping
+            # low-confidence blocks here would be fail-open for privacy too.
+            if len(redaction_blocks) < _REDACTION_BLOCK_CAP:
+                redaction_blocks.append(block)
+
+            # The model-facing payload keeps both limits: callers pay tokens for it.
+            if confidence < _MIN_CONFIDENCE:
+                continue
+            if len(blocks) < self.max_blocks:
+                blocks.append(block)
+                if char_count < self.text_limit:
+                    remaining = self.text_limit - char_count
+                    chunk = text[:remaining]
+                    if chunk:
+                        parts.append(chunk)
+                        char_count += len(chunk) + 1
 
         return {
             "available": True,
@@ -84,6 +105,7 @@ class OCRExtractor:
             "dimensions": {"width": width, "height": height},
             "text_excerpt": " ".join(parts).strip(),
             "blocks": blocks,
+            "redaction_blocks": redaction_blocks,
         }
 
     def _error_payload(self, image_path: Path, error: str) -> dict[str, Any]:
@@ -95,5 +117,6 @@ class OCRExtractor:
             "image_path": str(image_path),
             "text_excerpt": "",
             "blocks": [],
+            "redaction_blocks": [],
             "error": error,
         }

--- a/controller/app/pii_scrub.py
+++ b/controller/app/pii_scrub.py
@@ -45,13 +45,23 @@ DEFAULT_REPLACEMENT = "[REDACTED]"
 
 _RAW_PATTERNS: list[tuple[str, str]] = [
     # AWS access key IDs: AKIA / ASIA / AROA / AIDA / AIPA / ANPA / ANVA / APKA
-    ("aws_access_key", r"(?<![A-Z0-9])(A[KSIARP][IDA][A-Z0-9]{16})(?![A-Z0-9])"),
+    # The prefix is 4 characters and the identifier is 20 total. The previous
+    # pattern spelled the prefix as `A[KSIARP][IDA]` (3 chars) + 16, i.e. 19 —
+    # one short — so the trailing lookahead rejected every real key and this
+    # pattern could never match anything. Spell the prefixes out instead.
+    (
+        "aws_access_key",
+        r"(?<![A-Z0-9])((?:AKIA|ASIA|AROA|AIDA|AIPA|ANPA|ANVA|APKA)[A-Z0-9]{16})(?![A-Z0-9])",
+    ),
     # AWS secret access keys: 40 chars base64url after = sign or whitespace
     ("aws_secret_key", r"(?i)(?:aws_secret(?:_access)?_key|secret_access_key)\s*[=:]\s*([A-Za-z0-9/+=]{40})"),
     # JWT tokens: header.payload.signature (base64url)
     ("jwt_token", r"eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}"),
-    # Bearer tokens in Authorization headers
-    ("bearer_token", r"(?i)Bearer\s+([A-Za-z0-9\-._~+/]+=*)\b"),
+    # Bearer tokens in Authorization headers.
+    # No trailing \b: a word boundary cannot occur after '=', so it forced the
+    # engine to backtrack off the base64 padding and leave it in the output
+    # ("Bearer abc123==" redacted to "[REDACTED]==").
+    ("bearer_token", r"(?i)Bearer\s+([A-Za-z0-9\-._~+/]+=*)"),
     # Private / public key PEM headers
     ("pem_header", r"-----BEGIN\s+(?:RSA\s+)?(?:PRIVATE|PUBLIC)\s+KEY-----"),
     # Generic API key / token / secret / password in query params or JSON fields
@@ -228,10 +238,26 @@ def scrub_screenshot(
             continue
         result = scrub_text(text, replacement=replacement, enabled_patterns=enabled_patterns)
         if result.scrubbed:
-            x = int(block.get("x", 0))
-            y = int(block.get("y", 0))
-            w = int(block.get("width", 0))
-            h = int(block.get("height", 0))
+            # OCRExtractor emits geometry nested under "bbox" (see ocr.py); this
+            # read them as flat top-level keys, so every .get(..., 0) fell to its
+            # default and every rectangle computed to (0, 0, 0, 0). Redaction was
+            # a silent no-op in production while `hits` stayed non-empty, so the
+            # caller wrote a "pii_redaction / ok" audit event over an unredacted
+            # screenshot. The flat shape is still accepted for callers that pass
+            # geometry directly.
+            geometry = block.get("bbox") or block
+            x = int(geometry.get("x", 0))
+            y = int(geometry.get("y", 0))
+            w = int(geometry.get("width", 0))
+            h = int(geometry.get("height", 0))
+            if w <= 0 or h <= 0:
+                # A degenerate box redacts nothing. Refuse to report success for
+                # it — that is exactly how this defect stayed invisible.
+                logger.warning(
+                    "pii_scrub: OCR block matched %s but carries no usable geometry; cannot redact pixels",
+                    [h["pattern"] for h in result.hits],
+                )
+                continue
             boxes_to_redact.append((x, y, x + w, y + h))
             for hit in result.hits:
                 hit["bbox"] = {"x": x, "y": y, "width": w, "height": h}
@@ -361,8 +387,17 @@ class PiiScrubber:
         patterns: set[str] | None = None
         if raw_patterns:
             patterns = {p.strip() for p in raw_patterns.split(",") if p.strip()}
-            # validate — silently drop unknown names
-            patterns = patterns & set(ALL_PATTERN_NAMES)
+            # Fail closed on an unknown name. This previously intersected with the
+            # known set and silently dropped anything unrecognised, so a single
+            # typo ("emial") could reduce the set to empty — and an empty (but not
+            # None) set makes scrub_text skip every pattern, disabling PII
+            # scrubbing entirely while summary() still reported enabled: True.
+            unknown = sorted(patterns - set(ALL_PATTERN_NAMES))
+            if unknown:
+                raise ValueError(
+                    f"PII_SCRUB_PATTERNS contains unknown pattern name(s): {', '.join(unknown)}. "
+                    f"Valid names: {', '.join(sorted(ALL_PATTERN_NAMES))}"
+                )
         else:
             patterns = set(ALL_PATTERN_NAMES) - _NOISY_PATTERNS
 

--- a/controller/tests/test_pii_scrub.py
+++ b/controller/tests/test_pii_scrub.py
@@ -1,16 +1,31 @@
 from __future__ import annotations
 
+import io
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from PIL import Image
 
 from app.pii_scrub import (
+    ALL_PATTERN_NAMES,
     PiiScrubber,
     scrub_console_messages,
     scrub_network_body,
     scrub_screenshot,
     scrub_text,
 )
+
+
+def tmp_png(raw: bytes) -> Path:
+    """Write PNG bytes to a temp file and return its path."""
+    handle = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    try:
+        handle.write(raw)
+    finally:
+        handle.close()
+    return Path(handle.name)
 
 
 def _settings(**overrides: object) -> SimpleNamespace:
@@ -109,3 +124,178 @@ def test_screenshot_redaction_and_invalid_image_fallback() -> None:
     assert fallback == b"not-a-png"
     assert fallback_hits[0]["pattern"] == "email"
     assert scrub_screenshot(raw, [])[1] == []
+
+
+# ── Effect tests ───────────────────────────────────────────────────────────
+# These assert what actually happened to the bytes/pixels, not what the
+# scrubber reported. Redaction silently no-op'd in production for a long time
+# while returning hits and writing a "pii_redaction / ok" audit event, because
+# every test fed a block shape that OCRExtractor never emits.
+
+SECRET_EMAIL = "ops@corp.com"
+
+
+def _image_with_secret() -> tuple[bytes, tuple[int, int, int, int]]:
+    """A white PNG with the secret drawn at a known location."""
+    from PIL import ImageDraw
+
+    image = Image.new("RGB", (400, 120), "white")
+    ImageDraw.Draw(image).text((20, 40), SECRET_EMAIL, fill="black")
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    return buf.getvalue(), (18, 38, 170, 62)
+
+
+def _ink(png: bytes, region: tuple[int, int, int, int]) -> int:
+    """Count non-white pixels inside region — the only honest redaction check."""
+    image = Image.open(io.BytesIO(png)).convert("RGB")
+    x0, y0, x1, y1 = region
+    return sum(1 for x in range(x0, x1) for y in range(y0, y1) if image.getpixel((x, y)) != (255, 255, 255))
+
+
+def _fake_tesseract_data(text: str, *, x: int, y: int, width: int, height: int) -> dict[str, list]:
+    """The dict shape pytesseract.image_to_data(output_type=DICT) returns."""
+    return {
+        "text": [text],
+        "conf": ["96.0"],
+        "left": [x],
+        "top": [y],
+        "width": [width],
+        "height": [height],
+    }
+
+
+def test_redaction_covers_pixels_for_real_ocr_block_shape(monkeypatch) -> None:
+    """Blocks produced by the real OCRExtractor must actually redact pixels.
+
+    Regression: OCRExtractor nests geometry under "bbox" while scrub_screenshot
+    read flat x/y/width/height, so every rectangle collapsed to (0,0,0,0). This
+    drives the genuine _extract_sync code path (tesseract itself is stubbed) so
+    the two modules can never drift apart again without failing here.
+    """
+    from app import ocr as ocr_module
+
+    raw, region = _image_with_secret()
+    monkeypatch.setattr(
+        ocr_module.pytesseract,
+        "image_to_data",
+        lambda *a, **k: _fake_tesseract_data(SECRET_EMAIL, x=20, y=40, width=130, height=18),
+    )
+
+    extractor = ocr_module.OCRExtractor(enabled=True, language="eng", max_blocks=20, text_limit=2000)
+    payload = extractor._extract_sync(tmp_png(raw))
+
+    blocks = payload["redaction_blocks"]
+    assert blocks and "bbox" in blocks[0], "OCR block shape changed; scrub_screenshot must follow"
+
+    before = _ink(raw, region)
+    redacted, hits = scrub_screenshot(raw, blocks, enabled_patterns={"email"})
+    after = _ink(redacted, region)
+
+    assert hits, "the email should be detected"
+    assert before > 0, "fixture should actually draw the secret"
+    assert after != before, "reported a redaction but no pixel changed — the silent no-op is back"
+
+
+def test_degenerate_block_does_not_report_a_redaction() -> None:
+    """A zero-size box redacts nothing, so it must not be reported as success."""
+    raw, _ = _image_with_secret()
+    blocks = [{"text": SECRET_EMAIL, "bbox": {"x": 0, "y": 0, "width": 0, "height": 0}}]
+    redacted, hits = scrub_screenshot(raw, blocks, enabled_patterns={"email"})
+    assert hits == []
+    assert redacted == raw
+
+
+def test_redaction_is_not_starved_by_the_model_facing_block_cap(monkeypatch) -> None:
+    """ocr_max_blocks truncates the payload, never the redaction input."""
+    from app import ocr as ocr_module
+
+    words = [f"w{i}" for i in range(50)] + [SECRET_EMAIL]
+    monkeypatch.setattr(
+        ocr_module.pytesseract,
+        "image_to_data",
+        lambda *a, **k: {
+            "text": words,
+            "conf": ["96.0"] * len(words),
+            "left": [10] * len(words),
+            "top": [10] * len(words),
+            "width": [20] * len(words),
+            "height": [10] * len(words),
+        },
+    )
+    raw, _ = _image_with_secret()
+    extractor = ocr_module.OCRExtractor(enabled=True, language="eng", max_blocks=20, text_limit=2000)
+    payload = extractor._extract_sync(tmp_png(raw))
+
+    assert len(payload["blocks"]) == 20, "model-facing payload stays capped"
+    assert len(payload["redaction_blocks"]) == len(words), "redaction sees every block"
+    assert any(b["text"] == SECRET_EMAIL for b in payload["redaction_blocks"])
+    assert not any(b["text"] == SECRET_EMAIL for b in payload["blocks"])
+
+
+# ── Pattern coverage ───────────────────────────────────────────────────────
+# Twelve of the fifteen patterns had no behavioural assertion; line coverage
+# read 91% only because scrub_text loops them all regardless. That is how a
+# 19-character AWS pattern (real keys are 20) survived.
+
+CANONICAL_SAMPLES: dict[str, str] = {
+    "aws_access_key": "key=AKIAIOSFODNN7EXAMPLE",
+    "aws_secret_key": "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    "jwt_token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N",
+    "bearer_token": "Authorization: Bearer abc123XYZdef456==",
+    "pem_header": "-----BEGIN RSA PRIVATE KEY-----",
+    "api_key_param": "api_key=sk_live_abcdefgh12345678",
+    "password_field": '"password": "hunter2xyz"',
+    "credit_card": "4111111111111111",
+    "ssn": "123-45-6789",
+    "email": "ops@example.com",
+    "phone_us": "415-555-0132",
+    "phone_intl": "+44 20 7946 0958",
+    "gcp_sa_key": '"private_key_id": "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"',
+    "azure_secret": "client_secret=0123456789abcdef0123456789abcdef",
+    "generic_hex_token": "0123456789abcdef0123456789abcdef",
+    "generic_b64_secret": "credential=QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWY=",
+}
+
+
+def test_every_pattern_has_a_canonical_sample() -> None:
+    """Adding a pattern without a behavioural sample fails here, by design."""
+    assert set(CANONICAL_SAMPLES) == set(ALL_PATTERN_NAMES)
+
+
+@pytest.mark.parametrize("name", sorted(CANONICAL_SAMPLES))
+def test_pattern_redacts_its_canonical_sample(name: str) -> None:
+    sample = CANONICAL_SAMPLES[name]
+    result = scrub_text(sample, enabled_patterns={name})
+    assert result.scrubbed, f"{name} did not match its canonical sample: {sample!r}"
+    assert "[REDACTED]" in result.text
+
+
+def test_aws_access_key_matches_a_full_length_key() -> None:
+    """Regression: the pattern was 19 chars (A + 2 + 16); real key ids are 20."""
+    result = scrub_text("key=AKIAIOSFODNN7EXAMPLE", enabled_patterns={"aws_access_key"})
+    assert "AKIAIOSFODNN7EXAMPLE" not in result.text
+
+
+def test_bearer_token_redaction_consumes_base64_padding() -> None:
+    """Regression: a trailing \\b cannot match after '=', leaking the padding."""
+    result = scrub_text("Bearer abcdef123==", enabled_patterns={"bearer_token"})
+    assert "=" not in result.text
+
+
+# ── Configuration must fail closed ─────────────────────────────────────────
+
+
+def test_unknown_pattern_name_is_rejected() -> None:
+    """A typo used to empty the set, silently disabling ALL PII scrubbing while
+    summary() still reported enabled: True."""
+    with pytest.raises(ValueError) as excinfo:
+        PiiScrubber.from_settings(_settings(pii_scrub_patterns="emial,phon"))
+    assert "emial" in str(excinfo.value)
+
+
+def test_valid_pattern_subset_still_configures() -> None:
+    scrubber = PiiScrubber.from_settings(_settings(pii_scrub_patterns="email,ssn"))
+    assert scrubber.enabled_patterns == {"email", "ssn"}
+    assert scrubber.text("reach me at ops@example.com").scrubbed
+    assert not scrubber.text("Bearer abcdef123456").scrubbed


### PR DESCRIPTION
Four defects in the PII layer. All of them **reported success while doing nothing**, and CI was green on every one. The shared root cause: every test fed these functions shapes and values production never produces.

### 1. Screenshot redaction was a silent no-op

`ocr.py:61` emits geometry nested under `block["bbox"]`. `pii_scrub.py` read flat `x`/`y`/`width`/`height`, so every `.get(..., 0)` fell to its default and every rectangle computed to `(0,0,0,0)`.

Measured on a rendered image containing a secret:

```
ink in secret region, ORIGINAL : 307
after "redaction"              : 307   <- nothing happened
hits reported                  : 1     <- caller believes it worked
```

Because `hits` was non-empty the caller wrote a `pii_redaction / ok` audit event over an **unredacted** screenshot, which then went to `/data/artifacts/`, was served over `/artifacts/`, and was handed to the model. `test_pii_scrub.py:102` fed flat keys, which is exactly why nothing caught it.

A degenerate box is now refused rather than counted as a redaction — that silence is how this hid.

### 2. The AWS access-key pattern could never match a real key

It spelled the prefix as `A[KSIARP][IDA]` (3 chars) + 16 = **19**; real AWS key ids are **20**, so the trailing lookahead rejected every one. `AKIAIOSFODNN7EXAMPLE` passed through untouched. The eight documented prefixes are now spelled out explicitly.

### 3. A typo in `PII_SCRUB_PATTERNS` disabled all scrubbing, fail-open

Unknown names were "silently dropped" by intersecting with the known set, so `PII_SCRUB_PATTERNS="emial,phon"` produced an **empty set** — and an empty-but-not-`None` set makes `scrub_text` skip every pattern. `summary()` still reported `enabled: True`. Unknown names now raise at construction.

### 4. Redaction was starved by a token budget

`image_to_data` returns one block per **word**, and the list was truncated at `ocr_max_blocks` (default 20) — so only the first ~20 words of a page could ever be redacted; a nav bar exhausted the budget before reaching the content. OCR now returns an uncapped `redaction_blocks` alongside the capped model-facing `blocks`, and low-confidence blocks stay redaction-eligible (dropping them is fail-open for privacy).

### Plus: most screenshots were never redacted at all

`PII_SCRUB_SCREENSHOT=true` only covered `normal`/`rich` observes. The `fast` preset, manual captures, and the before/after snapshot taken on **every action** wrote unredacted PNGs. All screenshot writes now go through one redacting path. The PIL work moved off the event loop, since it runs while holding `session.lock`.

### The tests assert effects, not reports

- Pixels counted before and after, driven through the **real** `_extract_sync` (tesseract stubbed) so the two modules cannot drift apart again without failing here.
- **Confirmed each new test fails against the pre-fix code**, then passes.
- All **16** patterns now have a canonical-sample test — twelve had no behavioural assertion whatsoever, which is how #2 survived — plus a completeness test that fails if a pattern is added without a sample. It already earned its keep: it caught `generic_b64_secret` missing while I was writing it.

**637 → 661 passed**, 2 skipped, 199 subtests. `ruff check` clean.