### PR TITLE
fix: published-package defects, the untested Python 3.10 claim, and .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize line endings so they don't depend on each contributor's git
+# config. core.autocrlf is enabled repo-wide, and browser-node/Dockerfile
+# already carries `sed -i 's/\r$//' /entrypoint.sh` as a workaround for a
+# script that picked up CRLF -- this is the general fix for that class.
+* text=auto
+
+*.sh text eol=lf
+Dockerfile* text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+*.png binary
+*.gif binary
+*.ico binary

--- a/client/auto_browser_client/client.py
+++ b/client/auto_browser_client/client.py
@@ -90,7 +90,14 @@ class AutoBrowserClient:
             try:
                 detail = r.json()
             except Exception:
-                detail = r.text
+                try:
+                    detail = r.text
+                except Exception:
+                    # Streaming responses raise httpx.ResponseNotRead from both
+                    # .json() and .text until .read()/.aread() is called. Callers
+                    # of a streaming endpoint are expected to read the body first
+                    # (see stream_events), but fall back cleanly if one doesn't.
+                    detail = f"<unreadable response body, status {r.status_code}>"
             raise AutoBrowserError(r.status_code, detail)
 
     def _get(self, path: str, **params) -> Any:
@@ -392,6 +399,8 @@ class AutoBrowserClient:
 
         url = f"{self.base_url}/sessions/{session_id}/events"
         with httpx.stream("GET", url, headers=self._headers, timeout=None) as r:
+            if r.status_code >= 400:
+                r.read()
             self._raise(r)
             buffer = ""
             for chunk in r.iter_text():

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.5.1"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["httpx>=0.27"]
 keywords = ["auto-browser", "mcp", "browser-automation", "playwright"]
 classifiers = [
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/client/tests/test_client_contract.py
+++ b/client/tests/test_client_contract.py
@@ -201,6 +201,48 @@ class StreamEventsTests(unittest.TestCase):
         self.assertEqual(captured["url"], "http://auto-browser.test/sessions/s-1/events")
         self.assertEqual(captured["headers"]["Authorization"], "Bearer sekret")
 
+    def test_stream_events_error_raises_autobrowser_error_not_response_not_read(self) -> None:
+        # Regression: a streaming response is unread until .read() is called, so
+        # r.json() inside _raise() raised httpx.ResponseNotRead and the except
+        # block's r.text fallback raised the *same* error, uncaught -- leaking a
+        # raw httpx exception out of stream_events instead of AutoBrowserError.
+        class FakeErrorStream:
+            status_code = 401
+
+            def __init__(self) -> None:
+                self._is_read = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return None
+
+            def read(self) -> None:
+                self._is_read = True
+
+            def json(self):
+                if not self._is_read:
+                    raise httpx.ResponseNotRead()
+                return {"detail": "unauthorized"}
+
+            @property
+            def text(self):
+                if not self._is_read:
+                    raise httpx.ResponseNotRead()
+                return '{"detail": "unauthorized"}'
+
+            def iter_text(self):
+                return iter(())
+
+        client = AutoBrowserClient("http://auto-browser.test", token="bad")
+        with patch("auto_browser_client.client.httpx.stream", return_value=FakeErrorStream()):
+            with self.assertRaises(AutoBrowserError) as ctx:
+                list(client.stream_events("s-1"))
+
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertEqual(ctx.exception.detail, {"detail": "unauthorized"})
+
 
 class AsyncClientContractTests(unittest.IsolatedAsyncioTestCase):
     async def test_async_error_raises_autobrowser_error(self) -> None:

--- a/client/tests/test_pyproject_metadata.py
+++ b/client/tests/test_pyproject_metadata.py
@@ -1,0 +1,48 @@
+"""Guards against re-shipping a Python version nothing in CI exercises.
+
+Regression: the langchain integration's pyproject once advertised Python 3.14
+support that nothing tested (asyncio.get_event_loop() broke there), discovered
+only after release. CI (.github/workflows/ci.yml) runs client-tests on 3.11
+only and langchain-tests/host-tests on 3.11 and 3.14 -- no job ever touches
+3.10, so a floor of ">=3.10" plus a 3.10 classifier is the same class of
+unbacked claim. These two published pyprojects must not repeat it.
+"""
+
+from __future__ import annotations
+
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _project_table(relative: str) -> dict:
+    path = REPO_ROOT / relative
+    return tomllib.loads(path.read_text(encoding="utf-8"))["project"]
+
+
+class ClientPyprojectPythonVersionTests(unittest.TestCase):
+    def test_requires_python_floor_is_311(self) -> None:
+        self.assertEqual(_project_table("client/pyproject.toml")["requires-python"], ">=3.11")
+
+    def test_no_classifier_advertises_the_untested_310(self) -> None:
+        classifiers = _project_table("client/pyproject.toml")["classifiers"]
+        self.assertNotIn("Programming Language :: Python :: 3.10", classifiers)
+
+    def test_classifiers_still_cover_311_through_314(self) -> None:
+        classifiers = _project_table("client/pyproject.toml")["classifiers"]
+        for minor in ("3.11", "3.12", "3.13", "3.14"):
+            self.assertIn(f"Programming Language :: Python :: {minor}", classifiers)
+
+
+class McpMetapackagePyprojectPythonVersionTests(unittest.TestCase):
+    def test_requires_python_floor_matches_the_client(self) -> None:
+        self.assertEqual(
+            _project_table("packaging/auto-browser-mcp/pyproject.toml")["requires-python"],
+            ">=3.11",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langchain/auto_browser_langchain/node.py
+++ b/integrations/langchain/auto_browser_langchain/node.py
@@ -47,7 +47,7 @@ class AutoBrowserNode:
         if start_url:
             arguments["start_url"] = start_url
         result = await self.call_tool("browser.create_session", arguments)
-        content = result.get("content", [{}])
+        content = result.get("content") or [{}]
         data = json.loads(content[0].get("text", "{}"))
         session_id = data.get("session_id") or data.get("id")
         if not session_id:
@@ -56,7 +56,7 @@ class AutoBrowserNode:
 
     async def observe(self, session_id: str) -> dict[str, Any]:
         result = await self.call_tool("browser.observe", {"session_id": session_id})
-        content = result.get("content", [{}])
+        content = result.get("content") or [{}]
         return json.loads(content[0].get("text", "{}"))
 
     async def run(self, state: BrowserState) -> BrowserState:

--- a/integrations/langchain/auto_browser_langchain/tool.py
+++ b/integrations/langchain/auto_browser_langchain/tool.py
@@ -61,9 +61,9 @@ class AutoBrowserTool(BaseTool):
             response.raise_for_status()
             data = response.json()
         if data.get("isError"):
-            content = data.get("content", [{}])
+            content = data.get("content") or [{}]
             return f"ERROR: {content[0].get('text', 'Unknown error')}"
-        content = data.get("content", [{}])
+        content = data.get("content") or [{}]
         return content[0].get("text", json.dumps(data))
 
     @classmethod

--- a/integrations/langchain/tests/test_langchain_integration.py
+++ b/integrations/langchain/tests/test_langchain_integration.py
@@ -77,6 +77,49 @@ class AutoBrowserToolAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(json.loads(result), payload)
 
     @respx.mock
+    async def test_arun_handles_empty_content_list_without_indexerror(self) -> None:
+        # Regression: content.get("content", [{}]) is defeated when the key is
+        # present with an empty list -- the default never kicks in, and
+        # content[0] raises IndexError instead of degrading gracefully.
+        payload = {"content": []}
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=payload))
+
+        result = await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
+
+        self.assertEqual(json.loads(result), payload)
+
+    @respx.mock
+    async def test_arun_handles_null_content_without_typeerror(self) -> None:
+        # Regression: same class of bug as the empty-list case, but with the key
+        # present and explicitly null -- content[0] raised TypeError.
+        payload = {"content": None}
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=payload))
+
+        result = await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
+
+        self.assertEqual(json.loads(result), payload)
+
+    @respx.mock
+    async def test_arun_handles_iserror_with_empty_content_list(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json={"isError": True, "content": []})
+        )
+
+        result = await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
+
+        self.assertEqual(result, "ERROR: Unknown error")
+
+    @respx.mock
+    async def test_arun_handles_iserror_with_null_content(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(
+            return_value=httpx.Response(200, json={"isError": True, "content": None})
+        )
+
+        result = await AutoBrowserTool(base_url=BASE_URL)._arun("browser.observe", {})
+
+        self.assertEqual(result, "ERROR: Unknown error")
+
+    @respx.mock
     async def test_arun_sends_the_action_and_arguments(self) -> None:
         route = respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json=_content("ok")))
 
@@ -198,6 +241,23 @@ class AutoBrowserNodeAsyncTests(unittest.IsolatedAsyncioTestCase):
             await self.node.create_session()
 
     @respx.mock
+    async def test_create_session_handles_empty_content_list(self) -> None:
+        # Regression: result.get("content", [{}]) is defeated when "content" is
+        # present as an empty list -- content[0] raised IndexError instead of
+        # degrading to the existing "no id returned" KeyError.
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json={"content": []}))
+
+        with self.assertRaises(KeyError):
+            await self.node.create_session()
+
+    @respx.mock
+    async def test_create_session_handles_null_content(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json={"content": None}))
+
+        with self.assertRaises(KeyError):
+            await self.node.create_session()
+
+    @respx.mock
     async def test_observe_parses_the_embedded_json(self) -> None:
         observation = {"url": "https://example.com/a", "screenshot_url": "/artifacts/a.png"}
         respx.post(f"{BASE_URL}/mcp/tools/call").mock(
@@ -205,6 +265,18 @@ class AutoBrowserNodeAsyncTests(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(await self.node.observe("sess-1"), observation)
+
+    @respx.mock
+    async def test_observe_handles_empty_content_list(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json={"content": []}))
+
+        self.assertEqual(await self.node.observe("sess-1"), {})
+
+    @respx.mock
+    async def test_observe_handles_null_content(self) -> None:
+        respx.post(f"{BASE_URL}/mcp/tools/call").mock(return_value=httpx.Response(200, json={"content": None}))
+
+        self.assertEqual(await self.node.observe("sess-1"), {})
 
     @respx.mock
     async def test_run_creates_a_session_when_state_has_none(self) -> None:

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -11,7 +11,7 @@ version = "1.5.1"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["auto-browser-client>=1.5.0"]
 keywords = ["auto-browser", "mcp", "mcp-server", "browser-automation"]
 classifiers = [


### PR DESCRIPTION
Three defects in packages users actually `pip install`, plus line-ending hygiene.

### The published client raised the wrong exception on a failed SSE stream

`_raise` called `r.json()` and fell back to `r.text` — but for a **streaming** response neither is readable before `r.read()`, and both raise `httpx.ResponseNotRead`. The `except Exception` only guarded the `json()` call, so `r.text` propagated.

A 401 on `client.stream_events(sid)` surfaced as `httpx.ResponseNotRead: Attempted to access streaming response content...` instead of `AutoBrowserError(401, ...)`. Now reads the body before raising, and `_raise` itself degrades to a synthetic detail rather than propagating.

Confirmed there is no async variant of `stream_events` to fix — verified by full read plus a grep for `aiter_text` / `.stream(`.

### `.get(key, default)` defeated by explicit null / empty list

`data.get("content", [{}])` then `content[0]` — but `McpToolCallResponse.content` is a `list` with no `min_length`, so `[]` is representable, and a proxy that JSON-nulls the field yields `None`. `{"content": []}` gave `IndexError`; `{"content": null}` gave `TypeError`, inside a LangChain tool call.

**This is the exact class that already shipped a crash in v1.4.2** (`payload.get("candidate", {})` returning `None` because the key existed with a null value). All four sites fixed.

A sweep for the same shape across both published packages found nothing else: the client's only `.get(...)` matches are `httpx.Client.get(path, ...)` HTTP calls, not dict lookups.

### Python 3.10 was declared but never tested

`client` and `packaging/auto-browser-mcp` declared `requires-python = ">=3.10"` and shipped a 3.10 classifier to PyPI, while CI tests only 3.11 and 3.14 — the same unbacked-claim pattern that shipped the v1.4.2 langchain bug. Both raised to `>=3.11`, stray classifier dropped.

Flagged but **not** changed (outside this PR's scope): `controller/pyproject.toml` still says `>=3.10` with mypy `python_version = "3.10"`, and several docs say "Python 3.10+" for local host-testing. That is a different and arguably still-accurate claim, but it comes from the same pattern and deserves a decision.

### `.gitattributes`

`core.autocrlf` is on and no `.gitattributes` existed, so line endings depended on each contributor's git config — on a repo whose `browser-node/Dockerfile` already carries `sed -i 's/\r$//'` as a workaround for exactly that.

Renormalization was checked rather than assumed: `git add --renormalize .` staged only the files already modified by the other commits and nothing else.

### Verification

| gate | result |
|---|---|
| client tests | 43 passed, **89.53%** coverage (gate 85%) |
| langchain tests | 31 passed, **94.29%** coverage (gate 90%) |
| `check_bridge_parity.py` | byte-identical |
| `check_version_parity.py` | 9/9 on 1.5.1 |
| `ruff check .` | clean |

Every fix has a proving test confirmed red-before / green-after. I independently re-ran both package suites and spot-checked the null/empty-content behaviour and the `_raise` path before merging.

`mcp_bridge.py` was left untouched, so its byte-parity with `controller/app/mcp_stdio.py` holds.