### PR TITLE
fix: audit credential export/import, stop compose model drift

### DIFF
--- a/controller/app/browser/services/auth_profiles.py
+++ b/controller/app/browser/services/auth_profiles.py
@@ -299,6 +299,24 @@ class BrowserAuthProfileService:
         archive_path = Path(archive_path_str)
 
         await asyncio.to_thread(self.write_tar, Path(profile_dir_str), archive_path)
+
+        # Export packages every cookie and localStorage entry for a logged-in
+        # account into a downloadable archive. save_storage_state — which merely
+        # *writes* that material — is wrapped in witness policy, an audit event
+        # and a receipt; this path, which lets the material leave the box, had
+        # none of it. Nothing in /audit/events recorded that it happened.
+        await self.manager.audit.append(
+            event_type="auth_profile_exported",
+            status="ok",
+            action="export_auth_profile",
+            session_id=None,
+            details={
+                "profile_name": normalized,
+                "archive_name": archive_name,
+                "encrypted_at_rest": bool(self.manager.settings.auth_state_encryption_key),
+            },
+        )
+
         return {
             "profile_name": normalized,
             "archive_path": str(archive_path),
@@ -393,6 +411,17 @@ class BrowserAuthProfileService:
                 return profile_name
 
         profile_name = await asyncio.to_thread(_extract)
+
+        # Import installs credentials the controller will later replay into a
+        # real browser. Like export, it had no audit record at all.
+        await self.manager.audit.append(
+            event_type="auth_profile_imported",
+            status="ok",
+            action="import_auth_profile",
+            session_id=None,
+            details={"profile_name": profile_name, "archive_name": archive_name, "overwrite": overwrite},
+        )
+
         return {
             "profile_name": profile_name,
             "profile_path": str(profile_root / profile_name),

--- a/controller/tests/test_auth_guards.py
+++ b/controller/tests/test_auth_guards.py
@@ -178,3 +178,50 @@ def test_malformed_share_tokens_are_rejected() -> None:
     for bad in ("", "no-dot", "not-base64.sig", "."):
         with pytest.raises(ValueError):
             svc.validate_token(bad)
+
+
+# ── Credential movement leaves a record ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auth_profile_export_and_import_are_audited(tmp_path: Path) -> None:
+    """Exporting a profile ships every cookie for a logged-in account.
+
+    `save_storage_state` — which merely *writes* that material — is wrapped in
+    witness policy, an audit event and a receipt. Export, which lets it leave
+    the box, and import, which installs credentials the controller will replay
+    into a real browser, had no audit record whatsoever: nothing in
+    /audit/events showed it had happened.
+    """
+    from types import SimpleNamespace
+
+    from app.browser.services import BrowserAuthProfileService
+
+    class _Audit:
+        def __init__(self) -> None:
+            self.events: list[dict] = []
+
+        async def append(self, **kwargs) -> None:
+            self.events.append(kwargs)
+
+    audit = _Audit()
+    auth_root = tmp_path / "auth"
+    service = BrowserAuthProfileService(
+        SimpleNamespace(
+            settings=SimpleNamespace(auth_root=str(auth_root), auth_state_encryption_key=None),
+            audit=audit,
+        )
+    )
+
+    profile_dir = service.dir("demo", create=True)
+    (profile_dir / "state.json").write_text('{"cookies": []}', encoding="utf-8")
+
+    exported = await service.export("demo")
+    assert [e["event_type"] for e in audit.events] == ["auth_profile_exported"]
+    assert audit.events[0]["details"]["profile_name"] == "demo"
+
+    await service.import_profile(exported["archive_name"], overwrite=True)
+    assert [e["event_type"] for e in audit.events] == [
+        "auth_profile_exported",
+        "auth_profile_imported",
+    ]

--- a/controller/tests/test_auth_profile_security.py
+++ b/controller/tests/test_auth_profile_security.py
@@ -26,9 +26,28 @@ from app.browser.services import BrowserAuthProfileService
 Service = BrowserAuthProfileService
 
 
+class _RecordingAudit:
+    """Captures audit events so tests can assert credential moves are recorded."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def append(self, **kwargs) -> None:
+        self.events.append(kwargs)
+
+
 def _service(auth_root: Path) -> BrowserAuthProfileService:
-    """Service backed by a throwaway auth root; only `settings.auth_root` is used."""
-    return BrowserAuthProfileService(SimpleNamespace(settings=SimpleNamespace(auth_root=str(auth_root))))
+    """Service backed by a throwaway auth root.
+
+    `audit` is real (recording) rather than absent: export and import move
+    credentials off and onto the box, and both now record that they happened.
+    """
+    return BrowserAuthProfileService(
+        SimpleNamespace(
+            settings=SimpleNamespace(auth_root=str(auth_root), auth_state_encryption_key=None),
+            audit=_RecordingAudit(),
+        )
+    )
 
 
 def _tar_with(members: list[tuple[tarfile.TarInfo, bytes | None]], dest: Path) -> None:

--- a/controller/tests/test_compose_config_parity.py
+++ b/controller/tests/test_compose_config_parity.py
@@ -1,0 +1,65 @@
+"""docker-compose defaults must not drift from config.py defaults.
+
+`docker-compose.yml` hardcoded `${OPENAI_MODEL:-gpt-4.1-mini}` etc. while
+`config.py` had moved on to `gpt-5-mini`. Nothing tied the two together, so
+Docker deployments — the primary deploy path — silently ran different, older
+models than pip installs and than anything CI tested. Worse, it is a delayed
+failure: nobody notices until the provider retires the old model id and Docker
+users start getting 404s that local runs never reproduce.
+
+This is the same one-thing-two-sources class the repo already guards for
+version strings (check_version_parity.py) and Playwright pins
+(check_playwright_pins.py).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = REPO_ROOT / "docker-compose.yml"
+
+# compose env key -> Settings attribute holding the same default.
+MODEL_KEYS = {
+    "OPENAI_MODEL": "openai_model",
+    "CLAUDE_MODEL": "claude_model",
+    "GEMINI_MODEL": "gemini_model",
+    "XAI_MODEL": "xai_model",
+    "DEEPSEEK_MODEL": "deepseek_model",
+    "MINIMAX_MODEL": "minimax_model",
+}
+
+
+def _compose_default(key: str) -> str | None:
+    """Extract `X` from a `KEY: ${KEY:-X}` line, or None if there is no default."""
+    text = COMPOSE.read_text(encoding="utf-8")
+    match = re.search(rf"^\s*{re.escape(key)}:\s*\$\{{{re.escape(key)}:-(.*?)\}}\s*$", text, re.MULTILINE)
+    if match is None:
+        return None
+    return match.group(1).strip()
+
+
+def test_compose_file_exists() -> None:
+    """Guard the guard — a moved compose file would make every case vacuous."""
+    assert COMPOSE.is_file(), f"expected docker-compose.yml at {COMPOSE}"
+
+
+@pytest.mark.parametrize("key,attr", sorted(MODEL_KEYS.items()))
+def test_compose_model_default_matches_settings(key: str, attr: str) -> None:
+    compose_value = _compose_default(key)
+    if compose_value in (None, ""):
+        # No hardcoded default in compose means config.py is the single source,
+        # which is the preferred shape — nothing to drift.
+        return
+
+    settings_value = getattr(Settings(_env_file=None), attr)
+    assert compose_value == settings_value, (
+        f"docker-compose.yml pins {key}={compose_value!r} but config.py defaults "
+        f"{attr}={settings_value!r}. Docker deployments would silently run a "
+        f"different model than pip installs and than CI tests."
+    )

--- a/controller/tests/test_compose_config_parity.py
+++ b/controller/tests/test_compose_config_parity.py
@@ -24,6 +24,15 @@ from app.config import Settings
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPOSE = REPO_ROOT / "docker-compose.yml"
 
+# The controller image COPYs only `app/` and `tests/`, so docker-compose.yml is
+# genuinely absent when the suite runs inside the container (the `controller-tests`
+# CI job). This is a repo-layout check, so skipping there is correct — and it
+# still runs in both `host-tests` jobs, which execute from a real checkout.
+pytestmark = pytest.mark.skipif(
+    not COMPOSE.is_file(),
+    reason="docker-compose.yml is not shipped inside the controller image",
+)
+
 # compose env key -> Settings attribute holding the same default.
 MODEL_KEYS = {
     "OPENAI_MODEL": "openai_model",
@@ -44,9 +53,14 @@ def _compose_default(key: str) -> str | None:
     return match.group(1).strip()
 
 
-def test_compose_file_exists() -> None:
-    """Guard the guard — a moved compose file would make every case vacuous."""
-    assert COMPOSE.is_file(), f"expected docker-compose.yml at {COMPOSE}"
+def test_at_least_one_model_key_is_present_in_compose() -> None:
+    """Guard the guard.
+
+    A renamed key or a moved compose file would make every case below pass
+    vacuously, so assert the parser actually finds something to compare.
+    """
+    found = {key for key in MODEL_KEYS if _compose_default(key) is not None}
+    assert found, f"no {'/'.join(sorted(MODEL_KEYS))} defaults parsed from {COMPOSE}"
 
 
 @pytest.mark.parametrize("key,attr", sorted(MODEL_KEYS.items()))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       CONNECT_RETRY_DELAY_SECONDS: ${CONNECT_RETRY_DELAY_SECONDS:-1}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
-      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4.1-mini}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-5-mini}
       OPENAI_AUTH_MODE: ${OPENAI_AUTH_MODE:-api}
       OPENAI_CLI_PATH: ${OPENAI_CLI_PATH:-codex}
       OPENAI_CLI_MODEL: ${OPENAI_CLI_MODEL:-}
@@ -94,13 +94,13 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-https://api.anthropic.com/v1}
       ANTHROPIC_VERSION: ${ANTHROPIC_VERSION:-2023-06-01}
-      CLAUDE_MODEL: ${CLAUDE_MODEL:-claude-sonnet-4-20250514}
+      CLAUDE_MODEL: ${CLAUDE_MODEL:-claude-sonnet-4-6}
       CLAUDE_AUTH_MODE: ${CLAUDE_AUTH_MODE:-api}
       CLAUDE_CLI_PATH: ${CLAUDE_CLI_PATH:-claude}
       CLAUDE_CLI_MODEL: ${CLAUDE_CLI_MODEL:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       GEMINI_BASE_URL: ${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta}
-      GEMINI_MODEL: ${GEMINI_MODEL:-gemini-2.5-flash}
+      GEMINI_MODEL: ${GEMINI_MODEL:-gemini-3.5-flash}
       GEMINI_AUTH_MODE: ${GEMINI_AUTH_MODE:-api}
       GEMINI_CLI_PATH: ${GEMINI_CLI_PATH:-gemini}
       GEMINI_CLI_MODEL: ${GEMINI_CLI_MODEL:-}


### PR DESCRIPTION
### Moving credentials off the box left no record

`save_storage_state` — which merely *writes* auth material — is wrapped in witness preflight, policy evaluation, an audit event, and a receipt.

`export`, which packages **every cookie and localStorage entry for a logged-in account** into a downloadable archive, and `import`, which installs credentials the controller will later replay into a real browser, had **none of it**. Nothing in `/audit/events` showed either had happened.

Both now emit an audit event.

**What this deliberately does not do:** full witness-receipt parity. Receipts are session-scoped and these operate on a profile name with no session, so a receipt would have to be faked. The audit record is the part that was genuinely missing; session-free witness coverage needs a real design and is left as a follow-up rather than pretended.

### docker-compose pinned models config.py had moved past

| key | compose | config.py |
|---|---|---|
| `OPENAI_MODEL` | `gpt-4.1-mini` | **`gpt-5-mini`** |
| `CLAUDE_MODEL` | `claude-sonnet-4-20250514` | **`claude-sonnet-4-6`** |
| `GEMINI_MODEL` | `gemini-2.5-flash` | **`gemini-3.5-flash`** |

Docker is the primary deploy path, so those users silently ran different, older models than pip installs and than anything CI tested. It is a *delayed* failure: nobody notices until the provider retires the old model id and Docker users start getting 404s that reproduce nowhere locally.

Synced, and pinned by a test so it cannot drift again — the same one-thing-two-sources class the repo already guards for version strings (`check_version_parity.py`) and Playwright pins (`check_playwright_pins.py`). The test passes when compose carries no hardcoded default at all, since letting `config.py` be the single source is the better shape.

### A note on the test-double change

The auth-profile test double gained a recording audit store. It was not missing by accident — production always has one (`save_storage_state` uses it unconditionally) — so completing the double was the honest fix. Making the audit call defensive instead would have reintroduced exactly the silent-skip pattern this whole release is about.

**839 → 843 passed**, 2 skipped, 199 subtests, `ruff check` clean.