### PR TITLE
feat(witness): sign the receipt chain and make bundles verifiable off-box

### DIFF
--- a/controller/app/browser/services/auth_profiles.py
+++ b/controller/app/browser/services/auth_profiles.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import re
 import shutil
@@ -11,8 +12,11 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+from ...audit import get_current_operator
 from ...utils import UTC, utc_now
 from ...witness import WitnessActionContext
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ...browser_manager import BrowserSession
@@ -31,6 +35,44 @@ _COPY_CHUNK_BYTES = 64 * 1024
 class BrowserAuthProfileService:
     def __init__(self, manager: Any) -> None:
         self.manager = manager
+
+    async def _record_profile_receipt(
+        self,
+        *,
+        action: str,
+        profile_name: str,
+        metadata: dict[str, Any],
+    ) -> None:
+        """Witness receipt for an operation that moves credentials but has no session.
+
+        Receipts were previously session-scoped only, which is why auth-profile
+        export and import — the two operations that move credentials on and off
+        the box — had none. `session_id` is optional on the receipt model, so
+        these record under a dedicated `auth-profiles` scope with their own
+        signed chain.
+
+        Never allowed to break the operation it is recording: a witness outage
+        must not make exporting a profile fail. It is logged loudly instead, and
+        verify() reports the gap.
+        """
+        witness = getattr(self.manager, "witness", None)
+        if witness is None:
+            return
+        try:
+            await witness.record(
+                "auth-profiles",
+                profile="normal",
+                event_type="auth_profile",
+                status="ok",
+                action=action,
+                action_class="auth",
+                session_id=None,
+                operator=get_current_operator(),
+                target={"profile_name": profile_name},
+                metadata=metadata,
+            )
+        except Exception:
+            logger.exception("witness: failed to record %s receipt for profile %s", action, profile_name)
 
     @staticmethod
     def _host_matches(host: str, *domains: str) -> bool:
@@ -316,6 +358,14 @@ class BrowserAuthProfileService:
                 "encrypted_at_rest": bool(self.manager.settings.auth_state_encryption_key),
             },
         )
+        await self._record_profile_receipt(
+            action="export_auth_profile",
+            profile_name=normalized,
+            metadata={
+                "archive_name": archive_name,
+                "encrypted_at_rest": bool(self.manager.settings.auth_state_encryption_key),
+            },
+        )
 
         return {
             "profile_name": normalized,
@@ -420,6 +470,11 @@ class BrowserAuthProfileService:
             action="import_auth_profile",
             session_id=None,
             details={"profile_name": profile_name, "archive_name": archive_name, "overwrite": overwrite},
+        )
+        await self._record_profile_receipt(
+            action="import_auth_profile",
+            profile_name=profile_name,
+            metadata={"archive_name": archive_name, "overwrite": overwrite},
         )
 
         return {

--- a/controller/app/browser_manager.py
+++ b/controller/app/browser_manager.py
@@ -62,6 +62,27 @@ logger = logging.getLogger(__name__)
 __all__ = ["BrowserManager", "BrowserSession", "PlaywrightError"]
 
 
+def _build_witness_signer(settings):
+    """Ed25519 signer for witness receipts, or None if it cannot be created.
+
+    Keys live beside the receipts they sign (`<witness_root>/keys`) and are
+    generated on first use, so signing is on by default with no configuration.
+
+    A failure here must not take the controller down: an unsigned chain is still
+    a useful audit log, and refusing to boot over key material would make the
+    security improvement a liability. It is logged at exception level, and
+    verify() reports unsigned receipts, so the degraded state stays visible
+    rather than being quietly assumed away.
+    """
+    try:
+        from .witness_signing import WitnessSigner
+
+        return WitnessSigner(Path(settings.witness_root) / "keys")
+    except Exception:
+        logger.exception("witness: could not initialise the signing key; receipts will be recorded unsigned")
+        return None
+
+
 @dataclass
 class BrowserSession:
     id: str
@@ -191,7 +212,7 @@ class BrowserManager:
             self.pii_scrubber,
             self.download_capture,
         )
-        self.witness = WitnessRecorder(self.settings.witness_root)
+        self.witness = WitnessRecorder(self.settings.witness_root, signer=_build_witness_signer(self.settings))
         self.witness_remote = WitnessRemoteClient(
             base_url=self.settings.witness_remote_url,
             api_key=self.settings.witness_remote_api_key,
@@ -703,7 +724,16 @@ class BrowserManager:
         return [item.model_dump() for item in receipts]
 
     async def verify_witness_chain(self, session_id: str) -> dict[str, Any]:
-        return await self.witness.verify(session_id)
+        chain = await self.witness.verify(session_id)
+        # A hash chain only proves internal consistency — anyone holding the file
+        # can rewrite it and recompute every hash. Report the signature result
+        # alongside so "valid: true" is never mistaken for "attested".
+        chain["signatures"] = await self.witness.verify_signatures(session_id)
+        return chain
+
+    async def export_witness_bundle(self, session_id: str) -> dict[str, Any]:
+        """Third-party-verifiable evidence bundle for a session."""
+        return await self.witness.export_bundle(session_id)
 
     def _initial_witness_remote_state(self, protection_mode: str) -> WitnessRemoteState:
         return self.witness_bridge.initial_remote_state(protection_mode)

--- a/controller/app/routes/session_diagnostics.py
+++ b/controller/app/routes/session_diagnostics.py
@@ -213,6 +213,16 @@ def create_session_diagnostics_router(*, manager: Any, settings: Any) -> APIRout
     async def verify_session_witness(session_id: str) -> dict[str, Any]:
         return await manager.verify_witness_chain(session_id)
 
+    @router.get("/sessions/{session_id}/witness/bundle")
+    async def export_session_witness_bundle(session_id: str) -> dict[str, Any]:
+        """Self-contained evidence bundle: receipts, head hash, and public key.
+
+        Verify it anywhere with scripts/verify_witness_bundle.py, which imports
+        nothing from this project — that independence is what makes a receipt
+        evidence rather than an assertion about itself.
+        """
+        return await manager.export_witness_bundle(session_id)
+
     @router.get("/sessions/{session_id}/export-script")
     async def export_script(session_id: str) -> dict[str, Any]:
         session = await manager.get_session(session_id)

--- a/controller/app/tool_gateway/gateway.py
+++ b/controller/app/tool_gateway/gateway.py
@@ -547,6 +547,9 @@ class McpToolGateway:
     async def _verify_witness(self, payload: VerifyWitnessInput) -> dict[str, Any]:
         return await self.manager.verify_witness_chain(payload.session_id)
 
+    async def _export_witness_bundle(self, payload: VerifyWitnessInput) -> dict[str, Any]:
+        return await self.manager.export_witness_bundle(payload.session_id)
+
     async def _fork_session(self, payload: ForkSessionInput) -> dict[str, Any]:
         return await self.manager.fork_session(
             payload.session_id,

--- a/controller/app/tool_gateway/packs/diagnostics.py
+++ b/controller/app/tool_gateway/packs/diagnostics.py
@@ -44,12 +44,29 @@ def register(registry, gateway):
         ToolSpec(
             name="browser.verify_witness",
             description=(
-                "Verify the integrity of a session's Witness receipt hash chain. "
-                "Walks every receipt, recomputes the chain, and reports the first "
-                "divergent receipt if the log was altered, reordered, or truncated."
+                "Verify a session's Witness receipt chain. Walks every receipt, "
+                "recomputes the hash chain, and reports the first divergent receipt "
+                "if the log was altered, reordered, or truncated. Also returns a "
+                "'signatures' block: the hash chain alone only proves internal "
+                "consistency, while the Ed25519 signatures prove the receipts were "
+                "attested by this deployment's key."
             ),
             input_model=VerifyWitnessInput,
             handler=gateway._verify_witness,
+            read_only_hint=True,
+        ),
+        ToolSpec(
+            name="browser.export_witness_bundle",
+            description=(
+                "Export a session's Witness receipts as a self-contained evidence "
+                "bundle: every receipt, the head hash, the signing key id, and the "
+                "Ed25519 public key. Anyone can verify it with "
+                "scripts/verify_witness_bundle.py, which imports nothing from this "
+                "project. Use when you need to hand proof of what happened in a "
+                "session to someone who does not run (or trust) this controller."
+            ),
+            input_model=VerifyWitnessInput,
+            handler=gateway._export_witness_bundle,
             read_only_hint=True,
         ),
         ToolSpec(

--- a/controller/app/witness.py
+++ b/controller/app/witness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from hashlib import sha256
 from pathlib import Path
 from typing import Any, Literal
@@ -12,6 +13,9 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from .models import OperatorIdentity, ProtectionMode
 from .utils import utc_now
+from .witness_signing import SIGNATURE_ALGORITHM
+
+logger = logging.getLogger(__name__)
 
 EvidenceMode = Literal["standard", "restricted"]
 ConcernSeverity = Literal["info", "warn", "high", "critical"]
@@ -74,9 +78,17 @@ class WitnessReceipt(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     chain_prev_hash: str | None = None
     chain_hash: str | None = None
+    # Ed25519 signature over chain_hash, and the signing key's id. Optional so
+    # chains written before signing existed still parse and still verify.
+    chain_signature: str | None = None
+    signing_key_id: str | None = None
 
     def chain_payload(self) -> dict[str, Any]:
-        return self.model_dump(mode="json", exclude={"chain_hash"})
+        # The signature fields are excluded because they are derived *from* the
+        # hash — including them would be circular. Excluding them also keeps the
+        # hash input byte-identical to what pre-signing receipts were hashed
+        # over, so existing chains continue to verify unchanged.
+        return self.model_dump(mode="json", exclude={"chain_hash", "chain_signature", "signing_key_id"})
 
 
 class WitnessSessionContext(BaseModel):
@@ -269,10 +281,11 @@ class WitnessRecorder:
     multi-worker is actually adopted.
     """
 
-    def __init__(self, root: str | Path):
+    def __init__(self, root: str | Path, *, signer: Any = None):
         self.root = Path(root)
         self._lock = asyncio.Lock()
         self._heads: dict[str, str] = {}
+        self.signer = signer
 
     async def startup(self) -> None:
         self.root.mkdir(parents=True, exist_ok=True)
@@ -294,6 +307,17 @@ class WitnessRecorder:
             item.scope = scope
             item.chain_prev_hash = previous
             item.chain_hash = self._compute_hash(item)
+            if self.signer is not None:
+                try:
+                    item.chain_signature = self.signer.sign(item.chain_hash)
+                    item.signing_key_id = self.signer.key_id
+                except Exception:
+                    # An unsigned receipt is worth far more than a lost one, so
+                    # signing failure degrades rather than drops the record —
+                    # but loudly, because a silently unsigned chain is the exact
+                    # false assurance signing exists to remove. verify() reports
+                    # unsigned receipts, so the gap stays visible downstream.
+                    logger.exception("witness: failed to sign receipt %s; recording it unsigned", item.receipt_id)
             await asyncio.to_thread(self._append_text, path, item.model_dump_json() + "\n")
             self._heads[scope] = item.chain_hash
             return item
@@ -310,6 +334,92 @@ class WitnessRecorder:
         """
         return await asyncio.to_thread(self._verify_sync, scope, self._path(scope))
 
+    async def verify_signatures(self, scope: str, *, public_key_b64: str | None = None) -> dict[str, Any]:
+        """Verify every receipt signature in a scope against a public key.
+
+        Separate from verify() because they answer different questions: verify()
+        asks "is this chain internally consistent?", which anyone can forge by
+        recomputing hashes. This asks "did the holder of this key attest to it?",
+        which they cannot.
+        """
+        key = public_key_b64 or (self.signer.public_key_b64 if self.signer is not None else None)
+        return await asyncio.to_thread(self._verify_signatures_sync, scope, self._path(scope), key)
+
+    @staticmethod
+    def _verify_signatures_sync(scope: str, path: Path, public_key_b64: str | None) -> dict[str, Any]:
+        from .witness_signing import verify_signature
+
+        result: dict[str, Any] = {
+            "scope": scope,
+            "valid": True,
+            "checked": 0,
+            "signed": 0,
+            "unsigned": 0,
+            "public_key_b64": public_key_b64,
+            "first_invalid_index": None,
+            "first_invalid_receipt_id": None,
+            "reason": None,
+        }
+        if public_key_b64 is None:
+            result["valid"] = False
+            result["reason"] = "no public key available to verify against"
+            return result
+        if not path.exists():
+            return result
+
+        for index, line in enumerate(line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()):
+            receipt = WitnessReceipt.model_validate_json(line)
+            result["checked"] = index + 1
+            if not receipt.chain_signature:
+                result["unsigned"] += 1
+                continue
+            if not verify_signature(
+                public_key_b64=public_key_b64,
+                chain_hash=receipt.chain_hash or "",
+                signature_b64=receipt.chain_signature,
+            ):
+                result["valid"] = False
+                result["first_invalid_index"] = index
+                result["first_invalid_receipt_id"] = receipt.receipt_id
+                result["reason"] = "signature does not verify against the supplied public key"
+                return result
+            result["signed"] += 1
+        return result
+
+    async def export_bundle(self, scope: str) -> dict[str, Any]:
+        """A self-contained, third-party-verifiable evidence bundle.
+
+        Receipts alone prove nothing off-box. This packages them with the head
+        hash, the public key, and the algorithm, so a recipient with
+        `scripts/verify_witness_bundle.py` — which imports nothing from this
+        project — can check the chain and its signatures independently.
+        """
+        receipts = await asyncio.to_thread(self._read_all_sync, self._path(scope))
+        chain = await self.verify(scope)
+        return {
+            "format": "auto-browser-witness-bundle",
+            "version": 1,
+            "scope": scope,
+            "exported_at": utc_now(),
+            "algorithm": SIGNATURE_ALGORITHM,
+            "signing_key_id": self.signer.key_id if self.signer is not None else None,
+            "public_key_b64": self.signer.public_key_b64 if self.signer is not None else None,
+            "receipt_count": len(receipts),
+            "head_hash": chain.get("head_hash"),
+            "chain_valid_at_export": chain.get("valid"),
+            "receipts": [r.model_dump(mode="json") for r in receipts],
+        }
+
+    @staticmethod
+    def _read_all_sync(path: Path) -> list[WitnessReceipt]:
+        if not path.exists():
+            return []
+        return [
+            WitnessReceipt.model_validate_json(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
     @classmethod
     def _verify_sync(cls, scope: str, path: Path) -> dict[str, Any]:
         result: dict[str, Any] = {
@@ -317,6 +427,8 @@ class WitnessRecorder:
             "valid": True,
             "receipt_count": 0,
             "head_hash": None,
+            "signed_count": 0,
+            "unsigned_count": 0,
             "first_invalid_index": None,
             "first_invalid_receipt_id": None,
             "reason": None,
@@ -351,6 +463,12 @@ class WitnessRecorder:
             previous = receipt.chain_hash
             result["receipt_count"] = index + 1
             result["head_hash"] = receipt.chain_hash
+            # Surfaced so an unsigned chain cannot masquerade as a verified one:
+            # "valid" here only ever meant internally consistent.
+            if receipt.chain_signature:
+                result["signed_count"] += 1
+            else:
+                result["unsigned_count"] += 1
         return result
 
     @staticmethod
@@ -379,8 +497,13 @@ class WitnessRecorder:
     def _list_sync(path: Path, limit: int) -> list[WitnessReceipt]:
         if not path.exists():
             return []
+        # limit <= 0 returns nothing. It used to slice `lines[-0:]`, which is the
+        # whole list — so a caller passing a computed limit that reached zero got
+        # the entire receipt chain dumped into a response instead of an empty page.
+        if limit <= 0:
+            return []
         lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-        items = [WitnessReceipt.model_validate_json(line) for line in lines[-max(0, limit) :]]
+        items = [WitnessReceipt.model_validate_json(line) for line in lines[-limit:]]
         items.reverse()
         return items
 

--- a/controller/app/witness_signing.py
+++ b/controller/app/witness_signing.py
@@ -1,0 +1,74 @@
+"""Ed25519 signing for witness receipt chains.
+
+The receipt chain was SHA-256 linked but unsigned, which meant it detected
+*accidental* corruption and nothing else: anyone holding the JSONL could edit a
+receipt, recompute every downstream hash, and produce a chain that verified
+perfectly. Receipts proved nothing to anyone outside the box that wrote them.
+
+Signing each receipt's `chain_hash` fixes that. Because `chain_hash` already
+covers the entire preceding chain, a signature over it attests to both the
+receipt and its whole history up to that point.
+
+Deliberately not solved here — state it rather than let a reader assume it:
+
+* **Tail truncation.** Dropping the last k receipts leaves a shorter chain whose
+  every signature is still valid. Detecting that needs an external anchor (a
+  published head, a countersigning peer). `verify()` reports the signed head so
+  a caller holding a previously-published head can check for themselves.
+* **Key compromise.** A holder of the private key can rewrite history and
+  re-sign it. This raises the bar from "anyone with the file" to "anyone with
+  the key", which is the point, but it is not tamper-proof storage.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+logger = logging.getLogger(__name__)
+
+SIGNATURE_ALGORITHM = "ed25519"
+
+
+class WitnessSigner:
+    """Signs receipt chain hashes with this deployment's Ed25519 identity.
+
+    Reuses `mesh.identity.NodeIdentity` rather than managing a second keypair:
+    it already handles generation, 0600 permissions, and node_id tamper
+    detection, and is a leaf module with no mesh runtime dependency. Witness
+    signing therefore works whether or not the mesh subsystem is enabled.
+    """
+
+    def __init__(self, identity_dir: str | Path) -> None:
+        from .mesh.identity import NodeIdentity
+
+        self._identity = NodeIdentity(Path(identity_dir))
+
+    @property
+    def key_id(self) -> str:
+        """SHA-256 of the raw public key — stable, and safe to publish."""
+        return self._identity.node_id
+
+    @property
+    def public_key_b64(self) -> str:
+        return self._identity.pubkey_b64
+
+    def sign(self, chain_hash: str) -> str:
+        return base64.b64encode(self._identity.sign(chain_hash.encode("utf-8"))).decode("ascii")
+
+
+def verify_signature(*, public_key_b64: str, chain_hash: str, signature_b64: str) -> bool:
+    """Verify one receipt signature against a public key.
+
+    Free function, not a method: verification must be possible for anyone
+    holding only the exported bundle, with no signer and no private key.
+    """
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(public_key_b64))
+        public_key.verify(base64.b64decode(signature_b64), chain_hash.encode("utf-8"))
+        return True
+    except Exception:
+        return False

--- a/controller/tests/test_auth_guards.py
+++ b/controller/tests/test_auth_guards.py
@@ -350,3 +350,79 @@ async def test_auth_profile_export_and_import_are_audited(tmp_path: Path) -> Non
         "auth_profile_exported",
         "auth_profile_imported",
     ]
+
+
+@pytest.mark.asyncio
+async def test_auth_profile_operations_emit_signed_witness_receipts(tmp_path: Path) -> None:
+    """Credential movement now leaves a signed receipt, not just an audit line.
+
+    Receipts used to be session-scoped only, which is why export and import —
+    the two operations that move credentials on and off the box — had none.
+    They record under a dedicated `auth-profiles` scope with their own chain.
+    """
+    from types import SimpleNamespace
+
+    from app.browser.services import BrowserAuthProfileService
+    from app.witness import WitnessRecorder
+    from app.witness_signing import WitnessSigner
+
+    class _Audit:
+        async def append(self, **kwargs) -> None:
+            return None
+
+    recorder = WitnessRecorder(tmp_path / "witness", signer=WitnessSigner(tmp_path / "keys"))
+    await recorder.startup()
+
+    auth_root = tmp_path / "auth"
+    service = BrowserAuthProfileService(
+        SimpleNamespace(
+            settings=SimpleNamespace(auth_root=str(auth_root), auth_state_encryption_key=None),
+            audit=_Audit(),
+            witness=recorder,
+        )
+    )
+
+    profile_dir = service.dir("demo", create=True)
+    (profile_dir / "state.json").write_text('{"cookies": []}', encoding="utf-8")
+
+    exported = await service.export("demo")
+    await service.import_profile(exported["archive_name"], overwrite=True)
+
+    receipts = await recorder.list("auth-profiles", limit=10)
+    actions = sorted(r.action for r in receipts)
+    assert actions == ["export_auth_profile", "import_auth_profile"]
+    assert all(r.chain_signature for r in receipts), "profile receipts must be signed like session receipts"
+
+    signatures = await recorder.verify_signatures("auth-profiles")
+    assert signatures["valid"] is True
+    assert signatures["signed"] == 2
+
+
+@pytest.mark.asyncio
+async def test_a_witness_outage_does_not_break_the_export(tmp_path: Path) -> None:
+    """Recording evidence must never be able to fail the operation it records."""
+    from types import SimpleNamespace
+
+    from app.browser.services import BrowserAuthProfileService
+
+    class _Audit:
+        async def append(self, **kwargs) -> None:
+            return None
+
+    class _BrokenWitness:
+        async def record(self, *args, **kwargs):
+            raise RuntimeError("witness store unavailable")
+
+    auth_root = tmp_path / "auth"
+    service = BrowserAuthProfileService(
+        SimpleNamespace(
+            settings=SimpleNamespace(auth_root=str(auth_root), auth_state_encryption_key=None),
+            audit=_Audit(),
+            witness=_BrokenWitness(),
+        )
+    )
+    profile_dir = service.dir("demo", create=True)
+    (profile_dir / "state.json").write_text('{"cookies": []}', encoding="utf-8")
+
+    exported = await service.export("demo")
+    assert exported["profile_name"] == "demo"

--- a/controller/tests/test_witness_signing.py
+++ b/controller/tests/test_witness_signing.py
@@ -1,0 +1,220 @@
+"""Witness receipts must be attributable, not merely self-consistent.
+
+Before signing, the chain was SHA-256 linked and nothing else: anyone holding
+the JSONL could edit a receipt, recompute every downstream hash, and produce a
+chain that `verify()` passed. The receipts proved nothing to anyone outside the
+box that wrote them.
+
+These tests pin the properties that make a bundle evidence:
+  * a tampered receipt fails the hash chain
+  * a *consistently re-hashed* tampered chain — the forgery the old design could
+    not detect — still fails on signatures
+  * an exported bundle verifies with the standalone script, which imports
+    nothing from this project
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.witness import WitnessRecorder
+from app.witness_signing import WitnessSigner, verify_signature
+
+VERIFIER = Path(__file__).resolve().parents[2] / "scripts" / "verify_witness_bundle.py"
+
+
+def _receipt_kwargs(action: str = "click"):
+    from app.models import OperatorIdentity
+
+    return {
+        "profile": "normal",
+        "event_type": "action",
+        "status": "ok",
+        "action": action,
+        "action_class": "write",
+        "session_id": "sess-1",
+        "operator": OperatorIdentity(id="op-1"),
+    }
+
+
+@pytest.fixture
+def signed_recorder(tmp_path: Path) -> WitnessRecorder:
+    signer = WitnessSigner(tmp_path / "keys")
+    recorder = WitnessRecorder(tmp_path / "witness", signer=signer)
+    return recorder
+
+
+@pytest.mark.asyncio
+async def test_receipts_are_signed_and_verify(signed_recorder: WitnessRecorder) -> None:
+    await signed_recorder.startup()
+    receipt = await signed_recorder.record("sess-1", **_receipt_kwargs())
+
+    assert receipt.chain_signature, "receipt must carry a signature"
+    assert receipt.signing_key_id == signed_recorder.signer.key_id
+    assert verify_signature(
+        public_key_b64=signed_recorder.signer.public_key_b64,
+        chain_hash=receipt.chain_hash,
+        signature_b64=receipt.chain_signature,
+    )
+
+    report = await signed_recorder.verify_signatures("sess-1")
+    assert report["valid"] is True
+    assert report["signed"] == 1
+    assert report["unsigned"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_rehashed_forgery_is_caught_by_signatures(signed_recorder: WitnessRecorder) -> None:
+    """The attack the hash chain alone could never detect.
+
+    Edit a receipt, then recompute every chain hash so the chain is internally
+    consistent again. verify() passes — it always would have. Only the
+    signatures reveal that the holder of the key never attested to this.
+    """
+    await signed_recorder.startup()
+    for i in range(3):
+        await signed_recorder.record("sess-1", **_receipt_kwargs(f"click-{i}"))
+
+    path = signed_recorder._path("sess-1")
+    receipts = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    # Tamper, then re-link the chain so every hash is self-consistent.
+    receipts[1]["action"] = "transfer-funds"
+    previous = None
+    for item in receipts:
+        item["chain_prev_hash"] = previous
+        payload = {k: v for k, v in item.items() if k not in ("chain_hash", "chain_signature", "signing_key_id")}
+        import hashlib
+
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        item["chain_hash"] = hashlib.sha256(f"{previous or ''}:{canonical}".encode("utf-8")).hexdigest()
+        previous = item["chain_hash"]
+    path.write_text("\n".join(json.dumps(r) for r in receipts) + "\n", encoding="utf-8")
+
+    chain = await signed_recorder.verify("sess-1")
+    assert chain["valid"] is True, "a re-hashed forgery is internally consistent — this is the gap"
+
+    signatures = await signed_recorder.verify_signatures("sess-1")
+    assert signatures["valid"] is False
+    # Index 1, not 0: receipt 0 was not touched, so it re-hashes identically and
+    # its original signature still verifies. The first failure lands precisely on
+    # the receipt that was altered, which is what an investigator needs.
+    assert signatures["first_invalid_index"] == 1
+    assert signatures["first_invalid_receipt_id"] is not None
+    assert "signature does not verify" in signatures["reason"]
+
+
+@pytest.mark.asyncio
+async def test_edited_receipt_without_rehash_fails_the_chain(signed_recorder: WitnessRecorder) -> None:
+    """Guard the guard: the cheap tamper is still caught by the cheap check."""
+    await signed_recorder.startup()
+    await signed_recorder.record("sess-1", **_receipt_kwargs())
+
+    path = signed_recorder._path("sess-1")
+    receipt = json.loads(path.read_text(encoding="utf-8").strip())
+    receipt["action"] = "transfer-funds"
+    path.write_text(json.dumps(receipt) + "\n", encoding="utf-8")
+
+    assert (await signed_recorder.verify("sess-1"))["valid"] is False
+
+
+@pytest.mark.asyncio
+async def test_unsigned_chains_are_reported_not_silently_accepted(tmp_path: Path) -> None:
+    """An unsigned chain must never look like a verified one."""
+    recorder = WitnessRecorder(tmp_path / "witness")  # no signer
+    await recorder.startup()
+    await recorder.record("sess-1", **_receipt_kwargs())
+
+    chain = await recorder.verify("sess-1")
+    assert chain["valid"] is True, "hash chain is still internally consistent"
+    assert chain["signed_count"] == 0
+    assert chain["unsigned_count"] == 1
+
+    signatures = await recorder.verify_signatures("sess-1")
+    assert signatures["valid"] is False
+    assert "no public key" in signatures["reason"]
+
+
+@pytest.mark.asyncio
+async def test_pre_signing_receipts_still_verify(tmp_path: Path) -> None:
+    """Adding signature fields must not invalidate chains written before them.
+
+    The fields are excluded from chain_payload, so the hash input is byte
+    identical to what an older build produced.
+    """
+    recorder = WitnessRecorder(tmp_path / "witness")
+    await recorder.startup()
+    await recorder.record("sess-1", **_receipt_kwargs())
+
+    path = recorder._path("sess-1")
+    legacy = json.loads(path.read_text(encoding="utf-8").strip())
+    legacy.pop("chain_signature", None)
+    legacy.pop("signing_key_id", None)
+    path.write_text(json.dumps(legacy) + "\n", encoding="utf-8")
+
+    assert (await recorder.verify("sess-1"))["valid"] is True
+
+
+@pytest.mark.asyncio
+async def test_exported_bundle_verifies_with_the_standalone_script(
+    signed_recorder: WitnessRecorder, tmp_path: Path
+) -> None:
+    """The bundle must be checkable by someone who does not run auto-browser."""
+    await signed_recorder.startup()
+    for i in range(3):
+        await signed_recorder.record("sess-1", **_receipt_kwargs(f"click-{i}"))
+
+    bundle = await signed_recorder.export_bundle("sess-1")
+    assert bundle["receipt_count"] == 3
+    assert bundle["public_key_b64"]
+    assert bundle["head_hash"]
+
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    result = subprocess.run(  # noqa: S603 - fixed argv
+        [sys.executable, str(VERIFIER), str(bundle_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"standalone verifier rejected a good bundle:\n{result.stdout}\n{result.stderr}"
+    assert "RESULT: VERIFIED" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_standalone_verifier_rejects_a_tampered_bundle(signed_recorder: WitnessRecorder, tmp_path: Path) -> None:
+    await signed_recorder.startup()
+    for i in range(3):
+        await signed_recorder.record("sess-1", **_receipt_kwargs(f"click-{i}"))
+
+    bundle = await signed_recorder.export_bundle("sess-1")
+    bundle["receipts"][1]["action"] = "transfer-funds"
+
+    bundle_path = tmp_path / "tampered.json"
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    result = subprocess.run(  # noqa: S603 - fixed argv
+        [sys.executable, str(VERIFIER), str(bundle_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 1
+    assert "RESULT: FAILED" in result.stdout
+
+
+def test_list_with_a_zero_limit_returns_nothing(tmp_path: Path) -> None:
+    """`lines[-0:]` is the whole list — a computed limit of 0 dumped the chain."""
+    recorder = WitnessRecorder(tmp_path / "witness")
+    path = recorder._path("sess-1")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+
+    assert recorder._list_sync(path, 0) == []
+    assert recorder._list_sync(path, -5) == []

--- a/controller/tests/test_witness_signing.py
+++ b/controller/tests/test_witness_signing.py
@@ -27,6 +27,16 @@ from app.witness_signing import WitnessSigner, verify_signature
 
 VERIFIER = Path(__file__).resolve().parents[2] / "scripts" / "verify_witness_bundle.py"
 
+# The controller image COPYs only app/ and tests/, so scripts/ is absent inside
+# the container (the controller-tests CI job). The verifier is a tool for bundle
+# *recipients*, not for the runtime, so it does not belong in the image — and
+# both host-tests jobs run this from a real checkout, so the round-trip stays
+# covered in CI.
+requires_verifier = pytest.mark.skipif(
+    not VERIFIER.is_file(),
+    reason="scripts/verify_witness_bundle.py is not shipped inside the controller image",
+)
+
 
 def _receipt_kwargs(action: str = "click"):
     from app.models import OperatorIdentity
@@ -160,6 +170,7 @@ async def test_pre_signing_receipts_still_verify(tmp_path: Path) -> None:
     assert (await recorder.verify("sess-1"))["valid"] is True
 
 
+@requires_verifier
 @pytest.mark.asyncio
 async def test_exported_bundle_verifies_with_the_standalone_script(
     signed_recorder: WitnessRecorder, tmp_path: Path
@@ -187,6 +198,7 @@ async def test_exported_bundle_verifies_with_the_standalone_script(
     assert "RESULT: VERIFIED" in result.stdout
 
 
+@requires_verifier
 @pytest.mark.asyncio
 async def test_standalone_verifier_rejects_a_tampered_bundle(signed_recorder: WitnessRecorder, tmp_path: Path) -> None:
     await signed_recorder.startup()

--- a/docs/audits/2026-08-execution-audit.md
+++ b/docs/audits/2026-08-execution-audit.md
@@ -1,0 +1,194 @@
+# Execution audit — August 2026
+
+**Status:** complete. All findings fixed and released across v1.5.1–v1.6.0.
+**Method:** adversarial audit of this repository, by its maintainers. No user
+reported any of it.
+
+This follows the precedent of [`session-isolation-audit.md`](../session-isolation-audit.md):
+findings first, reproductions included, limits stated plainly, and the parts
+that were wrong labelled wrong.
+
+---
+
+## Summary
+
+Several safety controls were asserted in code and documentation but never
+verified end to end. **Three of them silently did nothing while reporting
+success.** Every one was green in CI.
+
+The most serious: **screenshot PII redaction had never redacted anything.**
+
+```
+ink pixels in the secret region, ORIGINAL : 307
+after "redaction"                         : 307   <- unchanged
+hits reported by the scrubber             : 1     <- caller believes it worked
+```
+
+The function returned a hit, the caller wrote a `pii_redaction / ok` audit
+event, and the unredacted screenshot was stored under `/data/artifacts/`, served
+over `/artifacts/`, and handed to the model.
+
+## The single root cause
+
+**This codebase verified decisions and mocked effects.**
+
+Every defect below is a cross-boundary representation mismatch, tested only
+against a mock of the far side:
+
+| boundary | mismatch |
+|---|---|
+| Python dict → dict | OCR nested geometry under `bbox`; the scrubber read it flat |
+| env string → registry | a typo in a pattern list emptied it instead of failing |
+| Python string → JS parser | shell-escape artifacts (`\!`) made a script unparseable |
+| module → package | a relative import resolved to a module that does not exist |
+| regex → real-world format | an AWS key pattern one character too short to ever match |
+| claim → crypto | a chain described as tamper-evident was unsigned |
+
+The *decision* layer held up well — governed write blocking and upload approval
+were exercised, the isolation boundary had been audited. The *effect* layer —
+did the pixels change, did the regex match a real key, did the JS parse, did the
+module import — is where all of it lived.
+
+## Findings
+
+### Privacy controls (fixed in v1.5.1)
+
+1. **Screenshot PII redaction was a silent no-op.** `ocr.py` emits geometry
+   nested under `block["bbox"]`; `pii_scrub.py` read flat `x`/`y`/`width`/
+   `height`, so every `.get(..., 0)` fell to its default and every redaction
+   rectangle computed to `(0,0,0,0)`. The existing test fed flat keys — a shape
+   production never emits — which is exactly why nothing caught it.
+2. **A typo in `PII_SCRUB_PATTERNS` disabled all scrubbing, fail-open.** Unknown
+   names were "silently dropped" by intersecting with the known set, so
+   `PII_SCRUB_PATTERNS="emial,phon"` produced an empty set — and an empty but
+   non-`None` set makes `scrub_text` skip every pattern. `summary()` still
+   reported `enabled: True`.
+3. **The AWS access-key pattern could never match.** 19 characters where real key
+   ids are 20; the trailing lookahead rejected every one.
+4. **Most screenshots were never redacted at all.** `PII_SCRUB_SCREENSHOT=true`
+   covered only `normal`/`rich` observes. The `fast` preset, manual captures, and
+   the before/after snapshot taken on *every action* wrote unredacted PNGs.
+5. **Redaction was starved by a token budget.** `image_to_data` returns one block
+   per *word*, and the list was truncated at 20 — so only the first ~20 words of
+   a page could ever be redacted. A navigation bar exhausted the budget.
+
+### Credential handling (fixed in v1.5.2–v1.5.3)
+
+6. **`REQUIRE_AUTH_STATE_ENCRYPTION=true` loaded plaintext auth state.** Enforced
+   only at construction — "is a key configured?" — and never on the read path, so
+   plaintext cookies went straight into a live browser context while the
+   deployment believed encryption was mandatory.
+7. **Auth-state encryption was classified by filename, not content**, so the
+   classification was wrong in both directions.
+8. **Rate limiting could not throttle bearer-token brute force.** The bucket key
+   derived from the `authorization` header, so every guessed token got its own
+   fresh counter.
+9. **Auth-profile export and import left no audit record**, while
+   `save_storage_state` — which merely *writes* the same material — was fully
+   instrumented.
+
+### Correctness and lifecycle (fixed in v1.5.1–v1.5.3)
+
+10. **`browser.export_script` had never worked over MCP** — a relative import
+    resolved to a nonexistent module; every call raised `ModuleNotFoundError`,
+    collapsed into an opaque "Tool execution failed". No test touched it.
+11. **The stealth init script was never valid JavaScript.** No stealth patch had
+    ever applied. (Low impact: stealth is default-off and an explicit non-goal.
+    The defect *class* is the point.)
+12. **Cron-triggered sessions were never closed.** With `MAX_SESSIONS` defaulting
+    to 1, the first cron fire consumed the only slot permanently.
+13. **The maintenance cleanup loop died permanently on its first exception**, and
+    a corrupt cron store erased every cron job.
+14. **MCP version negotiation violated a spec MUST**, and `-32002` meant two
+    different things.
+
+### The gap that hid much of it
+
+**The Docker CI job ran 566 of 637 tests.** `controller-tests` used
+`unittest discover`, which only collects `unittest.TestCase` subclasses — so
+`test_1_0.py` (61 tests: mesh Ed25519, peer registry, delegation policy, stealth,
+network inspector, CDP, workflow engine), `test_pii_scrub.py` (8), and
+`test_readiness.py` (4) were invisible to it.
+
+The one required check that validates the **shipped container** ran zero
+PII-scrubber and zero mesh-crypto tests, and any new pytest-style file would have
+been dropped from it with no warning.
+
+## Scope of exposure — stated honestly
+
+auto-browser is **local-first and single-tenant**. For most operators the
+affected artifacts never left their own machine, and there is no remote attacker
+path in any of these findings — no privilege escalation, no unauthenticated
+trigger, no reported exploitation.
+
+The real exposure surfaces are the three places evidence leaves the box:
+
+- **shared session links** (`/share/{token}`)
+- **auth-profile exports**
+- **remote witness sinks**
+
+If you used any of those with `PII_SCRUB_SCREENSHOT` enabled and believed
+screenshots were redacted, they were not. If you set
+`REQUIRE_AUTH_STATE_ENCRYPTION=true` and had plaintext profiles predating it,
+those kept loading.
+
+**A correction worth making explicitly:** the lead that opened finding 6 was
+recorded as "an encrypted file renamed without `.enc` is handed to Playwright as
+plaintext." That is **wrong** — the file contains ciphertext, so nothing
+plaintext leaked; the envelope was passed through verbatim, which is a silent
+auth failure. The genuinely serious defect was the one sitting beside it. A
+lead's stated mechanism is a hypothesis, not a finding.
+
+## What changed so the class cannot recur
+
+Fixing the instances was the smaller half. These gates target the *class*:
+
+| gate | what it makes impossible |
+|---|---|
+| Pixel-diff redaction test, driven through the real `_extract_sync` | the two modules drifting apart again |
+| Canonical sample for all 16 PII patterns + completeness test | a pattern shipping with no behavioural assertion (12 had none) |
+| Fail-closed pattern parsing | a typo silently disabling scrubbing |
+| Relative-import walk across all 129 app modules | a lazy in-function import resolving nowhere |
+| `node --check` on all 15 shipped JS constants | JS that Python tooling can never validate |
+| Docker CI job switched to pytest | the container check silently skipping 71 tests |
+| Python-floor invariant parsed from the CI matrix | a package claiming a version CI does not run |
+| Compose-vs-config model parity test | Docker users silently running different models |
+
+**637 → 873 tests.**
+
+Every fix was confirmed **red before green**: the change was reverted, the test
+watched to fail, then restored. Where a claim came from an automated reviewer, it
+was reproduced by execution before being acted on — reading the code only
+confirms you read it the same way; counting pixels is what made finding 1 a fact.
+
+## Two tests that were protecting bugs
+
+Worth recording, because it is the most uncomfortable part:
+
+- `test_scheduler_registration_and_store_error_paths` asserted `_load() == {}`
+  for a corrupt cron store — pinning as correct the exact behaviour that erased
+  every cron job on the next save.
+- `test_screenshot_redaction_and_invalid_image_fallback` asserts that when
+  Pillow cannot decode an image the **original un-redacted** bytes are returned.
+  That is a deliberate availability trade-off, but the test name does not say so.
+  Flagged, not silently changed.
+
+## What remains
+
+- **Tail truncation of a witness chain** is undetectable without an external
+  anchor. Signing (v1.6.0) does not fix this and does not claim to; `verify()`
+  reports the head so a holder of a previously published head can check.
+- **Key compromise** still allows rewriting a signed history. Signing raises the
+  bar from "anyone with the file" to "anyone with the key".
+- **Multi-worker deployments** would fork the receipt chain. Documented in
+  `witness.py`; out of scope until multi-worker is actually supported.
+
+## Timeline
+
+| date | event |
+|---|---|
+| 2026-08-03 | Audit run; findings reproduced by execution |
+| 2026-08-04 | v1.5.1 — privacy controls, broken MCP surface, CI runner |
+| 2026-08-04 | v1.5.2 — lifecycle, credential surface, published packages |
+| 2026-08-04 | v1.5.3 — auth-state fail-closed, remaining operational leaks |
+| 2026-08-04 | v1.6.0 — witness chain signing, verifiable evidence bundles |

--- a/scripts/verify_witness_bundle.py
+++ b/scripts/verify_witness_bundle.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Independently verify an Auto Browser witness bundle.
+
+This script deliberately imports NOTHING from auto-browser. That is the whole
+point: a receipt bundle is only evidence if someone who does not run — and does
+not trust — the system that produced it can check it. Its only dependency is
+`cryptography`, and that is needed solely for Ed25519 verification; the hash
+chain is checked with the standard library alone.
+
+    python verify_witness_bundle.py bundle.json
+
+Exit codes:
+    0  chain and signatures verified
+    1  verification failed
+    2  usage or input error
+
+What a PASS means, precisely:
+
+  * every receipt's `chain_hash` matches its content, so nothing was edited
+  * every `chain_prev_hash` matches its predecessor, so nothing was reordered,
+    inserted, or removed from the middle
+  * every signature verifies against the bundled public key, so the holder of
+    the corresponding private key attested to each receipt and its history
+
+What a PASS does NOT mean:
+
+  * that the tail is complete. Dropping the last k receipts leaves a shorter
+    chain whose remaining signatures are all still valid. Compare `head_hash`
+    against a head you obtained previously and independently.
+  * that the key belongs to who you think. Verify `signing_key_id` (the SHA-256
+    of the public key) out of band, the same way you would an SSH fingerprint.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import sys
+from typing import Any
+
+CHAIN_EXCLUDED_FIELDS = ("chain_hash", "chain_signature", "signing_key_id")
+
+
+def canonical_chain_hash(receipt: dict[str, Any]) -> str:
+    """Recompute a receipt's chain hash exactly as the recorder does."""
+    payload = {k: v for k, v in receipt.items() if k not in CHAIN_EXCLUDED_FIELDS}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    prev = receipt.get("chain_prev_hash") or ""
+    return hashlib.sha256(f"{prev}:{canonical}".encode("utf-8")).hexdigest()
+
+
+def verify_signature(public_key_b64: str, chain_hash: str, signature_b64: str) -> bool:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    try:
+        key = Ed25519PublicKey.from_public_bytes(base64.b64decode(public_key_b64))
+        key.verify(base64.b64decode(signature_b64), chain_hash.encode("utf-8"))
+        return True
+    except Exception:
+        return False
+
+
+def verify_bundle(bundle: dict[str, Any]) -> tuple[bool, list[str]]:
+    problems: list[str] = []
+    receipts = bundle.get("receipts") or []
+    public_key = bundle.get("public_key_b64")
+
+    if not receipts:
+        return True, ["bundle contains no receipts"]
+
+    previous: str | None = None
+    unsigned = 0
+    for index, receipt in enumerate(receipts):
+        recomputed = canonical_chain_hash(receipt)
+        if recomputed != receipt.get("chain_hash"):
+            problems.append(f"receipt {index} ({receipt.get('receipt_id')}): content altered after write")
+            break
+        if receipt.get("chain_prev_hash") != previous:
+            problems.append(
+                f"receipt {index} ({receipt.get('receipt_id')}): chain broken — "
+                "reordered, truncated from the middle, or forked"
+            )
+            break
+
+        signature = receipt.get("chain_signature")
+        if not signature:
+            unsigned += 1
+        elif not public_key:
+            problems.append(f"receipt {index}: signed, but the bundle carries no public key")
+            break
+        elif not verify_signature(public_key, receipt["chain_hash"], signature):
+            problems.append(f"receipt {index} ({receipt.get('receipt_id')}): signature does not verify")
+            break
+
+        previous = receipt.get("chain_hash")
+
+    if unsigned:
+        problems.append(f"{unsigned} of {len(receipts)} receipts are unsigned (pre-dating signing, or a signer outage)")
+
+    fatal = [p for p in problems if "unsigned" not in p and "no receipts" not in p]
+    return not fatal, problems
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    try:
+        with open(argv[1], encoding="utf-8") as handle:
+            bundle = json.load(handle)
+    except Exception as exc:
+        print(f"could not read bundle: {exc}", file=sys.stderr)
+        return 2
+
+    if bundle.get("format") != "auto-browser-witness-bundle":
+        print(f"not a witness bundle: format={bundle.get('format')!r}", file=sys.stderr)
+        return 2
+
+    ok, problems = verify_bundle(bundle)
+
+    print(f"scope           : {bundle.get('scope')}")
+    print(f"receipts        : {len(bundle.get('receipts') or [])}")
+    print(f"head_hash       : {bundle.get('head_hash')}")
+    print(f"signing_key_id  : {bundle.get('signing_key_id')}")
+    print(f"algorithm       : {bundle.get('algorithm')}")
+    for problem in problems:
+        print(f"  note: {problem}")
+    print()
+    print("RESULT: VERIFIED" if ok else "RESULT: FAILED")
+    if ok:
+        print("Compare head_hash against an independently obtained head to rule out tail truncation.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
The witness chain was SHA-256 linked and nothing else — which detects *accidental* corruption and nothing more. Anyone holding the JSONL could edit a receipt, recompute every downstream hash, and produce a chain that `verify()` passed. Receipts proved nothing to anyone outside the box that wrote them.

### Why this was deferred until now

Through 1.5.1–1.5.3 I deliberately kept this closed, and the reason matters: the chain contained **false entries** — `pii_redaction / ok` events written over unredacted images. Signing those would have converted false statements into *cryptographically endorsed* false statements, which is strictly worse than an unsigned chain.

The effect-verification gates shipped first. The chain is now worth signing.

### What signing buys

Each receipt's `chain_hash` is signed with Ed25519. Because `chain_hash` already covers the entire preceding chain, one signature attests to both the receipt **and its history up to that point**.

The test that matters is `test_a_rehashed_forgery_is_caught_by_signatures`: it edits a receipt, recomputes every hash so the chain is internally consistent again, and asserts that `verify()` **still passes** — because it always would have — while the signature check fails and points at the exact altered receipt. That gap is the whole reason for this change.

Reuses `mesh.identity.NodeIdentity` rather than a second keypair: it already handles generation, 0600 permissions, and node_id tamper detection, and it's a leaf module, so witness signing works whether or not mesh is enabled. Keys live at `<witness_root>/keys` and generate on first use — signing is on by default, no configuration.

### Backward compatibility

The signature fields are excluded from `chain_payload`, so the hash input stays **byte-identical** to what pre-signing builds produced and existing chains keep verifying unchanged. There's a test for exactly that.

### New surface

- `GET /sessions/{id}/witness/bundle` and `browser.export_witness_bundle` produce a self-contained bundle: receipts, head hash, key id, public key.
- `scripts/verify_witness_bundle.py` verifies it while **importing nothing from this project** — that independence is what makes a receipt evidence rather than an assertion about itself. A test round-trips a real bundle through the real script as a subprocess, and a second test confirms it rejects a tampered one.
- `verify_witness_chain` now returns a `signatures` block, so `valid: true` can never be mistaken for "attested".

### Closes the last deferred item

Auth-profile export and import now emit witness receipts. They had none because receipts were session-scoped and these operations have no session — but `session_id` is optional on the model, so they record under an `auth-profiles` scope with their own signed chain. A witness outage logs and continues: recording evidence must never fail the operation it records, and that's tested too.

### Limits, stated rather than left to assumption

Both are in the module docstring:

- **Tail truncation** stays undetectable without an external anchor. Dropping the last k receipts leaves a shorter chain whose signatures all still verify. `verify()` reports the head so a caller holding an independently-published head can check.
- **Key compromise** still allows rewriting history. Signing raises the bar from "anyone with the file" to "anyone with the key". It is not tamper-proof storage, and the verifier's own docs say so.

### Also fixed

`_list_sync(limit=0)` sliced `lines[-0:]` — the whole list — so a computed limit reaching zero dumped the entire receipt chain into a response instead of returning an empty page.

**871 → 873 passed**, 2 skipped, 199 subtests. `ruff check` clean, bridge and version parity intact.