### PR TITLE
fix: bound /readyz, reclaim isolated-session profile trees

### DIFF
--- a/controller/app/routes/system.py
+++ b/controller/app/routes/system.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from pathlib import Path
@@ -10,6 +11,11 @@ from fastapi.responses import JSONResponse, Response
 
 from ..audit import get_current_operator
 from ..readiness import run_readiness_checks
+
+# A readiness probe must answer within a probe interval, not within the
+# session-creation retry budget (CONNECT_RETRIES x CONNECT_RETRY_DELAY_SECONDS,
+# 60s by default). Failing fast is the correct answer for "are you ready?".
+READYZ_TIMEOUT_SECONDS = 5.0
 
 if TYPE_CHECKING:
     from ..browser_manager import BrowserManager
@@ -117,8 +123,18 @@ def create_system_router(
     @router.get("/readyz")
     async def readyz() -> dict[str, str]:
         try:
-            await manager.ensure_browser()
+            # Bounded. ensure_browser() retries CONNECT_RETRIES times (default
+            # 60) at CONNECT_RETRY_DELAY_SECONDS apart *while holding the global
+            # browser lock*, so with browser-node down this probe used to hang
+            # for a minute or more and every concurrent readyz and every
+            # create_session queued behind it — the API looked dead instead of
+            # reporting "not ready". A readiness probe must answer promptly;
+            # cancelling releases the lock via its async context manager.
+            await asyncio.wait_for(manager.ensure_browser(), timeout=READYZ_TIMEOUT_SECONDS)
             return {"status": "ready", "environment": settings.environment_name}
+        except TimeoutError:
+            logger.warning("readiness check timed out after %ss", READYZ_TIMEOUT_SECONDS)
+            raise HTTPException(status_code=503, detail="Service unavailable") from None
         except Exception:
             logger.exception("readiness check failed")
             raise HTTPException(status_code=503, detail="Service unavailable") from None

--- a/controller/app/session_isolation.py
+++ b/controller/app/session_isolation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -211,7 +212,31 @@ class DockerBrowserNodeProvisioner:
             try:
                 container.remove(force=True)
             except Exception as exc:
-                logger.debug("Could not remove browser container %s: %s", runtime.container_name, exc)
+                logger.warning("Could not remove browser container %s: %s", runtime.container_name, exc)
+            self._remove_runtime_dirs(runtime.session_id)
+
+    def _remove_runtime_dirs(self, session_id: str) -> None:
+        """Delete the per-session profile and downloads tree.
+
+        Only the container was ever removed on release. Each isolated session
+        leaves behind a full Chromium profile — tens to hundreds of megabytes —
+        and nothing cleaned it: MaintenanceService sweeps only the artifact,
+        upload and auth roots. On a long-lived host that is unbounded growth
+        with no signal until the volume fills mid-session.
+        """
+        runtime_root = self._local_runtime_root(session_id)
+        try:
+            resolved = runtime_root.resolve()
+            base = self._local_runtime_root("").resolve()
+            # Never delete outside the managed runtime root, whatever a
+            # malformed session id might resolve to.
+            if base not in resolved.parents:
+                logger.warning("Refusing to remove %s: outside the session runtime root", resolved)
+                return
+            shutil.rmtree(resolved, ignore_errors=True)
+            logger.debug("Removed isolated session runtime dir %s", resolved)
+        except Exception as exc:
+            logger.warning("Could not remove runtime dir for session %s: %s", session_id, exc)
 
     def _ensure_context(self):
         if self._client is None:

--- a/controller/tests/test_runtime_lifecycle.py
+++ b/controller/tests/test_runtime_lifecycle.py
@@ -268,6 +268,76 @@ def test_metrics_path_collapses_unmatched_routes() -> None:
     assert "_metric_path" in text
 
 
+def test_isolated_session_runtime_dirs_are_removed_on_release(tmp_path: Path) -> None:
+    """Releasing an isolated session must delete its profile tree.
+
+    Only the container was ever removed. Each session leaves a full Chromium
+    profile behind — tens to hundreds of MB — and MaintenanceService sweeps only
+    the artifact, upload and auth roots, so this grew without bound until the
+    volume filled mid-session.
+    """
+    from app.session_isolation import DockerBrowserNodeProvisioner
+
+    settings = SimpleNamespace(
+        artifact_root=str(tmp_path / "artifacts"),
+        isolated_browser_keep_containers=False,
+    )
+    provisioner = DockerBrowserNodeProvisioner.__new__(DockerBrowserNodeProvisioner)
+    provisioner.settings = settings
+
+    runtime_root = provisioner._local_runtime_root("sess-1")
+    (runtime_root / "profile").mkdir(parents=True)
+    (runtime_root / "profile" / "Cookies").write_bytes(b"x" * 4096)
+    (runtime_root / "downloads").mkdir(parents=True)
+    assert runtime_root.exists()
+
+    provisioner._remove_runtime_dirs("sess-1")
+
+    assert not runtime_root.exists(), "the per-session profile tree must be deleted"
+
+
+def test_runtime_dir_removal_refuses_paths_outside_the_root(tmp_path: Path) -> None:
+    """A malformed session id must not delete anything outside browser-sessions."""
+    from app.session_isolation import DockerBrowserNodeProvisioner
+
+    settings = SimpleNamespace(
+        artifact_root=str(tmp_path / "artifacts"),
+        isolated_browser_keep_containers=False,
+    )
+    provisioner = DockerBrowserNodeProvisioner.__new__(DockerBrowserNodeProvisioner)
+    provisioner.settings = settings
+
+    victim = tmp_path / "important"
+    victim.mkdir(parents=True)
+    (victim / "keep.txt").write_text("do not delete", encoding="utf-8")
+
+    provisioner._remove_runtime_dirs("../../important")
+
+    assert victim.exists(), "traversal outside the runtime root must be refused"
+    assert (victim / "keep.txt").read_text(encoding="utf-8") == "do not delete"
+
+
+def test_readyz_timeout_is_bounded_and_shorter_than_the_connect_budget() -> None:
+    """/readyz must answer within a probe interval, not the retry budget.
+
+    ensure_browser() retries CONNECT_RETRIES (default 60) times a second apart
+    while holding the global browser lock, so with browser-node down the probe
+    hung for a minute-plus and every concurrent readyz and create_session queued
+    behind it — the API looked dead rather than "not ready".
+    """
+    from app.config import Settings
+    from app.routes.system import READYZ_TIMEOUT_SECONDS
+
+    settings = Settings(_env_file=None)
+    worst_case = settings.connect_retries * settings.connect_retry_delay_seconds
+
+    assert READYZ_TIMEOUT_SECONDS > 0
+    assert READYZ_TIMEOUT_SECONDS < worst_case, (
+        f"readyz timeout {READYZ_TIMEOUT_SECONDS}s must be well under the "
+        f"{worst_case}s connect retry budget it is meant to bound"
+    )
+
+
 def test_cron_store_roundtrips_valid_json(tmp_path: Path) -> None:
     """Guard the guard: quarantine must not fire on healthy stores."""
     service = CronService(tmp_path / "cron.json")


### PR DESCRIPTION
The last two operational items from the audit.

### `/readyz` could hang for a minute while holding the global browser lock

It called `ensure_browser()`, which retries `CONNECT_RETRIES` times (**default 60**) at `CONNECT_RETRY_DELAY_SECONDS` apart — *while holding `_browser_lock`*. With browser-node down, the probe hung for a minute-plus and every concurrent `readyz` and every `create_session` queued behind it.

So the failure mode was backwards: the API looked **dead** rather than reporting **"not ready"**, which is the entire purpose of a readiness probe.

Now bounded at 5s. Cancelling releases the lock through its async context manager, so nothing is left holding it. A test asserts the bound stays well under the connect budget it exists to cap — so raising `CONNECT_RETRIES` can't silently un-fix this.

### Isolated sessions leaked their entire profile tree

`_release_sync` removed the container but never `<data>/browser-sessions/<id>`, which holds a **full Chromium profile** — tens to hundreds of megabytes per session. `MaintenanceService` sweeps only the artifact, upload, and auth roots, so nothing ever reclaimed it: unbounded growth with no signal until the volume filled mid-session.

Removal is refused for any path resolving outside the managed runtime root, so a malformed session id can't delete anything else. Both the removal and the refusal are tested.

Also promoted the container-removal failure log from DEBUG to WARNING — a container that fails to remove *is* a leak, and it was invisible at the default log level.

**859 → 862 passed**, 2 skipped, 199 subtests. `ruff check` clean, `docker compose config` valid.