### PR TITLE
release: v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,106 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.5.1] — 2026-08-04
+
+Found by an adversarial audit of this repo, not by a user report. Several safety
+controls were asserted in code and documentation but never verified end to end,
+and three of them silently did nothing while reporting success. Every one was
+green in CI.
+
+**If you rely on screenshot PII redaction, upgrade.** The severity is bounded by
+auto-browser being local-first and single-tenant — for most operators the
+affected artifacts never left their own box — but the real exposure surfaces are
+shared session links, auth-profile exports, and remote witness sinks.
+
 ### Security
+
+- **Screenshot PII redaction was a silent no-op.** `OCRExtractor` emits geometry
+  nested under `block["bbox"]`; `scrub_screenshot` read flat `x`/`y`/`width`/
+  `height`, so every `.get(..., 0)` fell to its default and every redaction
+  rectangle computed to `(0, 0, 0, 0)`. Measured on a rendered image: **307 ink
+  pixels in the secret region before, 307 after**, while the function returned a
+  hit and the caller wrote a `pii_redaction / ok` audit event over an unredacted
+  screenshot — which was then stored under `/data/artifacts/`, served over
+  `/artifacts/`, and handed to the model. The existing test fed flat keys, a
+  shape production never produces, which is why nothing caught it. A degenerate
+  box is now refused rather than counted as a redaction (#129).
+- **A typo in `PII_SCRUB_PATTERNS` disabled all PII scrubbing, fail-open.**
+  Unknown pattern names were "silently dropped" by intersecting with the known
+  set, so `PII_SCRUB_PATTERNS="emial,phon"` produced an empty set — and an empty
+  but non-`None` set makes `scrub_text` skip every pattern. `summary()` still
+  reported `enabled: True`. Unknown names now raise at construction (#129).
+- **The AWS access-key pattern could never match a real key.** It spelled the
+  prefix as `A[KSIARP][IDA]` (3 chars) + 16 = 19 characters; real AWS key ids are
+  20, so the trailing lookahead rejected every one. `AKIAIOSFODNN7EXAMPLE` passed
+  through unredacted. The eight documented prefixes are now explicit (#129).
+- **Most screenshots were never redacted at all.** `PII_SCRUB_SCREENSHOT=true`
+  only covered `normal`/`rich` observes. The `fast` preset, manual captures, and
+  the before/after snapshot taken on **every action** wrote unredacted PNGs. All
+  screenshot writes now go through one redacting path (#129).
+- **Redaction was starved by a token budget.** `image_to_data` returns one block
+  per *word*, and the list was truncated at `ocr_max_blocks` (default 20), so
+  only the first ~20 words of a page could ever be redacted — a navigation bar
+  exhausted the budget before the content. OCR now returns an uncapped
+  `redaction_blocks` alongside the capped model-facing `blocks`, and
+  low-confidence blocks stay redaction-eligible because dropping them is
+  fail-open for privacy (#129).
 - **`cryptography` 49.0.0 → 50.0.0 for CVE-2026-69247.** [GHSA-g6cj-pr64-35w5](https://github.com/advisories/GHSA-g6cj-pr64-35w5) is a Bleichenbacher oracle in PKCS#7 `EnvelopedData` decryption: `pkcs7_decrypt_der`/`_pem`/`_smime` distinguished invalid RSA padding from a wrong key length (leaking the recovered length) from bad content padding, by both error and timing. **Not reachable in this controller** — `cryptography` is used here only for `Fernet` (auth state at rest) and `Ed25519` (mesh identity), neither of which is on the affected path. The bump clears a real CVE off a pinned runtime dependency rather than closing a live hole here, and it unblocked `dependency-audit`, which had gone red on every open PR the day the advisory published (#120).
 
 ### Changed
 - **Playwright upgraded to 1.62.0 on both the pip and npm sides together** (#122), and Dependabot no longer proposes it from either ecosystem (#124). Playwright's websocket protocol requires an exact client/server version match, but the two pins are separate ecosystems to Dependabot, so it can only ever open half the change — which is not a smaller upgrade but the #60 outage, where every `docker compose up --build` crash-looped on readiness. It re-proposed that half in #97 (npm) and #121 (pip); `scripts/check_playwright_pins.py` blocked both. The guard stays and Playwright is now bumped by hand on both sides at once. 1.62 also raises the engine floor to Node ≥ 20, which `browser-node` meets because `python:3.11-slim` now aliases Debian trixie (Node 20.19).
 - Dependency bumps: `fastapi` `>=0.141.1,<0.142` (#115), `uvicorn[standard]` 0.52.0, `redis` 8.1.0, `prometheus-client` 0.26.0, `ruff` 0.16.1 (#124).
+
+### Fixed
+- **`browser.export_script` had never worked over MCP.** `tool_gateway/gateway.py`
+  did `from .playwright_export import ...`, which resolves to
+  `app.tool_gateway.playwright_export` — a module that does not exist. The real
+  module is `app.playwright_export`, and the REST route imported it correctly,
+  which hid the difference. Every MCP call raised `ModuleNotFoundError` and the
+  catch-all collapsed it into the opaque "Tool execution failed". No test touched
+  the tool (#130).
+- **The stealth init script was never valid JavaScript.** Two shell-escape
+  artifacts (`\!`) inside an r-string reached the JS source, so
+  `add_init_script` installed a script that threw at parse time in every page
+  context — no stealth patch had ever applied, silently and page-side. Stealth
+  is default-off and an explicit non-goal, so impact is low; the defect class is
+  the point (#130).
+- **MCP version negotiation violated a spec MUST.** `initialize` returned
+  `-32602` for any unrecognised `protocolVersion`. The spec requires responding
+  with a version the server *does* support so the client can downgrade, so a
+  newer client probing for backwards compatibility got a dead connection instead
+  of the graceful path (#130).
+- **`-32002` meant two different things** — the spec's "resource not found" and
+  "initialization required" — so clients could not tell them apart.
+  Initialization-required moves to `-32005` (#130).
+- **`browser.get_html` advertised a parameter that does nothing.** `full_page`
+  was in the published schema and the description promised "visible viewport
+  only", but the handler never read it and `page.content()` always returns the
+  full DOM. Still accepted so callers passing it do not start getting 422s;
+  marked deprecated and slated for removal in 1.6.0 (#130).
+
+### CI
+- **The Docker job ran 566 of 637 tests.** `controller-tests` used
+  `unittest discover`, which only collects `unittest.TestCase` subclasses — so
+  `test_1_0.py` (61 tests: mesh Ed25519 identity and signing, peer registry,
+  delegation policy, stealth, network inspector, CDP, workflow engine),
+  `test_pii_scrub.py` (8) and `test_readiness.py` (4) were invisible to it. The
+  one required check that validates the shipped container ran zero PII-scrubber
+  and zero mesh-crypto tests, and any new pytest-style file would have been
+  dropped from it with no warning. Now runs pytest (#128).
+- **Two gates for the defect class behind this release**, both confirmed to fail
+  against the pre-fix code. `test_tool_surface_walk.py` resolves every relative
+  import in all 129 modules under `app/`, at any depth, module-level or lazy —
+  function-body imports are invisible to import-time checks and to linters that
+  only resolve top-level imports, which is exactly why `export_script` survived.
+  `test_browser_scripts_syntax.py` parses all 15 shipped `*_SCRIPT` constants
+  with `node --check`; those strings only ever execute in a browser, so Python
+  tooling could never validate them (#130).
+- **All 16 PII patterns now have a behavioural test**, plus a completeness test
+  that fails if a pattern is added without one. Twelve had no assertion at all,
+  which is how the AWS defect survived. Redaction tests now assert pixels
+  changed, driven through the real OCR code path so the two modules cannot drift
+  apart again (#129).
 
 ### Added
 - **`session_id` may be omitted on MCP tools.** With exactly one live session, tools target it; with none live, observe/act tools (`observe`, `execute_action`, `find_elements`, `screenshot`, `get_html`, `wait_for_selector`) create one on demand — an agent's first `browser.observe` now works with zero setup calls. Anything ambiguous (multiple live sessions, or a non-create tool with none) stays an explicit structured error (`ambiguous_session` / `no_session`) rather than a guess. Explicit `session_id` behavior is unchanged.

--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-browser-browser-node",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "playwright": "1.62.0"
       }

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -3,4 +3,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.5.0"
+version = "1.5.1"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/controller/app/version.py
+++ b/controller/app/version.py
@@ -4,4 +4,4 @@ Bump together with the package versions in */pyproject.toml and
 browser-node/package.json during release prep.
 """
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.5.0"
+version = "1.5.1"
 description = "Controller API for auto-browser"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.5.0"
+version = "1.5.1"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # console script against that dependency.
 [project]
 name = "auto-browser-mcp"
-version = "1.5.0"
+version = "1.5.1"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Security patch release. Bumps all nine version strings to 1.5.1 and adds the CHANGELOG section the release workflow extracts for the GitHub release notes.

### What is in it

Several safety controls were asserted in code and documentation but never verified end to end. **Three of them silently did nothing while reporting success**, and every one was green in CI. Found by an adversarial audit of this repo, not by a user report.

The headline: **screenshot PII redaction had never redacted anything.** `OCRExtractor` nests geometry under `block["bbox"]`; `scrub_screenshot` read it flat, so every rectangle collapsed to `(0,0,0,0)`. Measured 307 ink pixels in the secret region before *and* after, while the caller wrote a `pii_redaction / ok` audit event over an unredacted image that then went to `/artifacts/` and to the model.

Alongside it: a typo in `PII_SCRUB_PATTERNS` disabled all scrubbing fail-open; the AWS key pattern was one character too short to ever match a real key; the `fast` preset and per-action snapshots skipped redaction entirely; `browser.export_script` had never worked over MCP; the stealth script was never valid JavaScript; and MCP version negotiation violated a spec MUST.

### Severity, stated honestly

auto-browser is local-first and single-tenant, so for most operators the affected artifacts never left their own box. The real exposure surfaces are **shared session links, auth-profile exports, and remote witness sinks**. The CHANGELOG says exactly that — no more and no less.

### One deliberate non-change

The `auto-browser-mcp` dependency floor stays at `>=1.5.0`. A blanket version replace had tightened it to `>=1.5.1`; nothing in this release requires the newer client, so tightening it would cut compatibility for no reason. Caught by reading the diff rather than trusting the replace.

### Verification

| gate | result |
|---|---|
| controller suite | **809 passed**, 2 skipped, 199 subtests (was 637 at v1.5.0) |
| `check_version_parity.py` | 9/9 agree on **1.5.1** |
| `check_playwright_pins.py` | matched at 1.62.0 |
| `check_bridge_parity.py` | byte-identical |
| `ruff check .` | clean |
| `extract_changelog.py 1.5.1` | 94 lines of notes, extracts cleanly |

### After merge

Tagging `v1.5.1` publishes `auto-browser-client`, `auto-browser-langchain`, and `auto-browser-mcp` to PyPI via trusted publishing and creates the GitHub release. **PyPI versions cannot be reused**, so I will confirm this PR is merged and green before pushing the tag.

Worth noting: those three packages have only formatting changes since 1.5.0 — every substantive fix is in `controller/`, which ships via git and compose rather than PyPI. They are republished because the parity system deliberately moves all nine strings together, and because the GitHub release is how the security fixes get announced.

### Recommended follow-up, your call

A **GitHub Security Advisory** for the two PII defects. A privacy control that silently did nothing, and a fail-open kill switch, are security-relevant to anyone who shared session links, exported auth profiles, or pointed a remote witness sink at their box — and a CHANGELOG entry does not notify watchers or feed scanners the way a GHSA does. I have not filed one: severity classification and whether to request a CVE are yours to decide.