### PR TITLE
docs: link the published security advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ someone who does not run — and does not trust — this controller.
 
 This also closes the August execution audit. Its full findings, reproductions,
 and the gates that close the defect class are published in
-[`docs/audits/2026-08-execution-audit.md`](./docs/audits/2026-08-execution-audit.md).
+[`docs/audits/2026-08-execution-audit.md`](./docs/audits/2026-08-execution-audit.md),
+and the two findings with user-facing security impact are disclosed as
+[GHSA-32ph-8hp6-7qgj](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-32ph-8hp6-7qgj).
 
 ### Added
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,17 @@ Include:
 - repro steps
 - logs, screenshots, or PoC if available
 
+## Published advisories
+
+Issues found by the maintainers are disclosed the same way a reported one would
+be, and the audits that found them are published in full:
+
+- [GHSA-32ph-8hp6-7qgj](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-32ph-8hp6-7qgj)
+  — safety controls that reported success while not functioning (fixed in 1.5.1
+  and 1.5.3). Write-up: [`docs/audits/2026-08-execution-audit.md`](./docs/audits/2026-08-execution-audit.md)
+- [`docs/session-isolation-audit.md`](./docs/session-isolation-audit.md) — response
+  to an external session-poisoning claim
+
 ## Handling goals
 
 The project aims to:

--- a/docs/audits/2026-08-execution-audit.md
+++ b/docs/audits/2026-08-execution-audit.md
@@ -2,7 +2,12 @@
 
 **Status:** complete. All findings fixed and released across v1.5.1–v1.6.0.
 **Method:** adversarial audit of this repository, by its maintainers. No user
-reported any of it.
+reported any of it, and there is no evidence of exploitation.
+**Advisory:** [GHSA-32ph-8hp6-7qgj](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-32ph-8hp6-7qgj)
+(Moderate) covers the two findings with user-facing security impact — the
+screenshot redaction no-op and the auth-state encryption fail-open. No CVE was
+requested: there is no attacker-controlled trigger, and the affected code ships
+as source with no package-manager coordinate to alert on.
 
 This follows the precedent of [`session-isolation-audit.md`](../session-isolation-audit.md):
 findings first, reproductions included, limits stated plainly, and the parts


### PR DESCRIPTION
Cross-links [GHSA-32ph-8hp6-7qgj](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-32ph-8hp6-7qgj) (Moderate) from the audit write-up, the CHANGELOG, and `SECURITY.md`.

The advisory covers the two findings with user-facing security impact — the screenshot redaction no-op and the auth-state encryption fail-open.

**No CVE was requested.** There is no attacker-controlled trigger in either finding, and the affected code ships as source with no package-manager coordinate, so a CVE would add process without adding reach. One can be requested on the same advisory later if anyone needs it — that direction is easy, the reverse is not.

`SECURITY.md` now lists published advisories alongside the isolation audit. Issues the maintainers find get disclosed the same way a reported one would, which is the point of having written that policy.

Docs only.