### PR TITLE
fix(auth-state): enforce encryption on read; classify by content, not filename

### DIFF
--- a/controller/app/auth_state.py
+++ b/controller/app/auth_state.py
@@ -12,6 +12,10 @@ from cryptography.fernet import Fernet
 
 from .utils import UTC
 
+# Auth state is cookies plus storage state — kilobytes. Anything larger is not
+# a state file, and content-sniffing it is not worth the read.
+_MAX_INSPECT_BYTES = 8 * 1024 * 1024
+
 
 @dataclass
 class PreparedAuthState:
@@ -82,6 +86,16 @@ class AuthStateManager:
                 f"Auth state is stale ({info['age_hours']}h old, max {info['max_age_hours']}h): {source_path}"
             )
         if not info["encrypted"]:
+            if self.require_encryption:
+                # REQUIRE_AUTH_STATE_ENCRYPTION was only enforced at
+                # construction ("is a key configured?") and never on read, so a
+                # plaintext state file loaded happily and its cookies went
+                # straight into a live browser context. The setting promised
+                # encrypted-at-rest and silently did not deliver it.
+                raise PermissionError(
+                    "REQUIRE_AUTH_STATE_ENCRYPTION=true but this auth state is not encrypted: "
+                    f"{source_path}. Re-save it with an encryption key configured."
+                )
             return PreparedAuthState(path=source_path, source_info=info)
         if self._fernet is None:
             raise RuntimeError("Encrypted auth state provided but AUTH_STATE_ENCRYPTION_KEY is not configured")
@@ -108,9 +122,17 @@ class AuthStateManager:
         }
         if path is None:
             return payload
+        # Suffix is only a hint for a path that does not exist yet. For a real
+        # file the content decides: naming alone meant a mislabelled file was
+        # classified wrongly in both directions — an encrypted envelope without
+        # `.enc` was passed to Playwright verbatim as if it were storage state
+        # (no cookies load, and the agent proceeds believing the profile applied).
         payload["encrypted"] = path.name.endswith(".enc")
         if not path.exists():
             return payload
+        detected = self._detect_encrypted(path)
+        if detected is not None:
+            payload["encrypted"] = detected
         stat = path.stat()
         modified = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
         age_hours = max(0.0, (datetime.now(UTC) - modified).total_seconds() / 3600.0)
@@ -124,6 +146,29 @@ class AuthStateManager:
             }
         )
         return payload
+
+    @staticmethod
+    def _detect_encrypted(path: Path) -> bool | None:
+        """Whether `path` holds a fernet envelope, by content.
+
+        Returns None when the file cannot be classified (unreadable, not JSON,
+        implausibly large) so the caller keeps its suffix-based assumption
+        rather than guessing.
+        """
+        try:
+            if path.stat().st_size > _MAX_INSPECT_BYTES:
+                return None
+            body = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+        if not isinstance(body, dict):
+            return None
+        if body.get("format") == "fernet-json" and isinstance(body.get("ciphertext"), str):
+            return True
+        # A Playwright storage-state file is the other legitimate shape here.
+        if "cookies" in body or "origins" in body:
+            return False
+        return None
 
     def _encrypt(self, plaintext: bytes) -> str:
         if self._fernet is None:

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -6,7 +6,10 @@ build-backend = "setuptools.build_meta"
 name = "auto-browser-controller"
 version = "1.5.2"
 description = "Controller API for auto-browser"
-requires-python = ">=3.10"
+# 3.11, not 3.10: CI tests 3.11 and 3.14, the Dockerfile pins python:3.11-slim,
+# and the published packages were corrected to >=3.11 in 1.5.2. A floor nothing
+# exercises is the same unbacked claim that shipped the 3.14 langchain bug.
+requires-python = ">=3.11"
 dynamic = ["dependencies", "optional-dependencies"]
 
 [project.urls]
@@ -30,14 +33,17 @@ python_functions = ["test_*"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+# Matches the root ruff.toml and requires-python. These disagreeing (py310 here
+# vs py311 at the root) meant the two byte-identical stdio-bridge copies were
+# formatted under different targets and could have drifted apart silently.
+target-version = "py311"
 
 [tool.ruff.lint]
 # Enforce syntax errors, unused imports, and import sorting
 select = ["E9", "F", "I"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 ignore_missing_imports = true
 strict = false
 warn_unused_ignores = true

--- a/controller/tests/test_auth_guards.py
+++ b/controller/tests/test_auth_guards.py
@@ -180,6 +180,131 @@ def test_malformed_share_tokens_are_rejected() -> None:
             svc.validate_token(bad)
 
 
+# ── Auth state must fail closed ────────────────────────────────────────────
+
+
+def _auth_manager(tmp_path: Path, *, require_encryption: bool, with_key: bool = True):
+    from cryptography.fernet import Fernet
+
+    from app.auth_state import AuthStateManager
+
+    key = Fernet.generate_key().decode() if with_key else None
+    return AuthStateManager(encryption_key=key, require_encryption=require_encryption, max_age_hours=0), key
+
+
+_STATE = {"cookies": [{"name": "session", "value": "SUPER-SECRET"}], "origins": []}
+
+
+def _write_plaintext(path: Path) -> Path:
+    import json
+
+    path.write_text(json.dumps(_STATE), encoding="utf-8")
+    return path
+
+
+def _write_envelope(path: Path, key: str) -> Path:
+    import json
+
+    from cryptography.fernet import Fernet
+
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "format": "fernet-json",
+                "ciphertext": Fernet(key.encode()).encrypt(json.dumps(_STATE).encode()).decode(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_require_encryption_refuses_plaintext_auth_state(tmp_path: Path) -> None:
+    """REQUIRE_AUTH_STATE_ENCRYPTION was only enforced at construction.
+
+    It checked "is a key configured?" and never checked the file being read, so
+    a plaintext state file loaded happily and its cookies went straight into a
+    live browser context. The setting promised encrypted-at-rest and silently
+    did not deliver it.
+    """
+    manager, _ = _auth_manager(tmp_path, require_encryption=True)
+    plain = _write_plaintext(tmp_path / "state.json")
+
+    with pytest.raises(PermissionError, match="not encrypted"):
+        manager.prepare_for_context(plain)
+
+
+def test_plaintext_is_allowed_when_encryption_is_not_required(tmp_path: Path) -> None:
+    """Guard the guard: the refusal is conditional on the setting."""
+    manager, _ = _auth_manager(tmp_path, require_encryption=False, with_key=False)
+    plain = _write_plaintext(tmp_path / "state.json")
+
+    prepared = manager.prepare_for_context(plain)
+    assert prepared.path == plain
+
+
+def test_encrypted_content_is_detected_without_the_enc_suffix(tmp_path: Path) -> None:
+    """Encryption status came from the filename, not the content.
+
+    An encrypted envelope named without `.enc` was classified as plaintext and
+    handed to Playwright verbatim — so no cookies loaded and the agent carried
+    on believing the auth profile had been applied.
+    """
+    import json
+
+    manager, key = _auth_manager(tmp_path, require_encryption=False)
+    mislabelled = _write_envelope(tmp_path / "state-no-suffix.json", key)
+
+    assert manager.inspect(mislabelled)["encrypted"] is True
+
+    prepared = manager.prepare_for_context(mislabelled)
+    body = json.loads(Path(prepared.path).read_text(encoding="utf-8"))
+    assert "cookies" in body, "the envelope must be decrypted, not passed through"
+    assert body["cookies"][0]["value"] == "SUPER-SECRET"
+    prepared.cleanup()
+
+
+def test_plaintext_named_enc_is_detected_as_plaintext(tmp_path: Path) -> None:
+    """The mislabelling is caught in both directions."""
+    manager, _ = _auth_manager(tmp_path, require_encryption=False)
+    mislabelled = _write_plaintext(tmp_path / "state.json.enc")
+
+    assert manager.inspect(mislabelled)["encrypted"] is False
+    assert manager.prepare_for_context(mislabelled).path == mislabelled
+
+
+def test_encrypted_state_without_a_key_is_refused(tmp_path: Path) -> None:
+    manager_with_key, key = _auth_manager(tmp_path, require_encryption=False)
+    encrypted = _write_envelope(tmp_path / "state.json.enc", key)
+
+    keyless, _ = _auth_manager(tmp_path, require_encryption=False, with_key=False)
+    with pytest.raises(RuntimeError, match="AUTH_STATE_ENCRYPTION_KEY"):
+        keyless.prepare_for_context(encrypted)
+
+
+def test_require_encryption_without_a_key_fails_at_construction(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="AUTH_STATE_ENCRYPTION_KEY"):
+        _auth_manager(tmp_path, require_encryption=True, with_key=False)
+
+
+def test_tampered_ciphertext_is_rejected(tmp_path: Path) -> None:
+    """A corrupted envelope must raise, not silently yield empty auth state."""
+    import json
+
+    from cryptography.fernet import InvalidToken
+
+    manager, key = _auth_manager(tmp_path, require_encryption=False)
+    path = _write_envelope(tmp_path / "state.json.enc", key)
+
+    body = json.loads(path.read_text(encoding="utf-8"))
+    body["ciphertext"] = body["ciphertext"][:-6] + "AAAAAA"
+    path.write_text(json.dumps(body), encoding="utf-8")
+
+    with pytest.raises(InvalidToken):
+        manager.prepare_for_context(path)
+
+
 # ── Credential movement leaves a record ────────────────────────────────────
 
 

--- a/controller/tests/test_python_floor_is_tested.py
+++ b/controller/tests/test_python_floor_is_tested.py
@@ -1,0 +1,115 @@
+"""No package may claim a Python version CI does not test.
+
+This exact pattern has now shipped two bugs:
+
+  * `auto-browser-langchain` advertised 3.14 in `requires-python` and its
+    classifiers while nothing tested it, so `asyncio.get_event_loop()` raising
+    on 3.14 broke the sync `_run` path in production (fixed in v1.4.2).
+  * `auto-browser-client` and `auto-browser-mcp` advertised 3.10 to PyPI while
+    CI tested only 3.11 and 3.14 (corrected in v1.5.2).
+
+Every previous fix corrected the *instances*. This asserts the invariant, so
+lowering a floor without adding the matching CI job fails here instead of on a
+user's machine.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+PYPROJECTS = (
+    "controller/pyproject.toml",
+    "client/pyproject.toml",
+    "integrations/langchain/pyproject.toml",
+    "packaging/auto-browser-mcp/pyproject.toml",
+)
+
+# Repo-layout checks: the controller image ships only `app/` and `tests/`, so
+# neither the workflow nor the sibling packages exist inside the container.
+pytestmark = pytest.mark.skipif(
+    not CI_WORKFLOW.is_file(),
+    reason="repo checkout not available (running inside the controller image)",
+)
+
+
+def _version_tuple(text: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in text.split("."))
+
+
+def _ci_tested_versions() -> set[tuple[int, ...]]:
+    """Every `python-version` value the CI workflow runs jobs on."""
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    found: set[tuple[int, ...]] = set()
+    # matrix form: python-version: ["3.11", "3.14"]
+    for match in re.finditer(r"python-version:\s*\[([^\]]+)\]", text):
+        for raw in match.group(1).split(","):
+            cleaned = raw.strip().strip('"').strip("'")
+            if cleaned:
+                found.add(_version_tuple(cleaned))
+    # scalar form: python-version: "3.11"
+    for match in re.finditer(r'python-version:\s*["\']([\d.]+)["\']', text):
+        found.add(_version_tuple(match.group(1)))
+    return found
+
+
+def test_ci_python_versions_were_parsed() -> None:
+    """Guard the guard — an unparsed workflow would make every case vacuous."""
+    versions = _ci_tested_versions()
+    assert versions, f"no python-version entries parsed from {CI_WORKFLOW}"
+    assert (3, 11) in versions
+
+
+@pytest.mark.parametrize("relative", PYPROJECTS)
+def test_requires_python_floor_is_actually_tested(relative: str) -> None:
+    path = REPO_ROOT / relative
+    if not path.is_file():
+        pytest.skip(f"{relative} not present")
+
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    requires = data.get("project", {}).get("requires-python")
+    assert requires, f"{relative} declares no requires-python"
+
+    match = re.search(r">=\s*([\d.]+)", requires)
+    assert match, f"{relative} has an unparseable requires-python: {requires!r}"
+    floor = _version_tuple(match.group(1))
+
+    tested = _ci_tested_versions()
+    assert floor in tested, (
+        f"{relative} declares requires-python {requires!r}, but CI never runs "
+        f"Python {'.'.join(str(p) for p in floor)}. Either add it to the CI "
+        f"matrix or raise the floor — an untested floor is a promise to users "
+        f"that nothing verifies."
+    )
+
+
+@pytest.mark.parametrize("relative", PYPROJECTS)
+def test_python_classifiers_do_not_exceed_the_floor(relative: str) -> None:
+    """A `Python :: 3.10` classifier with a `>=3.11` floor misleads PyPI users."""
+    path = REPO_ROOT / relative
+    if not path.is_file():
+        pytest.skip(f"{relative} not present")
+
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    requires = project.get("requires-python", "")
+    match = re.search(r">=\s*([\d.]+)", requires)
+    if not match:
+        pytest.skip(f"{relative} has no >= floor")
+    floor = _version_tuple(match.group(1))
+
+    for classifier in project.get("classifiers", []):
+        found = re.fullmatch(r"Programming Language :: Python :: (\d+\.\d+)", classifier)
+        if not found:
+            continue
+        advertised = _version_tuple(found.group(1))
+        assert advertised >= floor, (
+            f"{relative} ships classifier {classifier!r} but requires-python is "
+            f"{requires!r} — pip would refuse to install on that version."
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,25 @@ services:
     build:
       context: ./browser-node
     shm_size: 2gb
+    restart: unless-stopped
+    # Health means "the Playwright server the controller connects to is up",
+    # not "noVNC answers". This previously checked only :6080 (websockify), so
+    # a wedged or dead Chromium reported healthy for as long as noVNC survived
+    # — and the controller's depends_on: service_healthy gate passed anyway.
+    #   1. endpoint file non-empty — server.mjs writes it once it is listening,
+    #      and entrypoint.sh removes it on every start
+    #   2. :9223 accepts a connection — no -f, because the Playwright server
+    #      answers a plain GET with an HTTP error; only connection refusal
+    #      (curl exit 7) should fail the check
+    #   3. :6080 still serves — human takeover is a real feature and its
+    #      silent death should be visible too
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:6080/ >/dev/null || exit 1"]
+      test:
+        - CMD-SHELL
+        - >-
+          test -s "${BROWSER_WS_ENDPOINT_FILE:-/data/profile/browser-ws-endpoint.txt}"
+          && curl -s --max-time 3 -o /dev/null http://127.0.0.1:${PLAYWRIGHT_SERVER_PORT:-9223}/
+          && curl -fsS --max-time 3 http://127.0.0.1:6080/ >/dev/null
       interval: 10s
       timeout: 5s
       retries: 12
@@ -27,6 +44,15 @@ services:
   controller:
     build:
       context: ./controller
+    # Without this a controller OOM — a real risk on small hosts, where a
+    # leaked browser container plus Chromium is enough — left the container
+    # stopped forever. depends_on only gates startup ordering; nothing
+    # recovered afterwards, so MCP clients just got connection refused.
+    restart: unless-stopped
+    # Sessions are closed sequentially on shutdown and an isolated one can take
+    # ~10s (tunnel terminate + container stop), so the 10s default SIGKILLed
+    # cleanup mid-flight and orphaned containers and tunnels.
+    stop_grace_period: 60s
     depends_on:
       browser-node:
         condition: service_healthy


### PR DESCRIPTION
Investigated the suspected `.enc`-suffix bug. **The original suspicion was wrong, and the real finding is worse.**

### What I expected vs what is actually true

The lead was "an encrypted file renamed without `.enc` may be handed to Playwright as plaintext." That does not happen — the file contains ciphertext, so nothing plaintext leaks. What actually happens is that the ciphertext **envelope** is passed to Playwright verbatim as if it were storage state, so no cookies load and the agent carries on believing the auth profile was applied. A silent auth failure, not an exposure.

The genuinely serious defect was next to it.

### `REQUIRE_AUTH_STATE_ENCRYPTION=true` loaded plaintext cookies

The setting was enforced **only at construction** — "is a key configured?" — and never on the read path. Measured against the real code:

```
inspect().encrypted  : False
encryption_required  : True
prepare_for_context  : ACCEPTED, cookie value = 'SUPER-SECRET'
>>> FAIL-OPEN: 'encryption required' consumed plaintext cookies
```

A plaintext auth-state file loaded happily and its cookies went straight into a live browser context, while the setting advertised encrypted-at-rest. That is a fail-open on a security control.

### Root cause of both

`inspect()` decided `encrypted` from `path.name.endswith(".enc")` — the filename, never the content — so the classification was wrong in **both** directions.

Content now decides for a file that exists (fernet envelope vs Playwright storage-state shape). The suffix survives only as the hint for a path that does not exist yet, and an unclassifiable file falls back rather than guessing. `prepare_for_context` refuses plaintext when encryption is required.

After the fix, the same probe reports the envelope decrypting to real `cookies`/`origins`, and the plaintext case refused.

### Remaining operational items, also closed

- **browser-node's healthcheck watched the wrong service.** It curled noVNC `:6080`, not the Playwright server `:9223` the controller depends on — so a wedged or dead Chromium reported healthy for as long as websockify survived, and `depends_on: service_healthy` passed anyway. Now checks the endpoint file `server.mjs` writes on listen, that `:9223` accepts a connection (no `-f`: the Playwright server answers a plain GET with an HTTP error, so only connection *refusal* should fail), and that `:6080` still serves.
- **No restart policy on controller or browser-node.** A controller OOM left the container stopped forever with nothing recovering. Added — plus `stop_grace_period: 60s`, because sessions close sequentially and an isolated one can take ~10s, so the 10s default SIGKILLed cleanup mid-flight and orphaned containers and tunnels.
- **`controller/pyproject.toml` still claimed `>=3.10`** with mypy `python_version = "3.10"` while CI tests 3.11/3.14 — the last instance of the unbacked-floor pattern. Also `ruff target-version` disagreed with the root `ruff.toml` (py310 vs py311), which meant the two byte-identical stdio-bridge copies were formatted under **different targets** and could have drifted apart silently.

### The floor is now an invariant, not another one-off correction

This pattern has shipped two bugs (3.14 in langchain, 3.10 in client/mcp). A new test parses the CI matrix and fails if any package declares a Python version CI does not run, or ships a classifier below its own floor. **Verified it catches a lowered floor**, and it skips cleanly inside the controller image where the workflow isn't shipped.

**843 → 859 passed**, 2 skipped, 199 subtests. `ruff check` clean, bridge parity intact, `docker compose config` validated locally.