### PR TITLE
fix: repair three broken surfaces and an MCP spec violation

### DIFF
--- a/controller/app/browser_scripts.py
+++ b/controller/app/browser_scripts.py
@@ -14,7 +14,7 @@ STEALTH_INIT_SCRIPT = r"""
   } catch (_) {}
 
   // Chrome runtime object (many sites check for this)
-  if (\!window.chrome) {
+  if (!window.chrome) {
     window.chrome = {
       runtime: {
         onMessage: { addListener: () => {}, removeListener: () => {} },
@@ -88,7 +88,7 @@ STEALTH_INIT_SCRIPT = r"""
       };
     };
     patchGL(WebGLRenderingContext.prototype);
-    if (typeof WebGL2RenderingContext \!== 'undefined') patchGL(WebGL2RenderingContext.prototype);
+    if (typeof WebGL2RenderingContext !== 'undefined') patchGL(WebGL2RenderingContext.prototype);
   } catch (_) {}
 
   // Realistic hardware values

--- a/controller/app/mcp_transport.py
+++ b/controller/app/mcp_transport.py
@@ -27,7 +27,10 @@ SUPPORTED_PROTOCOL_VERSIONS = (
     "2025-03-26",
 )
 CURRENT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
-INITIALIZATION_REQUIRED_ERROR = -32002
+# -32002 is the spec's "resource not found" code and is used as such below, so
+# reusing it here left clients unable to tell "send initialized first" apart
+# from "no such resource". -32005 sits in the implementation-defined range.
+INITIALIZATION_REQUIRED_ERROR = -32005
 logger = logging.getLogger(__name__)
 
 
@@ -479,20 +482,26 @@ class McpHttpTransport:
 
     def _handle_initialize(self, request_id: Any, params: dict[str, Any]) -> Response:
         requested_version = params.get("protocolVersion")
-        if requested_version not in SUPPORTED_PROTOCOL_VERSIONS:
-            return self._json_error_response(
-                request_id,
-                -32602,
-                "Unsupported MCP protocol version",
-                data={
-                    "requested": requested_version,
-                    "supported": list(SUPPORTED_PROTOCOL_VERSIONS),
-                },
+        if requested_version in SUPPORTED_PROTOCOL_VERSIONS:
+            negotiated_version = requested_version
+        else:
+            # The spec requires a counter-offer here, not an error: "the server
+            # MUST respond with another protocol version it supports". Returning
+            # -32602 killed the connection outright for any client that opened
+            # with a version we do not speak — including a newer client probing
+            # for backwards compatibility, which is exactly the case graceful
+            # downgrade exists to serve. The client compares this against what it
+            # supports and disconnects itself if it cannot proceed.
+            negotiated_version = CURRENT_PROTOCOL_VERSION
+            logger.info(
+                "MCP client requested unsupported protocol version %r; offering %s",
+                requested_version,
+                negotiated_version,
             )
 
         session = McpSession(
             id=uuid4().hex,
-            protocol_version=requested_version,
+            protocol_version=negotiated_version,
             client_info=self._coerce_dict(params.get("clientInfo")),
             client_capabilities=self._coerce_dict(params.get("capabilities")),
         )

--- a/controller/app/tool_gateway/gateway.py
+++ b/controller/app/tool_gateway/gateway.py
@@ -738,7 +738,7 @@ class McpToolGateway:
         return {"session_id": payload.session_id, "key": payload.key, "set": True}
 
     async def _export_script(self, payload: ExportScriptInput) -> dict[str, Any]:
-        from .playwright_export import export_session_script
+        from ..playwright_export import export_session_script
 
         session = await self.manager.get_session(payload.session_id)
         start_url = session.page.url

--- a/controller/app/tool_gateway/packs/dom.py
+++ b/controller/app/tool_gateway/packs/dom.py
@@ -38,9 +38,10 @@ def register(registry, gateway):
         ToolSpec(
             name="browser.get_html",
             description=(
-                "Get the HTML source of the current page. "
-                "Set text_only=true to strip tags and return plain text. "
-                "Set full_page=false (default) for visible viewport only."
+                "Get the HTML source of the current page. Returns the full "
+                "serialized DOM, not just the visible viewport. "
+                "Set text_only=true to strip tags and return plain text instead. "
+                "(full_page is deprecated and ignored.)"
             ),
             input_model=GetPageHtmlInput,
             handler=gateway._get_html,

--- a/controller/app/tool_inputs.py
+++ b/controller/app/tool_inputs.py
@@ -538,5 +538,13 @@ class TriggerCronJobInput(CronJobIdInput):
 
 
 class GetPageHtmlInput(SessionIdInput):
-    full_page: bool = False
+    # Deprecated and ignored. page.content() always returns the full serialized
+    # DOM, so this never had anything to switch on — the handler has never read
+    # it. Still accepted so existing callers do not start getting 422s in a
+    # patch release; remove in 1.6.0.
+    full_page: bool = Field(
+        default=False,
+        description="Deprecated and ignored — get_html always returns the full page.",
+        deprecated=True,
+    )
     text_only: bool = False

--- a/controller/tests/test_browser_scripts_syntax.py
+++ b/controller/tests/test_browser_scripts_syntax.py
@@ -1,0 +1,86 @@
+"""Every shipped JavaScript snippet must actually parse as JavaScript.
+
+`STEALTH_INIT_SCRIPT` contained two shell-escape artifacts — `if (\\!window.chrome)`
+and `typeof WebGL2RenderingContext \\!== 'undefined'` — inside an r-string, so the
+backslashes reached the JS source verbatim. `page.add_init_script` installed a
+script that threw `SyntaxError` at parse time in every page context, meaning no
+stealth patch had *ever* applied. The failure happened page-side, so nothing in
+Python saw an exception and nothing in CI went red.
+
+These strings are only ever executed by a browser, so Python's own tooling can
+never validate them. This gate parses each one with Node.
+
+Skips cleanly when node is unavailable so the suite stays portable; CI has Node
+24 on the runner.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app import browser_scripts
+
+NODE = shutil.which("node")
+
+SCRIPT_NAMES = sorted(
+    name
+    for name in dir(browser_scripts)
+    if name.endswith("_SCRIPT") and isinstance(getattr(browser_scripts, name), str)
+)
+
+
+def _node_check(source: str) -> tuple[bool, str]:
+    """True if node can parse `source` as a script."""
+    handle = tempfile.NamedTemporaryFile("w", suffix=".js", delete=False, encoding="utf-8")
+    try:
+        handle.write(source)
+    finally:
+        handle.close()
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed argv, temp path
+            [NODE, "--check", handle.name],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.returncode == 0, result.stderr
+    finally:
+        Path(handle.name).unlink(missing_ok=True)
+
+
+def test_script_constants_were_discovered() -> None:
+    """Guard the guard — an empty list would make every case below vacuous."""
+    assert len(SCRIPT_NAMES) >= 10
+    assert "STEALTH_INIT_SCRIPT" in SCRIPT_NAMES
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available")
+@pytest.mark.parametrize("name", SCRIPT_NAMES)
+def test_script_is_valid_javascript(name: str) -> None:
+    source = getattr(browser_scripts, name)
+
+    # Statement-style scripts (STEALTH_INIT_SCRIPT) parse as-is. Expression-style
+    # ones (the `(args) => {...}` snippets passed to page.evaluate) need wrapping
+    # to be a complete script. Either shape is legitimate here.
+    ok, stderr = _node_check(source)
+    if not ok:
+        ok, stderr = _node_check(f"void (\n{source}\n);")
+
+    assert ok, f"{name} is not valid JavaScript:\n{stderr}"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available")
+def test_no_shell_escape_artifacts_in_scripts() -> None:
+    r"""`\!` is never valid JS and is the specific artifact that shipped."""
+    for name in SCRIPT_NAMES:
+        source = getattr(browser_scripts, name)
+        assert "\\!" not in source, (
+            f"{name} contains a backslash-bang, a shell-escaping artifact. "
+            r"In JS `\!` is a syntax error, so the whole script fails to parse "
+            "page-side and silently does nothing."
+        )

--- a/controller/tests/test_mcp_transport.py
+++ b/controller/tests/test_mcp_transport.py
@@ -75,6 +75,45 @@ class McpTransportTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.tempdir.cleanup()
 
+    def _initialize_with_version(self, version: str):
+        return self.client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": version,
+                    "clientInfo": {"name": "pytest", "version": "1.0.0"},
+                    "capabilities": {},
+                },
+            },
+        )
+
+    def test_unknown_protocol_version_gets_a_counter_offer_not_an_error(self) -> None:
+        """The spec requires a supported version in the result, not an error.
+
+        Returning -32602 killed the connection for any client opening with a
+        version we do not speak — including a newer client probing for backwards
+        compatibility, which is exactly what graceful downgrade exists for. The
+        client compares the offer against what it supports and disconnects itself
+        if it cannot proceed.
+        """
+        response = self._initialize_with_version("2099-01-01")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertNotIn("error", body, "unknown version must not be a hard error")
+        self.assertEqual(body["result"]["protocolVersion"], "2025-11-25")
+        self.assertEqual(response.headers[MCP_PROTOCOL_HEADER], "2025-11-25")
+
+    def test_older_supported_protocol_version_is_honoured(self) -> None:
+        """A counter-offer must not clobber a version we genuinely support."""
+        response = self._initialize_with_version("2025-06-18")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["result"]["protocolVersion"], "2025-06-18")
+
     def _initialize(self) -> tuple[str, str]:
         response = self.client.post(
             "/mcp",
@@ -116,7 +155,11 @@ class McpTransportTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         body = response.json()
-        self.assertEqual(body["error"]["code"], -32002)
+        # -32005, not -32002: the latter is the spec's "resource not found" code
+        # and is asserted as such elsewhere in this file. Sharing one code left
+        # clients unable to distinguish "send initialized first" from "no such
+        # resource".
+        self.assertEqual(body["error"]["code"], -32005)
         self.assertIn("notifications/initialized", body["error"]["message"])
 
     def test_tools_list_and_call_work_after_initialization(self) -> None:

--- a/controller/tests/test_tool_surface_walk.py
+++ b/controller/tests/test_tool_surface_walk.py
@@ -1,0 +1,85 @@
+"""Lazy relative imports must resolve to modules that actually exist.
+
+`browser.export_script` shipped broken: `tool_gateway/gateway.py` did
+`from .playwright_export import export_session_script`, which resolves to
+`app.tool_gateway.playwright_export` — a module that does not exist. The real
+module is `app.playwright_export`, and the REST route imported it correctly
+(`from ..playwright_export`), which hid the difference.
+
+Because the import sat *inside* the handler body, it only ran when an MCP client
+called the tool. Every call raised ModuleNotFoundError, the gateway's catch-all
+collapsed it into the opaque "Tool execution failed", and no test exercised the
+gateway path for that tool — so CI stayed green while a published tool was 100%
+broken.
+
+A function-level import is invisible to import-time checks and to linters that
+only resolve top-level imports, so nothing else in this repo covers it. This
+walks every module in `app/` and resolves every relative import, at any nesting
+depth, whether module-level or lazy.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+APP_ROOT = Path(__file__).resolve().parent.parent / "app"
+
+
+def _module_name_for(path: Path) -> str:
+    """app/tool_gateway/gateway.py -> app.tool_gateway.gateway"""
+    rel = path.relative_to(APP_ROOT.parent).with_suffix("")
+    parts = list(rel.parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _relative_imports(path: Path) -> list[tuple[int, int, str]]:
+    """Every `from .x import y` in the file as (lineno, level, module)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return [
+        (node.lineno, node.level, node.module or "")
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.level and node.level > 0
+    ]
+
+
+def _resolve(importer: str, level: int, module: str) -> str:
+    """Mirror Python's relative-import resolution."""
+    base = importer
+    # A module (not a package) consumes one level to reach its own package.
+    for _ in range(level):
+        base = base.rpartition(".")[0]
+    return f"{base}.{module}" if module else base
+
+
+ALL_MODULES = sorted(p for p in APP_ROOT.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+@pytest.mark.parametrize("path", ALL_MODULES, ids=lambda p: _module_name_for(p))
+def test_relative_imports_resolve(path: Path) -> None:
+    importer = _module_name_for(path)
+    is_package = path.name == "__init__.py"
+
+    for lineno, level, module in _relative_imports(path):
+        # Inside a package's __init__, level 1 means the package itself.
+        effective_level = level - 1 if is_package else level
+        target = _resolve(importer, effective_level, module)
+
+        assert importlib.util.find_spec(target) is not None, (
+            f"{importer}:{lineno} imports {'.' * level}{module!r}, which resolves "
+            f"to {target!r} — that module does not exist. If this import is inside "
+            f"a function body it will raise ModuleNotFoundError only when that code "
+            f"path runs in production."
+        )
+
+
+def test_walk_actually_covers_the_gateway() -> None:
+    """Guard the guard: the scan must reach the file the bug shipped in."""
+    names = {_module_name_for(p) for p in ALL_MODULES}
+    assert "app.tool_gateway.gateway" in names
+    assert len(names) > 100, "expected the whole app package to be walked"


### PR DESCRIPTION
Five defects on the MCP surface. Three of them meant a shipped, advertised capability did nothing at all.

### `browser.export_script` has never worked over MCP

`gateway.py` lives in `app.tool_gateway`, so `from .playwright_export import ...` resolved to `app.tool_gateway.playwright_export` — which does not exist. The real module is `app.playwright_export`, and the REST route imported it correctly (`from ..playwright_export`), which hid the difference.

```
find_spec("app.tool_gateway.playwright_export") -> None
find_spec("app.playwright_export")              -> FOUND
```

Every MCP call raised `ModuleNotFoundError`; the gateway catch-all collapsed it into the opaque "Tool execution failed". **Zero tests referenced the tool.** The fix is one character.

### The stealth init script was never valid JavaScript

Two shell-escape artifacts (`\!`) sat inside an `r"""` string, so the backslashes reached the JS source. `node --check` fails at line 11. `add_init_script` therefore installed a script that threw at parse time in **every** page context — no stealth patch has ever applied, silently, page-side, where Python never sees an exception.

Impact is genuinely low: stealth is default-off and "not a stealth browser" is an explicit non-goal in `ROADMAP.md`. The **defect class** is the point.

### Version negotiation violated a spec MUST

`_handle_initialize` returned `-32602` for any unrecognised `protocolVersion`. The spec requires responding with a version the server *does* support, so the client can downgrade. A newer client probing for backwards compatibility got a dead connection instead of the graceful path the rule exists to provide.

### `-32002` meant two different things

It is the spec's "resource not found" code, and was also used for "initialization required" — so a client could not tell them apart. The giveaway: `test_mcp_transport.py` asserted **both** meanings on the same code. Init-required moves to `-32005` (implementation-defined range); resource-not-found keeps `-32002`.

### `browser.get_html` advertised a parameter that does nothing

`full_page` was in the published schema and the description promised "visible viewport only" — but the handler never read it, and `page.content()` always returns the full DOM. The description was wrong twice over.

Kept accepted rather than removed: a 422 in a patch release would break anyone currently passing it. Marked deprecated, description corrected, slated for removal in 1.6.0.

### Two new gates, both confirmed to fail against the pre-fix code

**`test_tool_surface_walk.py`** resolves every relative import in every module under `app/` — any depth, module-level or lazy. Function-body imports are invisible to import-time checks and to linters that only resolve top-level imports, which is precisely why `export_script` survived. Walks 129 modules. Reverting the fix produces:

```
app.tool_gateway.gateway:741 imports .'playwright_export', which resolves to
'app.tool_gateway.playwright_export' — that module does not exist.
```

**`test_browser_scripts_syntax.py`** parses all 15 shipped `*_SCRIPT` constants with `node --check`, and separately rejects backslash-bang outright. These strings only ever execute in a browser, so Python tooling can never validate them. Skips cleanly when node is absent; CI has Node 24.

**661 → 809 passed**, 2 skipped, 199 subtests. `ruff check` clean, bridge parity intact.