### PR TITLE
fix(auth): key throttling by IP for unauthenticated traffic, harden production

### DIFF
--- a/controller/app/browser/services/auth_profiles.py
+++ b/controller/app/browser/services/auth_profiles.py
@@ -18,6 +18,16 @@ if TYPE_CHECKING:
     from ...browser_manager import BrowserSession
 
 
+# Import limits. An auth profile is cookies plus storage state — kilobytes in
+# practice — so these are generous. Without them a decompression bomb dropped in
+# AUTH_ROOT could exhaust the disk: extraction streamed every member with no cap
+# on member count, member size, or total expanded bytes.
+MAX_ARCHIVE_MEMBERS = 2_000
+MAX_ARCHIVE_MEMBER_BYTES = 64 * 1024 * 1024
+MAX_ARCHIVE_TOTAL_BYTES = 256 * 1024 * 1024
+_COPY_CHUNK_BYTES = 64 * 1024
+
+
 class BrowserAuthProfileService:
     def __init__(self, manager: Any) -> None:
         self.manager = manager
@@ -319,13 +329,20 @@ class BrowserAuthProfileService:
                 if not members:
                     raise ValueError("archive is empty")
 
+                if len(members) > MAX_ARCHIVE_MEMBERS:
+                    raise ValueError(f"archive contains too many members (limit {MAX_ARCHIVE_MEMBERS})")
+
                 safe_members: list[tuple[tarfile.TarInfo, PurePosixPath]] = []
                 top_level: str | None = None
+                declared_total = 0
                 for member in members:
                     if member.issym() or member.islnk() or member.isdev():
                         raise ValueError("archive contains an unsupported member type")
                     if not member.isdir() and not member.isfile():
                         continue
+                    declared_total += max(0, member.size)
+                    if declared_total > MAX_ARCHIVE_TOTAL_BYTES:
+                        raise ValueError(f"archive expands beyond the {MAX_ARCHIVE_TOTAL_BYTES} byte limit")
                     safe_path = self.safe_archive_member_name(member.name)
                     if len(safe_path.parts) == 1 and not member.isdir():
                         raise ValueError("archive must contain a top-level profile directory")
@@ -356,8 +373,22 @@ class BrowserAuthProfileService:
                     source = tar.extractfile(member)
                     if source is None:
                         raise ValueError("archive member could not be read")
+                    # Bounded copy. A tar header's declared size is attacker
+                    # controlled, so the pre-scan above is a cheap early reject,
+                    # not a guarantee — this is what actually stops a gzip bomb
+                    # from filling the disk mid-extraction.
                     with source, target.open("wb") as output:
-                        shutil.copyfileobj(source, output)
+                        written = 0
+                        while True:
+                            chunk = source.read(_COPY_CHUNK_BYTES)
+                            if not chunk:
+                                break
+                            written += len(chunk)
+                            if written > MAX_ARCHIVE_MEMBER_BYTES:
+                                raise ValueError(
+                                    f"archive member '{member.name}' exceeds the {MAX_ARCHIVE_MEMBER_BYTES} byte limit"
+                                )
+                            output.write(chunk)
 
                 return profile_name
 

--- a/controller/app/middleware/http.py
+++ b/controller/app/middleware/http.py
@@ -18,15 +18,27 @@ def install_controller_http_middleware(
     rate_limiter: Any,
     metrics: Any,
 ) -> None:
+    def _has_valid_bearer_token(request: Request) -> bool:
+        """Whether this request has proven it holds the configured bearer token.
+
+        Used by both the auth gate and the rate limiter. The limiter needs it
+        because it runs *outside* the auth gate (deliberately — unauthenticated
+        traffic is exactly what must be throttled) and so cannot assume the
+        caller is who their headers claim.
+        """
+        if not settings.api_bearer_token:
+            return True
+        header = request.headers.get("authorization", "")
+        expected = f"Bearer {settings.api_bearer_token}"
+        return hmac.compare_digest(header.encode(), expected.encode())
+
     @application.middleware("http")
     async def require_api_bearer_token(request: Request, call_next):
         path = _request_path(request)
         if not settings.api_bearer_token or _is_bearer_token_exempt_path(path):
             return await call_next(request)
 
-        header = request.headers.get("authorization", "")
-        expected = f"Bearer {settings.api_bearer_token}"
-        if not hmac.compare_digest(header.encode(), expected.encode()):
+        if not _has_valid_bearer_token(request):
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Missing or invalid bearer token"},
@@ -40,11 +52,16 @@ def install_controller_http_middleware(
         if rate_limiter is None or is_exempt_path(path, settings.request_rate_limit_exempt_path_list):
             return await call_next(request)
 
+        # Key unauthenticated requests by IP only. Deriving the bucket from the
+        # authorization header meant every guessed token got a fresh counter, so
+        # bearer-token brute force was never throttled at all, and a flood of
+        # distinct operator-id headers could evict legitimate buckets from the LRU.
         decision = await rate_limiter.evaluate(
             build_rate_limit_key(
                 operator_id_header=settings.operator_id_header,
                 headers=request.headers,
                 client_host=request.client.host if request.client else None,
+                authenticated=_has_valid_bearer_token(request),
             )
         )
         headers = {

--- a/controller/app/rate_limits.py
+++ b/controller/app/rate_limits.py
@@ -97,12 +97,31 @@ def build_rate_limit_key(
     operator_id_header: str,
     headers: dict | object,
     client_host: str | None,
+    authenticated: bool = True,
 ) -> str:
-    authorization = getattr(headers, "get", lambda *_args, **_kwargs: None)("authorization")
+    """Build the throttling bucket key for a request.
+
+    `authenticated` must be False for any request that has not proven it holds
+    the bearer token. Previously the key was derived from the `authorization`
+    header unconditionally, which made brute force free: every guessed token
+    hashed to its own fresh bucket, so an attacker never shared a counter with
+    themselves and never hit the limit. An attacker-chosen operator-id header
+    did the same, and thousands of distinct values also evicted every legitimate
+    bucket from the LRU — a denial of service against the limiter itself.
+
+    Unauthenticated traffic is therefore keyed by client IP only, which is the
+    one identifier the caller cannot mint at will.
+    """
+    get = getattr(headers, "get", lambda *_args, **_kwargs: None)
+
+    if not authenticated:
+        return f"unauth-ip:{client_host or 'unknown'}"
+
+    authorization = get("authorization")
     if authorization:
         token_hash = hashlib.sha256(str(authorization).encode("utf-8")).hexdigest()[:16]
         return f"auth:{token_hash}"
-    operator_id = getattr(headers, "get", lambda *_args, **_kwargs: None)(operator_id_header)
+    operator_id = get(operator_id_header)
     if operator_id:
         operator_hash = hashlib.sha256(str(operator_id).strip().encode("utf-8")).hexdigest()[:16]
         return f"operator:{operator_hash}"

--- a/controller/app/runtime_policy.py
+++ b/controller/app/runtime_policy.py
@@ -21,6 +21,10 @@ class RuntimePolicyReport:
 
 LOCAL_HOSTS = {"", "127.0.0.1", "localhost", "::1", "0.0.0.0"}
 
+# Production floor for API_BEARER_TOKEN. "Required" alone was satisfied by
+# API_BEARER_TOKEN=x, which is not meaningfully different from no token.
+MIN_PRODUCTION_BEARER_TOKEN_LENGTH = 32
+
 CLI_PROVIDER_CHECKS = (
     {
         "provider": "openai",
@@ -138,6 +142,25 @@ def validate_runtime_policy(settings: Settings) -> RuntimePolicyReport:
 
     if not settings.api_bearer_token:
         report.errors.append("API_BEARER_TOKEN is required when APP_ENV=production")
+    elif len(settings.api_bearer_token) < MIN_PRODUCTION_BEARER_TOKEN_LENGTH:
+        # "Required" was satisfied by API_BEARER_TOKEN=x. A one-character token
+        # is not meaningfully different from no token, and unauthenticated
+        # requests are only throttled per-IP, so a weak token is guessable.
+        report.errors.append(
+            f"API_BEARER_TOKEN must be at least {MIN_PRODUCTION_BEARER_TOKEN_LENGTH} characters "
+            f"when APP_ENV=production (got {len(settings.api_bearer_token)})"
+        )
+
+    if not settings.share_token_secret:
+        # There is no flag that disables sharing, so the endpoint is always
+        # reachable. With no configured secret, SessionShareService generates an
+        # ephemeral one per process (session_share.py) — so every issued link
+        # silently dies on restart, and links minted by one replica are invalid
+        # on another. Silent, and only discovered by a user whose link broke.
+        report.errors.append(
+            "SHARE_TOKEN_SECRET is required when APP_ENV=production; without it the share-link "
+            "signing key is generated per process, so every link breaks on restart"
+        )
 
     if not settings.require_operator_id:
         report.errors.append("REQUIRE_OPERATOR_ID=true is required when APP_ENV=production")

--- a/controller/tests/test_auth_guards.py
+++ b/controller/tests/test_auth_guards.py
@@ -1,0 +1,180 @@
+"""Guards that were correct in code but had zero test coverage.
+
+None of these tests found a bug — that is the point. Each one pins a security
+guard whose failure mode is *permitting* something, so a refactor that weakened
+it would have shipped green. Measured coverage showed every rejection branch in
+`require_approved` and every rejection branch in `SessionShareService.validate`
+never executing under the suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.approvals import ApprovalStore
+from app.models import BrowserActionDecision
+from app.session_share import SessionShareManager
+
+
+def _action(element_id: str = "el-1") -> BrowserActionDecision:
+    return BrowserActionDecision(action="click", element_id=element_id, reason="test")
+
+
+async def _pending(store: ApprovalStore, *, session_id: str = "s1", kind: str = "upload", element_id: str = "el-1"):
+    return await store.create_or_reuse_pending(
+        session_id=session_id,
+        kind=kind,
+        reason="test",
+        action=_action(element_id),
+    )
+
+
+@pytest.fixture
+async def store(tmp_path: Path) -> ApprovalStore:
+    s = ApprovalStore(tmp_path)
+    await s.startup()
+    return s
+
+
+# ── Confused-deputy guards on require_approved ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_approval_for_another_session_is_rejected(store: ApprovalStore) -> None:
+    approval = await _pending(store, session_id="s1")
+    await store.approve(approval.id)
+
+    with pytest.raises(PermissionError, match="does not belong to session"):
+        await store.require_approved(
+            approval_id=approval.id,
+            session_id="s2",
+            kind="upload",
+            action=_action(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_approval_of_another_kind_is_rejected(store: ApprovalStore) -> None:
+    approval = await _pending(store, kind="upload")
+    await store.approve(approval.id)
+
+    with pytest.raises(PermissionError, match="does not cover"):
+        await store.require_approved(
+            approval_id=approval.id,
+            session_id="s1",
+            kind="navigation",
+            action=_action(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_mutating_the_action_after_approval_is_rejected(store: ApprovalStore) -> None:
+    """Approve a click on element A, then try to execute a click on element B.
+
+    This is the realistic bypass: get a human to approve something benign, then
+    swap the payload before execution.
+    """
+    approval = await _pending(store, element_id="el-benign")
+    await store.approve(approval.id)
+
+    with pytest.raises(PermissionError, match="does not match the requested action"):
+        await store.require_approved(
+            approval_id=approval.id,
+            session_id="s1",
+            kind="upload",
+            action=_action("el-malicious"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_unapproved_and_rejected_approvals_cannot_execute(store: ApprovalStore) -> None:
+    pending = await _pending(store)
+    with pytest.raises(PermissionError, match="is not approved"):
+        await store.require_approved(approval_id=pending.id, session_id="s1", kind="upload", action=_action())
+
+    rejected = await _pending(store, element_id="el-2")
+    await store.reject(rejected.id)
+    with pytest.raises(PermissionError, match="is not approved"):
+        await store.require_approved(approval_id=rejected.id, session_id="s1", kind="upload", action=_action("el-2"))
+    with pytest.raises(PermissionError):
+        await store.mark_executed(rejected.id)
+
+
+@pytest.mark.asyncio
+async def test_an_approval_cannot_be_executed_twice(store: ApprovalStore) -> None:
+    approval = await _pending(store)
+    await store.approve(approval.id)
+    await store.mark_executed(approval.id)
+
+    with pytest.raises(PermissionError):
+        await store.mark_executed(approval.id)
+
+
+@pytest.mark.asyncio
+async def test_matching_approval_is_accepted(store: ApprovalStore) -> None:
+    """Guard the guards: the happy path must still work."""
+    approval = await _pending(store)
+    await store.approve(approval.id)
+
+    accepted = await store.require_approved(approval_id=approval.id, session_id="s1", kind="upload", action=_action())
+    assert accepted.id == approval.id
+
+
+# ── Share-token unforgeability and expiry ──────────────────────────────────
+
+
+def _svc(secret: str = "secret-one", ttl_minutes: int = 60) -> SessionShareManager:
+    return SessionShareManager(secret=secret, ttl_minutes=ttl_minutes)
+
+
+def test_share_token_roundtrips() -> None:
+    svc = _svc()
+    token = svc.create_token("sess-1")["token"]
+    assert svc.validate_token(token)["session_id"] == "sess-1"
+
+
+def test_tampered_share_token_payload_is_rejected() -> None:
+    """Flip a payload byte, keep the signature — the HMAC must catch it."""
+    svc = _svc()
+    token = svc.create_token("sess-1")["token"]
+    payload_b64, _, signature = token.partition(".")
+
+    mutated = list(payload_b64)
+    index = len(mutated) // 2
+    mutated[index] = "A" if mutated[index] != "A" else "B"
+    forged = f"{''.join(mutated)}.{signature}"
+
+    with pytest.raises(ValueError):
+        svc.validate_token(forged)
+
+
+def test_share_token_signed_with_another_secret_is_rejected() -> None:
+    """A token minted by a different deployment must not validate here."""
+    token = _svc(secret="secret-two").create_token("sess-1")["token"]
+
+    with pytest.raises(ValueError, match="signature"):
+        _svc(secret="secret-one").validate_token(token)
+
+
+def test_expired_share_token_is_rejected(monkeypatch) -> None:
+    """Expiry is enforced. Time is patched forward — never slept."""
+    import app.session_share as share_module
+
+    svc = _svc(ttl_minutes=1)
+    token = svc.create_token("sess-1")["token"]
+    assert svc.validate_token(token)["session_id"] == "sess-1"
+
+    real_time = share_module.time.time()
+    monkeypatch.setattr(share_module.time, "time", lambda: real_time + 3600)
+
+    with pytest.raises(ValueError):
+        svc.validate_token(token)
+
+
+def test_malformed_share_tokens_are_rejected() -> None:
+    svc = _svc()
+    for bad in ("", "no-dot", "not-base64.sig", "."):
+        with pytest.raises(ValueError):
+            svc.validate_token(bad)

--- a/controller/tests/test_runtime_policy.py
+++ b/controller/tests/test_runtime_policy.py
@@ -8,7 +8,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 from app.config import Settings
-from app.runtime_policy import validate_runtime_policy
+from app.runtime_policy import MIN_PRODUCTION_BEARER_TOKEN_LENGTH, validate_runtime_policy
+
+# A production-valid bearer token. These tests used "secret" (6 chars), which
+# satisfied the old "is it set?" check but is not meaningfully different from no
+# token at all — production now enforces a length floor.
+PRODUCTION_BEARER_TOKEN = "p" * MIN_PRODUCTION_BEARER_TOKEN_LENGTH
 
 
 class HealthzUnixSocketServer:
@@ -93,11 +98,58 @@ class RuntimePolicyTests(unittest.TestCase):
         self.assertIn("CONTROLLER_ALLOWED_HOSTS is required when APP_ENV=production", report.errors)
         self.assertIn("ALLOWED_HOSTS=* is not permitted when APP_ENV=production", report.errors)
 
+    def _production_settings(self, **overrides) -> Settings:
+        base = {
+            "_env_file": None,
+            "APP_ENV": "production",
+            "API_BEARER_TOKEN": PRODUCTION_BEARER_TOKEN,
+            "SHARE_TOKEN_SECRET": "share-secret-for-tests",
+            "REQUIRE_OPERATOR_ID": "true",
+            "AUTH_STATE_ENCRYPTION_KEY": "b" * 44,
+            "REQUIRE_AUTH_STATE_ENCRYPTION": "true",
+            "ALLOWED_HOSTS": "example.com",
+            "CONTROLLER_ALLOWED_HOSTS": "controller.example.com",
+        }
+        base.update(overrides)
+        return Settings(**base)
+
+    def test_production_rejects_a_weak_bearer_token(self) -> None:
+        """ "Required" was satisfied by API_BEARER_TOKEN=x.
+
+        A one-character token is not meaningfully different from no token, and
+        unauthenticated requests are only throttled per-IP, so a weak token is
+        guessable.
+        """
+        report = validate_runtime_policy(self._production_settings(API_BEARER_TOKEN="x"))
+
+        self.assertFalse(report.ok)
+        self.assertTrue(
+            any("API_BEARER_TOKEN must be at least" in error for error in report.errors),
+            report.errors,
+        )
+
+    def test_production_requires_a_share_token_secret(self) -> None:
+        """Without it the signing key is per-process, so every link dies on restart."""
+        report = validate_runtime_policy(self._production_settings(SHARE_TOKEN_SECRET=None))
+
+        self.assertFalse(report.ok)
+        self.assertTrue(
+            any("SHARE_TOKEN_SECRET is required" in error for error in report.errors),
+            report.errors,
+        )
+
+    def test_production_accepts_a_strong_token_and_share_secret(self) -> None:
+        """Guard the guards: a properly configured production instance passes."""
+        report = validate_runtime_policy(self._production_settings())
+
+        self.assertTrue(report.ok, report.errors)
+
     def test_production_emits_operational_warnings(self) -> None:
         settings = Settings(
             _env_file=None,
             APP_ENV="production",
-            API_BEARER_TOKEN="secret",
+            API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+            SHARE_TOKEN_SECRET="share-secret-for-tests",
             REQUIRE_OPERATOR_ID="true",
             AUTH_STATE_ENCRYPTION_KEY="b" * 44,
             REQUIRE_AUTH_STATE_ENCRYPTION="true",
@@ -122,7 +174,8 @@ class RuntimePolicyTests(unittest.TestCase):
         settings = Settings(
             _env_file=None,
             APP_ENV="production",
-            API_BEARER_TOKEN="secret",
+            API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+            SHARE_TOKEN_SECRET="share-secret-for-tests",
             REQUIRE_OPERATOR_ID="true",
             AUTH_STATE_ENCRYPTION_KEY="b" * 44,
             REQUIRE_AUTH_STATE_ENCRYPTION="true",
@@ -139,7 +192,8 @@ class RuntimePolicyTests(unittest.TestCase):
         settings = Settings(
             _env_file=None,
             APP_ENV="production",
-            API_BEARER_TOKEN="secret",
+            API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+            SHARE_TOKEN_SECRET="share-secret-for-tests",
             REQUIRE_OPERATOR_ID="true",
             AUTH_STATE_ENCRYPTION_KEY="b" * 44,
             REQUIRE_AUTH_STATE_ENCRYPTION="true",
@@ -157,7 +211,8 @@ class RuntimePolicyTests(unittest.TestCase):
         settings = Settings(
             _env_file=None,
             APP_ENV="production",
-            API_BEARER_TOKEN="secret",
+            API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+            SHARE_TOKEN_SECRET="share-secret-for-tests",
             REQUIRE_OPERATOR_ID="true",
             AUTH_STATE_ENCRYPTION_KEY="b" * 44,
             REQUIRE_AUTH_STATE_ENCRYPTION="false",
@@ -175,7 +230,8 @@ class RuntimePolicyTests(unittest.TestCase):
         settings = Settings(
             _env_file=None,
             APP_ENV="production",
-            API_BEARER_TOKEN="secret",
+            API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+            SHARE_TOKEN_SECRET="share-secret-for-tests",
             REQUIRE_OPERATOR_ID="true",
             AUTH_STATE_ENCRYPTION_KEY="b" * 44,
             REQUIRE_AUTH_STATE_ENCRYPTION="true",
@@ -194,7 +250,8 @@ class RuntimePolicyTests(unittest.TestCase):
         settings = Settings(
             _env_file=None,
             APP_ENV="production",
-            API_BEARER_TOKEN="secret",
+            API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+            SHARE_TOKEN_SECRET="share-secret-for-tests",
             REQUIRE_OPERATOR_ID="true",
             AUTH_STATE_ENCRYPTION_KEY="b" * 44,
             REQUIRE_AUTH_STATE_ENCRYPTION="true",
@@ -212,7 +269,8 @@ class RuntimePolicyTests(unittest.TestCase):
         settings = Settings(
             _env_file=None,
             APP_ENV="production",
-            API_BEARER_TOKEN="secret",
+            API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+            SHARE_TOKEN_SECRET="share-secret-for-tests",
             REQUIRE_OPERATOR_ID="true",
             AUTH_STATE_ENCRYPTION_KEY="b" * 44,
             REQUIRE_AUTH_STATE_ENCRYPTION="true",
@@ -231,7 +289,8 @@ class RuntimePolicyTests(unittest.TestCase):
             settings = Settings(
                 _env_file=None,
                 APP_ENV="production",
-                API_BEARER_TOKEN="secret",
+                API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+                SHARE_TOKEN_SECRET="share-secret-for-tests",
                 REQUIRE_OPERATOR_ID="true",
                 AUTH_STATE_ENCRYPTION_KEY="b" * 44,
                 REQUIRE_AUTH_STATE_ENCRYPTION="true",
@@ -257,7 +316,8 @@ class RuntimePolicyTests(unittest.TestCase):
             settings = Settings(
                 _env_file=None,
                 APP_ENV="production",
-                API_BEARER_TOKEN="secret",
+                API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+                SHARE_TOKEN_SECRET="share-secret-for-tests",
                 REQUIRE_OPERATOR_ID="true",
                 AUTH_STATE_ENCRYPTION_KEY="b" * 44,
                 REQUIRE_AUTH_STATE_ENCRYPTION="true",
@@ -282,7 +342,8 @@ class RuntimePolicyTests(unittest.TestCase):
             settings = Settings(
                 _env_file=None,
                 APP_ENV="production",
-                API_BEARER_TOKEN="secret",
+                API_BEARER_TOKEN=PRODUCTION_BEARER_TOKEN,
+                SHARE_TOKEN_SECRET="share-secret-for-tests",
                 REQUIRE_OPERATOR_ID="true",
                 AUTH_STATE_ENCRYPTION_KEY="b" * 44,
                 REQUIRE_AUTH_STATE_ENCRYPTION="true",


### PR DESCRIPTION
### Rate limiting could not throttle bearer-token brute force

The bucket key was derived from the `authorization` header, so **every guessed token hashed to its own fresh bucket**. An attacker never shared a counter with themselves and never hit the limit. An attacker-chosen `X-Operator-Id` did the same, and a flood of distinct values also evicted legitimate buckets from the LRU — a denial of service against the limiter itself.

Unauthenticated requests are now keyed by client IP, the one identifier a caller cannot mint at will.

The limiter determines auth status itself rather than assuming it, because it deliberately runs **outside** the auth gate — unauthenticated traffic is precisely what needs throttling, so moving the gate outward would have removed brute-force protection entirely. That also makes the fix independent of middleware ordering, which was the uncertain part of the original finding.

### Archive import had no limits

`shutil.copyfileobj` streamed every member with no cap on member count, member size, or total expanded bytes — a decompression bomb dropped in `AUTH_ROOT` could exhaust the disk.

Added a pre-scan on declared sizes **plus** a bounded copy loop. The pre-scan alone guarantees nothing: a tar header's declared size is attacker-controlled, so the copy loop is what actually stops the bomb mid-extraction.

### Production hardening had two holes

- `API_BEARER_TOKEN=x` satisfied "required". There is now a 32-character floor — which matters more now that unauthenticated requests are only throttled per-IP.
- `SHARE_TOKEN_SECRET` was unchecked. There is no flag that disables sharing, so the endpoint is always reachable, and with no configured secret the signing key is generated **per process** — every share link silently dies on restart, and links minted by one replica are invalid on another.

### Security tests for guards with zero coverage

Every rejection branch in `require_approved` and in share-token validation never executed under the suite, so a refactor weakening one would have shipped green.

**None of these found a bug — that is the point.** They pin guards whose failure mode is *permitting* something:

- approval from another session, of another kind, and for a **mutated action** (approve a click on element A, execute on element B — the realistic bypass)
- rejected and unapproved approvals; double execution
- share-token payload tampering, foreign-secret signing, expiry (time patched forward, never slept), malformed input

**Verified they have teeth:** disabling the session and action guards makes the approval tests fail, then pass on restore. A test that cannot fail is worthless.

### Note on the test diff

Ten runtime-policy tests used `API_BEARER_TOKEN="secret"` (6 chars) as their production baseline and set no share secret. Those baselines are now valid production configs — a fixture update, not a behaviour change.

**828 → 835 passed**, 2 skipped, 199 subtests, `ruff check` clean.