### PR TITLE
fix(runtime): stop the cron leak, the dying cleanup loop, and four silent failures

### DIFF
--- a/controller/app/agent_jobs.py
+++ b/controller/app/agent_jobs.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from uuid import uuid4
 
@@ -240,6 +241,27 @@ class AgentJobQueue:
         self.audit = audit_store
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._cancellation_reasons: dict[str, str] = {}
+        # job_id -> coroutine function invoked once the job reaches a terminal
+        # state, whatever that state is. Used by callers that created a session
+        # solely to run this job and must close it afterwards (see CronService).
+        # Deliberately in-memory: if the controller restarts, the browser
+        # sessions these callbacks would close are gone with it.
+        self._on_finish: dict[str, Callable[[], Awaitable[None]]] = {}
+
+    def on_finish(self, job_id: str, callback: Callable[[], Awaitable[None]]) -> None:
+        """Register a callback to run when `job_id` reaches a terminal state."""
+        self._on_finish[job_id] = callback
+
+    async def _run_finish_callback(self, job_id: str) -> None:
+        callback = self._on_finish.pop(job_id, None)
+        if callback is None:
+            return
+        try:
+            await callback()
+        except Exception:
+            # Never let cleanup failure escape into the worker loop — but never
+            # swallow it silently either, or a leaked session looks like success.
+            logger.exception("finish callback for agent job %s failed", job_id)
 
     async def startup(self) -> None:
         await self.store.startup()
@@ -386,8 +408,18 @@ class AgentJobQueue:
                 self.queue.task_done()
 
     async def _process_job(self, job_id: str) -> None:
+        try:
+            await self._process_job_inner(job_id)
+        finally:
+            # Runs on success, failure, and cancellation alike. Whoever created a
+            # session purely to host this job gets it back here or not at all.
+            await self._run_finish_callback(job_id)
+
+    async def _process_job_inner(self, job_id: str) -> None:
         record = await self.store.start_queued(job_id)
         if record is None:
+            # Not in a queued state — nothing will run, so the caller's session
+            # still needs releasing. _process_job's finally does that.
             return
 
         await self._audit("agent_job_started", "running", record)
@@ -433,8 +465,19 @@ class AgentJobQueue:
             event_type = "agent_job_cancelled" if user_cancelled else "agent_job_interrupted"
             await self._audit(event_type, record.status, record)
             raise
-        except Exception:
-            record = await self.store.finish(record.id, status="failed", result=None, error="agent_job_failed")
+        except Exception as exc:
+            # Previously a bare `except Exception` that recorded the constant
+            # string "agent_job_failed" and logged nothing at all, so a crashing
+            # provider adapter, a Playwright error, or a JSON parse failure were
+            # indistinguishable and left no server-side traceback.
+            logger.exception("agent job %s failed", job_id)
+            detail = f"{type(exc).__name__}: {exc}"
+            record = await self.store.finish(
+                record.id,
+                status="failed",
+                result=None,
+                error=detail[:500],
+            )
         await self._audit("agent_job_finished", record.status, record)
 
     async def _audit(self, event_type: str, status: str, record: AgentJobRecord) -> None:

--- a/controller/app/audit.py
+++ b/controller/app/audit.py
@@ -102,12 +102,21 @@ class FileAuditStore:
         if not self.events_path.exists():
             return []
         events: list[AuditEvent] = []
+        malformed = 0
         with self.events_path.open(encoding="utf-8") as fh:
             for raw in fh:
                 raw = raw.strip()
                 if not raw:
                     continue
-                event = AuditEvent.model_validate_json(raw)
+                try:
+                    event = AuditEvent.model_validate_json(raw)
+                except Exception:
+                    # One torn line — a kill mid-append leaves a partial record —
+                    # used to raise here, so listing 500s'd permanently and
+                    # _trim_sync could never age the bad line out. Skip and count
+                    # instead, matching AgentJobStore._list_sync.
+                    malformed += 1
+                    continue
                 if session_id and event.session_id != session_id:
                     continue
                 if event_type and event.event_type != event_type:
@@ -115,6 +124,12 @@ class FileAuditStore:
                 if operator_id and event.operator.id != operator_id:
                     continue
                 events.append(event)
+        if malformed:
+            logger.warning(
+                "skipped %d malformed line(s) in %s while listing audit events",
+                malformed,
+                self.events_path,
+            )
         events.reverse()
         return events[:limit]
 

--- a/controller/app/cron_service.py
+++ b/controller/app/cron_service.py
@@ -72,6 +72,9 @@ class CronService:
         self.manager = manager
         self._scheduler: Any = None
         self._lock = asyncio.Lock()
+        # cron job id -> session id currently hosting its run. Guards against
+        # overlapping fires and records what _release_run must close.
+        self._active_runs: dict[str, str] = {}
 
     async def startup(self) -> None:
         """Start the scheduler and register all enabled cron jobs."""
@@ -254,6 +257,17 @@ class CronService:
 
         from .models import AgentRunRequest
 
+        # Refuse to start a second run while this job's previous one is still in
+        # flight. Without this, a schedule faster than its own runtime stacks up
+        # sessions and hits the session cap even with the release below.
+        if job_id in self._active_runs:
+            logger.warning(
+                "cron job %s skipped: previous run (session %s) is still active",
+                job_id,
+                self._active_runs[job_id],
+            )
+            return {"triggered": False, "job_id": job_id, "reason": "previous_run_active"}
+
         # Create session for the job
         session_result = await self.manager.create_session(
             name=f"cron-{job_id}",
@@ -262,6 +276,7 @@ class CronService:
             proxy_persona=job.get("proxy_persona"),
         )
         session_id = session_result["id"]
+        self._active_runs[job_id] = session_id
 
         # Enqueue agent run
         run_request = AgentRunRequest(
@@ -269,7 +284,24 @@ class CronService:
             goal=job["goal"],
             max_steps=job.get("max_steps", 20),
         )
-        queued = await self.job_queue.enqueue_run(session_id, run_request)
+        try:
+            queued = await self.job_queue.enqueue_run(session_id, run_request)
+        except Exception:
+            # Enqueue can reject (queue at capacity). The session exists but
+            # nothing will ever run in it, so release it here rather than
+            # stranding it until restart.
+            await self._release_run(job_id, session_id)
+            raise
+
+        # This session exists only to host this job, and nothing else will ever
+        # close it. Before this, the first cron fire consumed a session slot
+        # permanently — with MAX_SESSIONS defaulting to 1, every later fire and
+        # every manual create_session then failed "Session limit reached", and
+        # under docker_ephemeral each fire also leaked a browser container.
+        self.job_queue.on_finish(
+            queued["id"],
+            lambda: self._release_run(job_id, session_id),
+        )
 
         # Update run metadata
         async with self._lock:
@@ -287,14 +319,48 @@ class CronService:
             "queued_job": queued,
         }
 
+    async def _release_run(self, job_id: str, session_id: str) -> None:
+        """Close the session a cron run was given, and clear the in-flight mark.
+
+        Called from the job queue's finish callback on completion, failure and
+        cancellation alike. The mark is cleared even if the close fails —
+        otherwise one stuck close would block that cron job forever.
+        """
+        self._active_runs.pop(job_id, None)
+        if self.manager is None:
+            return
+        try:
+            await self.manager.close_session(session_id)
+        except Exception as exc:
+            logger.warning(
+                "cron job %s: failed to close session %s: %s",
+                job_id,
+                session_id,
+                exc,
+            )
+
     def _load(self) -> dict[str, Any]:
         if not self._store_path.exists():
             return {}
         try:
             return json.loads(self._store_path.read_text(encoding="utf-8"))
         except Exception as exc:
-            logger.warning("failed to load cron store %s: %s", self._store_path, exc)
-            return {}
+            # Do NOT return {} here. That looked harmless but was destructive:
+            # the next _save() persisted the empty dict over the damaged file,
+            # permanently erasing every cron job the operator had defined. A
+            # fallback that hides a bug is worse than the bug.
+            quarantine = self._store_path.with_suffix(f".corrupt-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}.json")
+            try:
+                self._store_path.replace(quarantine)
+                logger.error(
+                    "cron store %s is unreadable (%s); moved to %s. Cron jobs are not loaded until this is resolved.",
+                    self._store_path,
+                    exc,
+                    quarantine,
+                )
+            except Exception:
+                logger.exception("cron store %s is unreadable and could not be quarantined", self._store_path)
+            raise RuntimeError(f"cron store {self._store_path} is unreadable: {exc}") from exc
 
     def _save(self, data: dict[str, Any]) -> None:
         self._store_path.parent.mkdir(parents=True, exist_ok=True)

--- a/controller/app/events.py
+++ b/controller/app/events.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 
 _SESSION_QUEUES: dict[str, list[asyncio.Queue]] = defaultdict(list)
 _GLOBAL_QUEUES: list[asyncio.Queue] = []
+# id(queue) -> events dropped for that subscriber. Keyed by id rather than the
+# queue itself because asyncio.Queue is unhashable-by-value and we only need a
+# counter, not a reference (holding one would pin dead subscribers in memory).
+_DROPPED_EVENTS: dict[int, int] = {}
 
 
 def _now() -> str:
@@ -64,13 +68,34 @@ def _dispatch(session_id: str, event: dict[str, Any]) -> None:
         try:
             q.put_nowait(payload)
         except asyncio.QueueFull:
-            logger.debug("SSE queue full for session %s — dropping event", session_id)
+            _record_drop(q, f"session {session_id}")
     # Push to global subscribers
     for q in list(_GLOBAL_QUEUES):
         try:
             q.put_nowait(payload)
         except asyncio.QueueFull:
-            logger.debug("SSE queue full for global subscriber — dropping event")
+            _record_drop(q, "global subscriber")
+
+
+def _record_drop(queue: asyncio.Queue, who: str) -> None:
+    """Count a dropped SSE event and warn the first time it happens per queue.
+
+    Drops were logged at DEBUG, so an operator watching a live stream silently
+    missed actions with nothing at the default log level to tell them. WARNING
+    once per subscriber keeps that visible without flooding the log when a slow
+    consumer drops continuously.
+    """
+    count = _DROPPED_EVENTS.get(id(queue), 0) + 1
+    _DROPPED_EVENTS[id(queue)] = count
+    if count == 1:
+        logger.warning("SSE queue full for %s — dropping events (consumer is too slow)", who)
+    else:
+        logger.debug("SSE queue full for %s — %d events dropped so far", who, count)
+
+
+def dropped_event_count() -> int:
+    """Total SSE events dropped across all subscribers since process start."""
+    return sum(_DROPPED_EVENTS.values())
 
 
 # ── Public emit helpers ──────────────────────────────────────────────────────

--- a/controller/app/maintenance.py
+++ b/controller/app/maintenance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -8,6 +9,8 @@ from typing import Callable, Iterable
 
 from .config import Settings
 from .utils import UTC
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -90,7 +93,15 @@ class MaintenanceService:
             try:
                 await asyncio.wait_for(self._stop_event.wait(), timeout=self.settings.cleanup_interval_seconds)
             except asyncio.TimeoutError:
-                await self.run_cleanup()
+                try:
+                    await self.run_cleanup()
+                except Exception:
+                    # A single failed sweep must not kill the loop. Previously any
+                    # exception here ended the task silently and nothing observed
+                    # it, so artifacts/uploads/auth grew forever with only a stale
+                    # last_report as the clue. The stat race below was a live
+                    # trigger for exactly this.
+                    logger.exception("cleanup sweep failed; the maintenance loop continues")
 
     def _cleanup_roots(self) -> list[tuple[str, float]]:
         return [
@@ -132,7 +143,14 @@ class MaintenanceService:
                 stats.skipped_recent += 1
                 continue
             if path.is_file():
-                size = path.stat().st_size
+                # Same FileNotFoundError race the mtime stat above already
+                # guards: a concurrent writer or another sweep can remove the
+                # file between the two stats. Unguarded, this propagated out of
+                # run_cleanup and killed the loop permanently.
+                try:
+                    size = path.stat().st_size
+                except FileNotFoundError:
+                    continue
                 path.unlink(missing_ok=True)
                 stats.deleted_files += 1
                 stats.bytes_reclaimed += size

--- a/controller/app/middleware/http.py
+++ b/controller/app/middleware/http.py
@@ -101,6 +101,19 @@ def install_controller_http_middleware(
         finally:
             reset_current_operator(token)
 
+    def _metric_path(request: Request) -> str:
+        """Prometheus label for a request path — always a bounded value.
+
+        Only the matched route *template* may become a label. Using the raw URL
+        path meant unmatched requests each minted their own label, so on a public
+        MCP endpoint ordinary scanner traffic grew the metrics registry without
+        bound for the lifetime of the process. Unmatched requests all collapse
+        into one bucket instead.
+        """
+        route = request.scope.get("route")
+        template = getattr(route, "path", None)
+        return template or "__unmatched__"
+
     @application.middleware("http")
     async def record_http_metrics(request: Request, call_next):
         if not metrics.enabled:
@@ -113,15 +126,14 @@ def install_controller_http_middleware(
             duration = time.perf_counter() - start
             metrics.record_http_request(
                 method=request.method,
-                path=_request_path(request),
+                path=_metric_path(request),
                 status_code=500,
                 duration_seconds=duration,
             )
             raise
 
         duration = time.perf_counter() - start
-        route = request.scope.get("route")
-        path = getattr(route, "path", None) or _request_path(request)
+        path = _metric_path(request)
         metrics.record_http_request(
             method=request.method,
             path=path,

--- a/controller/app/orchestrator.py
+++ b/controller/app/orchestrator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -10,6 +11,8 @@ from .browser_manager import BrowserManager
 from .models import AgentRunResult, AgentStepResult, ProviderName, WorkflowProfile
 from .provider_registry import ProviderRegistry
 from .providers.base import ProviderAPIError, ProviderDecision
+
+logger = logging.getLogger(__name__)
 
 
 class BrowserOrchestrator:
@@ -76,13 +79,20 @@ class BrowserOrchestrator:
                 error_code=None,
             )
         except Exception as exc:
+            # This module logged nothing at all, so a crashing provider adapter,
+            # a Playwright error and a JSON parse failure were indistinguishable
+            # — the caller got the constant string "Agent step failed" and there
+            # was no server-side traceback anywhere to diagnose from.
+            logger.exception("agent step failed for session %s (provider=%s)", session_id, provider_name)
             if isinstance(exc, ProviderAPIError):
                 error_code: int | None = exc.status_code or (503 if exc.retryable else 502)
             elif isinstance(exc, httpx.HTTPStatusError):
                 error_code = exc.response.status_code
             else:
                 error_code = None
-            error_message = "Provider request failed" if error_code else "Agent step failed"
+            error_message = (
+                "Provider request failed" if error_code else f"Agent step failed: {type(exc).__name__}: {exc}"[:300]
+            )
             result = AgentStepResult(
                 provider=provider_name,
                 model=model_name,

--- a/controller/app/session_store.py
+++ b/controller/app/session_store.py
@@ -92,7 +92,16 @@ class RedisSessionStore(_MarkInterruptedMixin):
         self.client: Redis | None = None
 
     async def startup(self) -> None:
-        self.client = redis_from_url(self.url, decode_responses=True)
+        # Without timeouts a *hung* redis (as opposed to a refused connection)
+        # blocks indefinitely. upsert() runs inside create_session and after
+        # every successful action, so a silently wedged redis froze all session
+        # activity with no error and no timeout to surface it.
+        self.client = redis_from_url(
+            self.url,
+            decode_responses=True,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
         await self.client.ping()
 
     async def shutdown(self) -> None:

--- a/controller/app/utils.py
+++ b/controller/app/utils.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Coroutine
 from datetime import datetime, timezone
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 UTC = timezone.utc
 
@@ -28,4 +31,19 @@ def spawn_background_task(coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
     task = asyncio.ensure_future(coro)
     _BACKGROUND_TASKS.add(task)
     task.add_done_callback(_BACKGROUND_TASKS.discard)
+    task.add_done_callback(_log_background_task_exception)
     return task
+
+
+def _log_background_task_exception(task: asyncio.Task[Any]) -> None:
+    """Surface failures in fire-and-forget tasks.
+
+    Nothing awaits these, so without this an exception only ever appeared as
+    asyncio's "exception was never retrieved" warning at garbage-collection
+    time — long after the fact, unattributed, and easy to miss entirely.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("background task %s failed: %s", task.get_name(), exc, exc_info=exc)

--- a/controller/tests/test_cron_service.py
+++ b/controller/tests/test_cron_service.py
@@ -92,8 +92,17 @@ class CronServiceTests(unittest.IsolatedAsyncioTestCase):
         scheduler.remove_job.assert_called_with(created["id"])
         self.assertIsInstance(updated["run_count"], int)
 
+        # A corrupt store must fail loudly and be quarantined. This previously
+        # asserted `_load() == {}` — pinning the destructive behaviour as
+        # correct, because the next _save() then wrote that empty dict over the
+        # damaged file and permanently erased every cron job.
         self.store_path.write_text("{bad json", encoding="utf-8")
-        self.assertEqual(service._load(), {})
+        with self.assertRaises(RuntimeError):
+            service._load()
+        self.assertFalse(self.store_path.exists())
+        quarantined = list(self.store_path.parent.glob("crons.corrupt-*.json"))
+        self.assertEqual(len(quarantined), 1)
+        self.assertEqual(quarantined[0].read_text(encoding="utf-8"), "{bad json")
 
         uninitialized = CronService(self.store_path)
         with self.assertRaises(RuntimeError):

--- a/controller/tests/test_input_validation.py
+++ b/controller/tests/test_input_validation.py
@@ -243,8 +243,16 @@ class BrowserManagerProxyPersonaTests(unittest.IsolatedAsyncioTestCase):
 class CronServiceProxyPersonaTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
-        self.manager = SimpleNamespace(create_session=AsyncMock(return_value={"id": "session-1"}))
-        self.job_queue = SimpleNamespace(enqueue_run=AsyncMock(return_value={"id": "job-1"}))
+        self.manager = SimpleNamespace(
+            create_session=AsyncMock(return_value={"id": "session-1"}),
+            close_session=AsyncMock(),
+        )
+        # on_finish is how the cron service hands back the session it created;
+        # without it the run would leak a session slot (see test_runtime_lifecycle).
+        self.job_queue = SimpleNamespace(
+            enqueue_run=AsyncMock(return_value={"id": "job-1"}),
+            on_finish=lambda job_id, callback: None,
+        )
         self.cron = CronService(
             Path(self.tempdir.name) / "crons.json",
             job_queue=self.job_queue,

--- a/controller/tests/test_runtime_lifecycle.py
+++ b/controller/tests/test_runtime_lifecycle.py
@@ -1,0 +1,277 @@
+"""Lifecycle regressions: things that leak, wedge, or die silently.
+
+Each test here corresponds to a defect that was invisible in production because
+the failure mode was *silence* — a session never released, a loop that stopped
+running, a store quietly emptied, an exception recorded as a constant string.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.audit import FileAuditStore
+from app.cron_service import CronService
+from app.maintenance import MaintenanceService
+
+
+class _FakeManager:
+    """Tracks create/close so a leaked session is observable."""
+
+    def __init__(self) -> None:
+        self.created: list[str] = []
+        self.closed: list[str] = []
+        self._counter = 0
+
+    async def create_session(self, **kwargs) -> dict:
+        self._counter += 1
+        session_id = f"sess-{self._counter}"
+        self.created.append(session_id)
+        return {"id": session_id}
+
+    async def close_session(self, session_id: str) -> None:
+        self.closed.append(session_id)
+
+    @property
+    def leaked(self) -> list[str]:
+        return [s for s in self.created if s not in self.closed]
+
+
+class _FakeJobQueue:
+    """Captures the finish callback instead of running a real worker."""
+
+    def __init__(self) -> None:
+        self.callbacks: dict[str, object] = {}
+        self.enqueued: list[str] = []
+        self.fail_enqueue = False
+
+    async def enqueue_run(self, session_id: str, payload) -> dict:
+        if self.fail_enqueue:
+            raise RuntimeError("Job queue is at capacity. Try again later.")
+        self.enqueued.append(session_id)
+        return {"id": f"job-for-{session_id}"}
+
+    def on_finish(self, job_id: str, callback) -> None:
+        self.callbacks[job_id] = callback
+
+    async def finish(self, job_id: str) -> None:
+        await self.callbacks[job_id]()
+
+
+def _cron(tmp_path: Path) -> tuple[CronService, _FakeManager, _FakeJobQueue]:
+    manager = _FakeManager()
+    queue = _FakeJobQueue()
+    service = CronService(tmp_path / "cron.json", job_queue=queue, manager=manager)
+    return service, manager, queue
+
+
+def _job(job_id: str = "j1") -> dict:
+    return {"id": job_id, "goal": "do a thing", "schedule": "* * * * *"}
+
+
+@pytest.mark.asyncio
+async def test_cron_session_is_closed_when_the_run_finishes(tmp_path: Path) -> None:
+    """The session a cron run is given must come back.
+
+    Regression: _run_job_now created a session and nothing ever closed it. With
+    MAX_SESSIONS defaulting to 1, the first cron fire consumed the only slot
+    permanently — every later fire and every manual create_session then failed
+    "Session limit reached".
+    """
+    service, manager, queue = _cron(tmp_path)
+
+    result = await service._run_job_now(_job())
+    assert result["triggered"] is True
+    assert manager.leaked == [result["session_id"]], "session is held while the run is in flight"
+
+    await queue.finish(f"job-for-{result['session_id']}")
+
+    assert manager.leaked == [], "session must be released once the job reaches a terminal state"
+
+
+@pytest.mark.asyncio
+async def test_cron_session_is_closed_even_when_the_run_fails(tmp_path: Path) -> None:
+    """Release is unconditional — a failed run must not strand its session."""
+    service, manager, queue = _cron(tmp_path)
+    result = await service._run_job_now(_job())
+
+    # The queue invokes the callback from a finally, so failure looks the same.
+    await queue.finish(f"job-for-{result['session_id']}")
+
+    assert manager.leaked == []
+
+
+@pytest.mark.asyncio
+async def test_cron_session_is_released_when_enqueue_is_rejected(tmp_path: Path) -> None:
+    """A full queue must not leave an orphaned session behind."""
+    service, manager, queue = _cron(tmp_path)
+    queue.fail_enqueue = True
+
+    with pytest.raises(RuntimeError):
+        await service._run_job_now(_job())
+
+    assert manager.leaked == []
+
+
+@pytest.mark.asyncio
+async def test_cron_skips_a_fire_while_the_previous_run_is_active(tmp_path: Path) -> None:
+    """A schedule faster than its own runtime must not stack sessions."""
+    service, manager, queue = _cron(tmp_path)
+
+    first = await service._run_job_now(_job())
+    second = await service._run_job_now(_job())
+
+    assert second["triggered"] is False
+    assert second["reason"] == "previous_run_active"
+    assert len(manager.created) == 1, "the overlapping fire must not create a second session"
+
+    await queue.finish(f"job-for-{first['session_id']}")
+    third = await service._run_job_now(_job())
+    assert third["triggered"] is True, "a new run is allowed once the previous one released"
+
+
+def test_corrupt_cron_store_is_quarantined_not_silently_emptied(tmp_path: Path) -> None:
+    """Returning {} here used to destroy every cron job on the next save."""
+    store = tmp_path / "cron.json"
+    store.write_text("{not valid json", encoding="utf-8")
+    service = CronService(store)
+
+    with pytest.raises(RuntimeError, match="unreadable"):
+        service._load()
+
+    assert not store.exists(), "the damaged file is moved aside"
+    quarantined = list(tmp_path.glob("cron.corrupt-*.json"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_text(encoding="utf-8") == "{not valid json"
+
+
+@pytest.mark.asyncio
+async def test_maintenance_loop_survives_a_failing_sweep(tmp_path: Path, caplog) -> None:
+    """One bad sweep must not end the loop.
+
+    Regression: _run_loop had no guard, so a single exception killed the task
+    with nothing observing it and artifacts grew forever afterwards.
+    """
+    settings = SimpleNamespace(
+        cleanup_interval_seconds=0.01,
+        artifact_root=str(tmp_path / "artifacts"),
+        upload_root=str(tmp_path / "uploads"),
+        auth_root=str(tmp_path / "auth"),
+        artifact_retention_hours=1,
+        upload_retention_hours=1,
+        auth_retention_hours=1,
+    )
+    service = MaintenanceService(settings=settings, session_provider=lambda: [])
+
+    calls = {"n": 0}
+
+    async def exploding_cleanup():
+        calls["n"] += 1
+        raise OSError("simulated stat race")
+
+    service.run_cleanup = exploding_cleanup  # type: ignore[assignment]
+
+    with caplog.at_level(logging.ERROR):
+        task = asyncio.create_task(service._run_loop())
+        await asyncio.sleep(0.08)
+        service._stop_event.set()
+        await asyncio.wait_for(task, timeout=2)
+
+    assert calls["n"] >= 2, "loop kept running after the first failure"
+    assert any("cleanup sweep failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_audit_listing_survives_a_torn_line(tmp_path: Path) -> None:
+    """A partial line from a kill mid-append must not 500 the listing forever."""
+    from app.models import AuditEvent, OperatorIdentity
+
+    def _event(action: str) -> AuditEvent:
+        return AuditEvent(
+            id=f"evt-{action}",
+            timestamp="2026-08-04T00:00:00Z",
+            event_type="test_event",
+            status="ok",
+            action=action,
+            session_id="s1",
+            operator=OperatorIdentity(id="op-1"),
+        )
+
+    store = FileAuditStore(str(tmp_path), max_events=100)
+    await store.startup()
+    await store.append_event(_event("a"))
+
+    # Simulate a process killed halfway through writing a record.
+    with store.events_path.open("a", encoding="utf-8") as fh:
+        fh.write('{"event_type": "torn", "sta\n')
+
+    await store.append_event(_event("b"))
+
+    events = await store.list(limit=50, session_id=None, event_type=None, operator_id=None)
+    actions = [e.action for e in events]
+    assert "a" in actions and "b" in actions, "valid records on both sides of the tear survive"
+
+
+def test_background_task_failures_are_logged(caplog) -> None:
+    """Fire-and-forget failures used to surface only at GC time, if at all."""
+    from app.utils import spawn_background_task
+
+    async def boom():
+        raise ValueError("kaboom")
+
+    async def drive():
+        task = spawn_background_task(boom())
+        with pytest.raises(ValueError):
+            await task
+
+    with caplog.at_level(logging.ERROR):
+        asyncio.run(drive())
+
+    assert any("kaboom" in str(r.getMessage()) or "kaboom" in str(r.exc_info) for r in caplog.records)
+
+
+def test_events_module_counts_dropped_sse_events() -> None:
+    """Drops were DEBUG-only, so an operator silently missed actions."""
+    from app import events as events_module
+
+    queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+    queue.put_nowait("occupied")
+
+    before = events_module.dropped_event_count()
+    events_module._SESSION_QUEUES["sess-x"].append(queue)
+    try:
+        events_module._dispatch("sess-x", {"type": "test"})
+    finally:
+        events_module._SESSION_QUEUES["sess-x"].remove(queue)
+
+    assert events_module.dropped_event_count() == before + 1
+
+
+def test_redis_session_store_sets_socket_timeouts() -> None:
+    """A hung (not refused) redis blocked every action indefinitely."""
+    source = Path(__file__).resolve().parent.parent / "app" / "session_store.py"
+    text = source.read_text(encoding="utf-8")
+    assert "socket_connect_timeout=2" in text
+    assert "socket_timeout=2" in text
+
+
+def test_metrics_path_collapses_unmatched_routes() -> None:
+    """Raw URL paths as Prometheus labels grow the registry without bound."""
+    source = Path(__file__).resolve().parent.parent / "app" / "middleware" / "http.py"
+    text = source.read_text(encoding="utf-8")
+    assert "__unmatched__" in text
+    assert "_metric_path" in text
+
+
+def test_cron_store_roundtrips_valid_json(tmp_path: Path) -> None:
+    """Guard the guard: quarantine must not fire on healthy stores."""
+    service = CronService(tmp_path / "cron.json")
+    service._save({"j1": _job()})
+    assert service._load()["j1"]["goal"] == "do a thing"
+    assert not list(tmp_path.glob("*corrupt*"))
+    assert json.loads((tmp_path / "cron.json").read_text(encoding="utf-8"))["j1"]["id"] == "j1"


### PR DESCRIPTION
Nine lifecycle defects. Every one failed *silently* — a session never released, a loop that stopped running, a store quietly emptied, an exception recorded as a constant string.

### R1 (critical) — cron sessions were never closed; the first fire wedged the service

`_run_job_now` created a session per fire and nothing ever released it. With `MAX_SESSIONS` defaulting to **1**, the first cron fire consumed the only slot permanently — every later fire *and every manual `create_session`* then failed "Session limit reached". Under `docker_ephemeral` each fire also leaked a browser container.

The queue now carries an in-memory finish-callback registry, invoked from a `finally` in `_process_job` so it fires on completion, failure, and cancellation alike. `CronService` registers a release for the session it created, and additionally refuses to start a run while that job's previous one is still in flight — otherwise a schedule faster than its own runtime just stacks sessions. A rejected enqueue releases too, rather than stranding a session nothing will ever use.

The registry is deliberately **not** persisted: after a restart, the browser sessions it would close are gone with the process anyway.

### R2 (critical) — the cleanup loop died permanently, silently

`_run_loop` had no guard, so the first exception ended the task with nothing observing it; artifacts/uploads/auth then grew forever with only a stale `last_report` as the clue. A live trigger sat in the same file — the `st_size` stat raced concurrent deletion while the `mtime` stat above it was already guarded.

Worth noting: `maintenance.py` had **no logger at all**, so my own guard would have raised `NameError`. The test caught it before it shipped.

### R3 — job and orchestrator failures discarded the real exception

`agent_jobs` recorded the constant `"agent_job_failed"` and logged nothing. `orchestrator.py` did not even import `logging`. A crashing provider adapter, a Playwright error, and a JSON parse failure were indistinguishable, with no traceback anywhere. Both now log and persist the exception type and message.

### R4 — a corrupt cron store erased every cron job

`_load` returned `{}` on a parse error, and the next `_save` wrote that empty dict over the damaged file. It now quarantines the file and raises.

**An existing test asserted `_load() == {}`** — it was pinning the destructive behaviour as correct. Updated.

### R5–R9

- One torn line (kill mid-append) broke audit listing **forever**: `list` 500s'd permanently and `_trim_sync` could never age the bad line out. Malformed lines are now skipped and counted, matching `AgentJobStore._list_sync`.
- Fire-and-forget task failures surfaced only as asyncio's GC-time "exception was never retrieved" warning.
- **Unbounded Prometheus label cardinality** — the raw URL path became a label, so on a public MCP endpoint ordinary scanner traffic grew the registry for the process lifetime. Only matched route templates are labels now.
- SSE drops were DEBUG-only, so an operator watching a live stream silently missed actions.
- redis had no socket timeouts, so a *hung* (not refused) server blocked `upsert` indefinitely — and `upsert` runs inside `create_session` and after every successful action.

### Verification

**819 → 821 passed**, 2 skipped, 199 subtests, `ruff check` clean.

Confirmed red→green: removing the session-release registration makes `test_cron_session_is_closed_when_the_run_finishes` and `..._even_when_the_run_fails` both fail, then pass on restore.

The two changed cron tests were encoding old behaviour, not regressions — one of them literally asserted the destructive `{}` return.