### PR TITLE
release: v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,81 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.5.3] — 2026-08-04
+
+Closes the audit. The remaining lead turned out to hide a worse defect than the
+one it described.
+
+**If you set `REQUIRE_AUTH_STATE_ENCRYPTION=true`, upgrade.** It did not do what
+it says.
+
+### Security
+
+- **`REQUIRE_AUTH_STATE_ENCRYPTION=true` loaded plaintext auth state.** The
+  setting was enforced only at construction — "is a key configured?" — and never
+  on the read path, so a plaintext state file loaded happily and its cookies went
+  straight into a live browser context while the deployment believed encryption
+  was mandatory. Measured against the real code:
+
+  ```
+  inspect().encrypted  : False
+  encryption_required  : True
+  prepare_for_context  : ACCEPTED, cookie value = 'SUPER-SECRET'
+  ```
+
+  `prepare_for_context` now refuses unencrypted state when encryption is
+  required (#137).
+- **Auth-state encryption was classified by filename, not content.** `inspect()`
+  decided `encrypted` from `path.name.endswith(".enc")`, so the classification
+  was wrong in both directions. An encrypted envelope named without `.enc` was
+  *not* leaked as plaintext — it is ciphertext — but it was handed to Playwright
+  verbatim as if the envelope were storage state, so no cookies loaded and the
+  agent proceeded believing the auth profile had been applied. A silent auth
+  failure rather than an exposure. Content now decides for a file that exists;
+  the suffix remains only as the hint for a path that does not exist yet, and an
+  unclassifiable file falls back rather than guessing (#137).
+
+### Fixed
+
+- **`/readyz` could hang for a minute while holding the global browser lock.**
+  It called `ensure_browser()`, which retries `CONNECT_RETRIES` (default 60)
+  times a second apart while holding `_browser_lock`, so with browser-node down
+  every concurrent probe and every `create_session` queued behind it — the API
+  looked dead rather than reporting "not ready", which is the opposite of a
+  readiness probe's purpose. Now bounded at 5 seconds (#138).
+- **Isolated sessions leaked their entire profile tree.** `_release_sync` removed
+  the container but never `<data>/browser-sessions/<id>`, which holds a full
+  Chromium profile — tens to hundreds of megabytes per session — and the
+  maintenance sweep covers only the artifact, upload and auth roots. Unbounded
+  growth with no signal until the volume filled mid-session. Removal is refused
+  for any path resolving outside the managed runtime root (#138).
+- **browser-node's healthcheck watched the wrong service.** It probed noVNC
+  `:6080`, not the Playwright server `:9223` the controller actually depends on,
+  so a wedged or dead Chromium reported healthy for as long as websockify
+  survived — and the controller's `depends_on: service_healthy` gate passed
+  anyway (#137).
+- **No restart policy on controller or browser-node**, so a controller OOM left
+  the container stopped forever with nothing recovering. Added, with a 60s
+  `stop_grace_period`: sessions close sequentially and an isolated one can take
+  ~10s, so the 10s default SIGKILLed cleanup mid-flight and orphaned containers
+  and tunnels (#137).
+
+### Changed
+
+- `controller/pyproject.toml` raised to `requires-python = ">=3.11"` (with mypy
+  and ruff `target-version` to match) — the last instance of the unbacked-floor
+  pattern. Its ruff target also disagreed with the root `ruff.toml` (py310 vs
+  py311), which meant the two byte-identical stdio-bridge copies were formatted
+  under different targets and could have drifted apart silently (#137).
+
+### CI
+
+- **The Python floor is now an invariant, not a repeated correction.** This
+  pattern shipped two bugs — 3.14 advertised and untested in langchain, 3.10 in
+  the client and mcp packages. A test parses the CI matrix and fails if any
+  package declares a Python version CI does not run, or ships a classifier below
+  its own floor (#137).
+
 ## [1.5.2] — 2026-08-04
 
 The rest of the audit that produced 1.5.1. Same theme — guarantees that were

--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-browser-browser-node",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "playwright": "1.62.0"
       }

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -3,4 +3,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.5.2"
+version = "1.5.3"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/controller/app/version.py
+++ b/controller/app/version.py
@@ -4,4 +4,4 @@ Bump together with the package versions in */pyproject.toml and
 browser-node/package.json during release prep.
 """
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.5.2"
+version = "1.5.3"
 description = "Controller API for auto-browser"
 # 3.11, not 3.10: CI tests 3.11 and 3.14, the Dockerfile pins python:3.11-slim,
 # and the published packages were corrected to >=3.11 in 1.5.2. A floor nothing

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.5.2"
+version = "1.5.3"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # console script against that dependency.
 [project]
 name = "auto-browser-mcp"
-version = "1.5.2"
+version = "1.5.3"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Closes the audit. The remaining lead — the suspected `.enc`-suffix bug — turned out to hide a worse defect than the one it described.

### The headline

**`REQUIRE_AUTH_STATE_ENCRYPTION=true` loaded plaintext auth state.** Enforced only at construction ("is a key configured?"), never on the read path — so plaintext cookies went straight into a live browser context while the deployment believed encryption was mandatory.

```
inspect().encrypted  : False
encryption_required  : True
prepare_for_context  : ACCEPTED, cookie value = 'SUPER-SECRET'
```

Root cause: `inspect()` classified encryption by **filename**, never content — wrong in both directions. The originally-suspected symptom (encrypted file handed over as plaintext) does *not* happen; it's ciphertext. What happened instead was the envelope being passed to Playwright verbatim, so no cookies loaded and the agent proceeded believing the profile applied. Worth stating precisely rather than repeating the scarier guess.

### Also in this release

| | |
|---|---|
| `/readyz` | hung up to a minute holding the global browser lock — the API looked *dead* rather than *not ready* |
| isolated sessions | leaked their whole Chromium profile tree, unbounded |
| browser-node healthcheck | watched noVNC, not the Playwright server the controller depends on |
| controller & browser-node | no restart policy; an OOM stopped them forever |
| `controller/pyproject.toml` | still claimed an untested Python 3.10 floor |

### Verification

| gate | result |
|---|---|
| controller suite | **862 passed**, 2 skipped, 199 subtests (637 at v1.5.0) |
| `check_version_parity.py` | 9/9 on **1.5.3** |
| `check_playwright_pins.py` | matched at 1.62.0 |
| `check_bridge_parity.py` | byte-identical |
| `ruff check .` | clean |
| `docker compose config` | valid |
| `extract_changelog.py 1.5.3` | 61 lines |

The Python floor is now an **invariant** rather than a third one-off correction: a test parses the CI matrix and fails if any package claims a version CI does not run.

### Still open, deliberately

- **Witness receipts remain unsigned.** Sequenced after the effect-verification work, not forgotten — signing a chain whose entries were false would have been worse than not signing it.
- **Witness receipts for profile-scoped operations.** Receipts are session-scoped; export/import have none, so v1.5.2 added the audit record rather than faking one.
- **The GHSA decision** from v1.5.1 is still yours — and this release adds a second candidate, since a fail-open on `REQUIRE_AUTH_STATE_ENCRYPTION` is squarely security-relevant.