### PR TITLE
release: v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-08-04
+
+Witness receipts are now signed, and an exported bundle can be verified by
+someone who does not run — and does not trust — this controller.
+
+This also closes the August execution audit. Its full findings, reproductions,
+and the gates that close the defect class are published in
+[`docs/audits/2026-08-execution-audit.md`](./docs/audits/2026-08-execution-audit.md).
+
+### Added
+
+- **Ed25519-signed Witness receipt chains.** The chain was SHA-256 linked and
+  nothing else, which detects accidental corruption and nothing more: anyone
+  holding the JSONL could edit a receipt, recompute every downstream hash, and
+  produce a chain that `verify()` passed. Each receipt's `chain_hash` is now
+  signed, and because that hash already covers the entire preceding chain, one
+  signature attests to both the receipt and its history to that point. Signing
+  is on by default — keys live at `<witness_root>/keys` and generate on first
+  use.
+- **Exportable evidence bundles.** `GET /sessions/{id}/witness/bundle` and
+  `browser.export_witness_bundle` produce a self-contained bundle: every
+  receipt, the head hash, the signing key id, and the public key.
+  `scripts/verify_witness_bundle.py` checks it while importing nothing from this
+  project — that independence is what makes a receipt evidence rather than an
+  assertion about itself.
+- **`verify_witness_chain` now returns a `signatures` block**, so `valid: true`
+  can never be mistaken for "attested". The hash chain only ever proved internal
+  consistency.
+- **Auth-profile export and import emit Witness receipts.** They previously had
+  none, because receipts were session-scoped and these operations have no
+  session; they now record under an `auth-profiles` scope with their own signed
+  chain. A witness outage logs and continues — recording evidence must never
+  fail the operation it records.
+
+### Fixed
+
+- `WitnessRecorder.list(limit=0)` sliced `lines[-0:]` — the whole list — so a
+  caller passing a computed limit that reached zero received the entire receipt
+  chain instead of an empty page.
+
+### Notes
+
+Existing chains keep verifying unchanged: the signature fields are excluded from
+the hash input, so it stays byte-identical to what pre-signing builds produced.
+
+Two limits are stated in `witness_signing.py` rather than left to assumption.
+**Tail truncation** remains undetectable without an external anchor — dropping
+the last k receipts leaves a shorter chain whose signatures all still verify, so
+`verify()` reports the head for comparison against an independently obtained
+one. **Key compromise** still allows rewriting history; signing raises the bar
+from "anyone with the file" to "anyone with the key", and is not tamper-proof
+storage.
+
 ## [1.5.3] — 2026-08-04
 
 Closes the audit. The remaining lead turned out to hide a worse defect than the

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Works with:
 - **Login once, reuse later.** Save named auth profiles and reopen fresh sessions that are already signed in.
 - **Local-first by default.** Run the full stack on your own box with Docker Compose, or use Codespaces for a quick hosted demo.
 - **Safety rails built in.** Approvals, operator identity, PII scrubbing, Witness receipts, and policy presets are all part of the product surface.
+- **Evidence you can hand to someone else.** Witness receipt chains are Ed25519-signed, and an exported bundle verifies with [`scripts/verify_witness_bundle.py`](./scripts/verify_witness_bundle.py) — which imports nothing from this project, so a recipient need not run or trust this controller to check it.
+- **We audit ourselves in public.** [`docs/audits/2026-08-execution-audit.md`](./docs/audits/2026-08-execution-audit.md) documents an adversarial audit of this repo that found safety controls which reported success while doing nothing, with reproductions, the fixes, and the gates that close the class.
 - **Governed skill induction.** Verified browser traces can become staged skill candidates with signed provenance, verifier adapters, and review-only graduation — agents that prove they can repeat themselves correctly, not just act once.
 
 ## Release Highlights (v1.5.0)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,8 +2,9 @@
 
 This is the near-term direction for Auto Browser.
 
-## Now (current in v1.5.0)
+## Now (current in v1.6.0)
 
+- Ed25519-signed Witness receipt chains — each receipt attests to itself and its whole history, and an exported bundle verifies anywhere via `scripts/verify_witness_bundle.py`, which imports nothing from this project
 - `text` observation preset — accessibility outline, extracted text, and interactables with no screenshot and no OCR
 - text/regex `query` mode on `browser.find_elements` — locate a string on the page without a full observe
 - any OpenAI-compatible model can drive the browser (OpenRouter, xAI, DeepSeek, MiniMax, custom base URL for Ollama / vLLM / Azure / Groq, …)
@@ -12,7 +13,7 @@ This is the near-term direction for Auto Browser.
 - reusable auth profiles + import/export
 - human takeover via noVNC
 - approvals and audit trails
-- Witness receipts with on-demand hash-chain verification (REST + MCP)
+- Witness receipts with on-demand hash-chain verification and Ed25519 signatures (REST + MCP), plus third-party-verifiable evidence bundles
 - MCP transport + REST API with 70+ tools (curated and full profiles)
 - Docker-based isolated session mode with orphan reaping and resource limits
 - Stage 0 convergence harness for governed skill induction
@@ -39,6 +40,8 @@ This is the near-term direction for Auto Browser.
 
 ## Recently Shipped
 
+- v1.6.0 Ed25519-signed Witness chains and exportable, independently verifiable evidence bundles
+- v1.5.1–v1.5.3 an adversarial execution audit of this repo and its fixes — several safety controls were asserted but never verified end to end, and three silently did nothing while reporting success. Findings, reproductions and the gates that close the class are in [`docs/audits/2026-08-execution-audit.md`](./docs/audits/2026-08-execution-audit.md)
 - v1.5.0 `text` observation preset, `find_elements` query mode, actionable MCP tool errors, and an MCP stdio bridge cold-start fix that names the endpoint and the remedy
 - v1.4.x whole-repo quality gates, nine-string version parity enforcement, `auto-browser-langchain` test coverage from zero to 94%, and the Python 3.14 `asyncio.get_event_loop()` fix
 - v1.4.0 generic OpenAI-compatible provider adapter (OpenRouter / xAI / DeepSeek / MiniMax / custom base URL), `browser://audit/events` MCP resource, and a CI guard for Playwright pin parity

--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-browser-browser-node",
-      "version": "1.5.3",
+      "version": "1.6.0",
       "dependencies": {
         "playwright": "1.62.0"
       }

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -3,4 +3,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.5.3"
+__version__ = "1.6.0"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.5.3"
+version = "1.6.0"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/controller/app/version.py
+++ b/controller/app/version.py
@@ -4,4 +4,4 @@ Bump together with the package versions in */pyproject.toml and
 browser-node/package.json during release prep.
 """
 
-__version__ = "1.5.3"
+__version__ = "1.6.0"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.5.3"
+version = "1.6.0"
 description = "Controller API for auto-browser"
 # 3.11, not 3.10: CI tests 3.11 and 3.14, the Dockerfile pins python:3.11-slim,
 # and the published packages were corrected to >=3.11 in 1.5.2. A floor nothing

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.5.3"
+version = "1.6.0"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # console script against that dependency.
 [project]
 name = "auto-browser-mcp"
-version = "1.5.3"
+version = "1.6.0"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Witness receipts are signed, and an exported bundle can be verified by someone who does not run — and does not trust — this controller.

### What signing changes

The chain was SHA-256 linked and nothing else, which detects accidental corruption and nothing more: anyone holding the JSONL could edit a receipt, recompute every downstream hash, and produce a chain that `verify()` passed.

Each receipt's `chain_hash` is now Ed25519-signed. Because that hash already covers the entire preceding chain, one signature attests to both the receipt **and its history to that point**.

### Why it waited until now

Signing was deliberately held back through 1.5.1–1.5.3. The chain contained **false entries** — `pii_redaction / ok` events written over unredacted images — and signing those would have converted false statements into cryptographically endorsed ones, which is strictly worse than an unsigned chain.

The effect-verification gates shipped first. That sequencing was the right call and it's worth recording as one.

### The audit is published

`docs/audits/2026-08-execution-audit.md` follows the precedent of the existing `session-isolation-audit.md`: findings first, reproductions included, limits stated plainly, and **the parts that were wrong labelled wrong** — including the lead that opened the auth-state finding, whose stated mechanism turned out to be incorrect.

It also records the two tests that were protecting bugs, which is the least comfortable part and the most useful to a reader.

### Verification

| gate | result |
|---|---|
| controller suite | **873 passed**, 2 skipped, 199 subtests (637 at v1.5.0) |
| `check_version_parity.py` | 9/9 on **1.6.0** |
| `check_playwright_pins.py` | matched at 1.62.0 |
| `check_bridge_parity.py` | byte-identical |
| `ruff check .` | clean |
| `extract_changelog.py 1.6.0` | 42 lines |

Existing chains keep verifying — signature fields are excluded from the hash input, so it stays byte-identical to pre-signing builds. There is a test for that specifically.

### Why minor, not patch

Nothing breaks, so it is minor in spirit. But signing, a new public bundle format, two new endpoints, and a new MCP tool is a feature release, not a patch.