### PR TITLE
fix(security): remove code execution from the CDP allowlist; secure the Codespaces overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.6.1] — 2026-08-04
+
+Security fixes from a **privately reported** vulnerability disclosure (received
+2026-06-17). Reported findings, verified before fixing.
+
+**If you use the Codespaces overlay, upgrade and set `API_BEARER_TOKEN`.**
+
+### Security
+
+- **`Runtime.evaluate` and `Network.getCookies` were in the "safe" raw-CDP
+  allowlist.** `/sessions/{id}/cdp/raw` is gated solely by
+  `_ALLOWED_CDP_COMMANDS`, and that list — described as safe — permitted
+  arbitrary JavaScript execution in the page context. Because sessions reuse
+  stored auth profiles, that meant cookie theft and acting as the logged-in user
+  on every site a profile is authenticated to, plus `fetch()`-based SSRF to
+  internal and cloud-metadata addresses which bypasses the navigation allowlist
+  entirely. `Network.getCookies` returned credential material directly.
+
+  Both removed. This does not affect internal element intelligence (which issues
+  CDP commands directly rather than through `raw_cdp_command`) or
+  `browser.eval_js` (which uses Playwright's `page.evaluate` and is governed and
+  auditable). The allowlist is now pinned by tests that reject any entry which
+  is not read-only introspection.
+
+- **The Codespaces overlay published an unauthenticated control plane.**
+  `docker-compose.codespaces.yml` binds the API to `0.0.0.0` so the port
+  forwarder can reach it, while `API_BEARER_TOKEN` defaults to unset and the
+  bearer middleware fails open when it is. Combined with the CDP issue above,
+  anyone who could reach the forwarded port could open a session from a saved
+  auth profile and export its cookies.
+
+  The overlay now requires `API_BEARER_TOKEN` via Compose's `${VAR:?message}`
+  form, so it refuses to start rather than silently publishing an
+  unauthenticated browser control plane.
+
+- **Raw VNC is no longer published on `0.0.0.0` in that overlay.** `x11vnc` runs
+  `-nopw`, so port 5900 is unauthenticated by design and is only safe behind a
+  loopback bind. noVNC (6080) remains published, so human takeover still works.
+
+### Known and not yet addressed
+
+The same report raised items that need design decisions rather than patches, and
+they are deliberately **not** claimed as fixed here: the API remaining
+unauthenticated by default outside the Codespaces overlay (loopback-bound in the
+base compose), auth profiles not being owner-scoped, operator identity being a
+self-asserted header, and the Codex host-bridge running with sandbox approvals
+bypassed. These are tracked for the next release.
+
 ## [1.6.0] — 2026-08-04
 
 Witness receipts are now signed, and an exported bundle can be verified by

--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-browser-browser-node",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "playwright": "1.62.0"
       }

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -3,4 +3,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.6.0"
+version = "1.6.1"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/controller/app/cdp/passthrough.py
+++ b/controller/app/cdp/passthrough.py
@@ -15,10 +15,29 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Commands allowed through the raw CDP passthrough
+# Commands allowed through the raw CDP passthrough.
+#
+# This list is the security boundary of /sessions/{id}/cdp/raw, so it may only
+# contain *read-only introspection*. Two entries did not belong and were removed
+# (reported privately, 2026-06-17):
+#
+#   Runtime.evaluate   — runs arbitrary JavaScript in the page context. Since
+#                        sessions reuse stored auth profiles, that is cookie
+#                        theft and acting as the logged-in user on every site a
+#                        profile is authenticated to, plus fetch()-based SSRF to
+#                        internal and cloud-metadata addresses, bypassing the
+#                        navigation allowlist entirely. An allowlist advertised
+#                        as safe cannot contain arbitrary code execution.
+#   Network.getCookies — returns cookies for all origins, including HttpOnly
+#                        ones, which is the credential material directly.
+#
+# Removing them does not affect internal element intelligence, which issues
+# Runtime.evaluate against the CDP session directly rather than through
+# raw_cdp_command, nor browser.eval_js, which uses Playwright's page.evaluate.
+# Callers that genuinely need scripted evaluation should use browser.eval_js,
+# which is governed and auditable.
 _ALLOWED_CDP_COMMANDS = frozenset(
     [
-        "Runtime.evaluate",
         "DOM.getDocument",
         "DOM.querySelector",
         "DOM.getAttributes",
@@ -26,7 +45,6 @@ _ALLOWED_CDP_COMMANDS = frozenset(
         "CSS.getComputedStyleForNode",
         "CSS.getMatchedStylesForNode",
         "Animation.getPlaybackRate",
-        "Network.getCookies",
         "Performance.getMetrics",
         "Page.getLayoutMetrics",
         "Accessibility.getFullAXTree",

--- a/controller/app/version.py
+++ b/controller/app/version.py
@@ -4,4 +4,4 @@ Bump together with the package versions in */pyproject.toml and
 browser-node/package.json during release prep.
 """
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.6.0"
+version = "1.6.1"
 description = "Controller API for auto-browser"
 # 3.11, not 3.10: CI tests 3.11 and 3.14, the Dockerfile pins python:3.11-slim,
 # and the published packages were corrected to >=3.11 in 1.5.2. A floor nothing

--- a/controller/tests/test_cdp_allowlist.py
+++ b/controller/tests/test_cdp_allowlist.py
@@ -1,0 +1,98 @@
+"""The raw CDP allowlist is a security boundary, not a convenience list.
+
+`/sessions/{id}/cdp/raw` is gated solely by `_ALLOWED_CDP_COMMANDS`, and that
+list contained `Runtime.evaluate` and `Network.getCookies` while being described
+as "safe" (reported privately 2026-06-17).
+
+Sessions reuse stored auth profiles, so arbitrary JavaScript in the page context
+is cookie theft and acting as the logged-in user on every site a profile is
+authenticated to — plus `fetch()`-based SSRF to internal and cloud-metadata
+addresses, which bypasses the navigation allowlist entirely.
+
+These tests pin the boundary so a future "just add one more command" cannot
+quietly reopen it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.cdp.passthrough import _ALLOWED_CDP_COMMANDS
+
+# Commands that must never be reachable through the raw passthrough, with the
+# reason each is disqualifying.
+FORBIDDEN = {
+    "Runtime.evaluate": "arbitrary JavaScript in an authenticated page context",
+    "Runtime.callFunctionOn": "arbitrary JavaScript in an authenticated page context",
+    "Runtime.compileScript": "arbitrary JavaScript in an authenticated page context",
+    "Network.getCookies": "returns cookies for all origins, including HttpOnly",
+    "Network.getAllCookies": "returns cookies for all origins, including HttpOnly",
+    "Network.setCookie": "forges credentials",
+    "Page.navigate": "bypasses the navigation allowlist",
+    "Browser.grantPermissions": "escalates page capabilities",
+    "Fetch.enable": "allows request interception and rewriting",
+}
+
+
+@pytest.mark.parametrize("command", sorted(FORBIDDEN))
+def test_dangerous_cdp_commands_are_not_allowlisted(command: str) -> None:
+    assert command not in _ALLOWED_CDP_COMMANDS, (
+        f"{command} is reachable through /sessions/{{id}}/cdp/raw — {FORBIDDEN[command]}. "
+        "This allowlist is the only gate on that endpoint."
+    )
+
+
+def test_allowlist_is_read_only_introspection() -> None:
+    """Every entry must be a getter-shaped read, not an action.
+
+    A positive check as well as the negative one above: a command that is
+    dangerous but not on the FORBIDDEN list should still fail here.
+    """
+    # Verb prefixes that denote a read. `query` is included because
+    # DOM.querySelector locates a node without mutating anything; it is the only
+    # non-`get` read currently on the list.
+    allowed_prefixes = ("get", "resolve", "describe", "query")
+    for command in _ALLOWED_CDP_COMMANDS:
+        _, _, method = command.partition(".")
+        assert method.startswith(allowed_prefixes), (
+            f"{command} is not read-only introspection. The raw CDP passthrough may "
+            f"only expose getters; anything that acts on the page belongs behind a "
+            f"governed tool with an audit trail."
+        )
+
+
+def test_allowlist_is_not_empty() -> None:
+    """Guard the guard — an empty list would make both checks above vacuous."""
+    assert len(_ALLOWED_CDP_COMMANDS) >= 5
+
+
+COMPOSE = Path(__file__).resolve().parents[2] / "docker-compose.codespaces.yml"
+
+
+@pytest.mark.skipif(not COMPOSE.is_file(), reason="repo checkout not available inside the controller image")
+def test_codespaces_overlay_requires_a_bearer_token() -> None:
+    """The one shipped config that binds 0.0.0.0 must not run unauthenticated.
+
+    Compose's `:?` form fails the run when the variable is unset, which is the
+    behaviour we want: refuse to start rather than silently publish an
+    unauthenticated control plane driving a browser that holds stored logins.
+    """
+    text = COMPOSE.read_text(encoding="utf-8")
+    assert re.search(r"API_BEARER_TOKEN:\s*\$\{API_BEARER_TOKEN:\?", text), (
+        "docker-compose.codespaces.yml publishes the API on 0.0.0.0 and must "
+        "require API_BEARER_TOKEN via the ${VAR:?message} form"
+    )
+
+
+@pytest.mark.skipif(not COMPOSE.is_file(), reason="repo checkout not available inside the controller image")
+def test_codespaces_overlay_does_not_publish_passwordless_vnc() -> None:
+    """x11vnc runs -nopw, so raw VNC is only safe on a loopback bind."""
+    text = COMPOSE.read_text(encoding="utf-8")
+    published = re.findall(r'"0\.0\.0\.0:[^"]*:(\d+)"', text)
+    assert "5900" not in published, (
+        "raw VNC (5900) must not be published on 0.0.0.0 — x11vnc runs -nopw, "
+        "so the port is unauthenticated by design. noVNC (6080) covers takeover."
+    )

--- a/controller/tests/test_cdp_passthrough.py
+++ b/controller/tests/test_cdp_passthrough.py
@@ -111,7 +111,12 @@ class CDPPassthroughTests(unittest.IsolatedAsyncioTestCase):
         fake = _FakeCDPSession(
             {
                 "DOM.getDocument": {"root": {"nodeId": 1}},
-                "Runtime.evaluate": RuntimeError("eval failed"),
+                # Previously this used Runtime.evaluate as the "allowed command
+                # that fails at runtime" example. It is no longer allowed through
+                # the raw passthrough at all — arbitrary JS in an authenticated
+                # page is cookie theft plus SSRF — so a genuinely read-only
+                # command stands in for that case.
+                "Accessibility.getFullAXTree": RuntimeError("ax tree failed"),
             }
         )
         passthrough = CDPPassthrough(fake)
@@ -119,11 +124,16 @@ class CDPPassthroughTests(unittest.IsolatedAsyncioTestCase):
         success = await passthrough.raw_cdp_command("DOM.getDocument", {"depth": 1})
         self.assertEqual(success["root"]["nodeId"], 1)
 
-        error = await passthrough.raw_cdp_command("Runtime.evaluate", {"expression": "1+1"})
-        self.assertEqual(error, {"error": "cdp_command_failed", "method": "Runtime.evaluate"})
+        error = await passthrough.raw_cdp_command("Accessibility.getFullAXTree")
+        self.assertEqual(error, {"error": "cdp_command_failed", "method": "Accessibility.getFullAXTree"})
 
         with self.assertRaisesRegex(ValueError, "not in the allowed list"):
             await passthrough.raw_cdp_command("Page.navigate")
+
+        # The security property this endpoint depends on.
+        for blocked in ("Runtime.evaluate", "Network.getCookies"):
+            with self.assertRaisesRegex(ValueError, "not in the allowed list"):
+                await passthrough.raw_cdp_command(blocked, {"expression": "document.cookie"})
 
     async def test_from_page_builds_passthrough_from_new_cdp_session(self) -> None:
         fake_session = _FakeCDPSession({"DOM.getDocument": {"root": {"nodeId": 1}}})

--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -1,5 +1,21 @@
 # Use in Codespaces: docker compose -f docker-compose.yml -f docker-compose.codespaces.yml up
 #
+# This overlay publishes on 0.0.0.0 so the Codespaces port-forwarder can reach
+# the services. That makes it the one shipped configuration where the API is not
+# loopback-only, so it must not run unauthenticated.
+#
+# API_BEARER_TOKEN uses `:?`, so Compose refuses to start when it is unset rather
+# than silently publishing an unauthenticated control plane that can drive a
+# browser holding stored logins. Reported privately 2026-06-17: with the API on
+# 0.0.0.0 and no token, anyone who could reach the port could open a session from
+# a saved auth profile and export its cookies.
+#
+#   export API_BEARER_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+#
+# Raw VNC (5900) is deliberately no longer published here: x11vnc runs `-nopw`,
+# so that port is unauthenticated by design and is only safe behind a loopback
+# bind. noVNC (6080) stays published so human takeover still works.
+#
 # `!override` replaces the base service's `ports` list instead of merging with it.
 # Without it, Compose appends these entries to the base 127.0.0.1 bindings, so both
 # 127.0.0.1:PORT and 0.0.0.0:PORT are published for the same container port and the
@@ -9,8 +25,9 @@ services:
   browser-node:
     ports: !override
       - "0.0.0.0:${NOVNC_PORT:-6080}:6080"
-      - "0.0.0.0:${VNC_PORT:-5900}:5900"
 
   controller:
+    environment:
+      API_BEARER_TOKEN: ${API_BEARER_TOKEN:?set API_BEARER_TOKEN before using the Codespaces overlay - it publishes the API on 0.0.0.0 and must not run unauthenticated}
     ports: !override
       - "0.0.0.0:${API_PORT:-8000}:8000"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.6.0"
+version = "1.6.1"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # console script against that dependency.
 [project]
 name = "auto-browser-mcp"
-version = "1.6.0"
+version = "1.6.1"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
From a **privately reported vulnerability disclosure received 2026-06-17** that had not been triaged. I verified every claim against the code before fixing.

### `Runtime.evaluate` was in the allowlist advertised as "safe"

`/sessions/{id}/cdp/raw` is gated **solely** by `_ALLOWED_CDP_COMMANDS`, and that list contained `Runtime.evaluate` and `Network.getCookies`.

`Runtime.evaluate` runs arbitrary JavaScript in the page context. Because sessions reuse stored auth profiles, that is:

- cookie theft and acting as the logged-in user on **every site a profile is authenticated to**
- `fetch()`-based SSRF to internal and cloud-metadata addresses, bypassing the navigation allowlist entirely

`Network.getCookies` returns the credential material outright.

**Blast radius was checked before removing them**, and it is small: internal element intelligence issues `Runtime.evaluate` against the CDP session directly rather than through `raw_cdp_command`, and `browser.eval_js` uses Playwright's `page.evaluate`. Neither goes through this allowlist.

The allowlist is now pinned **two ways** — a deny-list of command families that must never appear, and a positive check that every entry is read-only introspection, so a command that is dangerous but absent from the deny-list still fails. Verified both catch a re-added `Runtime.evaluate`.

### The Codespaces overlay published an unauthenticated control plane

`docker-compose.codespaces.yml` binds the API to `0.0.0.0` so the port forwarder can reach it, while `API_BEARER_TOKEN` defaults unset and the bearer middleware fails open when it is. Combined with the above, anyone reaching the forwarded port could open a session from a saved auth profile and export its cookies.

The overlay now requires `API_BEARER_TOKEN` via Compose's `${VAR:?message}` form. Verified: it exits 1 with an explanatory message when unset, and configs cleanly when set.

Raw VNC is also no longer published on `0.0.0.0` there — `x11vnc` runs `-nopw`, so 5900 is unauthenticated by design and only safe behind a loopback bind. noVNC (6080) stays published, so human takeover still works.

### Deliberately NOT claimed as fixed

Recorded as such in the CHANGELOG rather than quietly omitted. The same report raised items needing design decisions, not patches:

- the API being unauthenticated by default outside this overlay (base compose is loopback-bound, so reachability is limited — but the default is still fail-open)
- auth profiles not being owner-scoped
- operator identity being a self-asserted header
- the Codex host-bridge running with sandbox approvals bypassed

### Note on the existing test

`test_raw_cdp_command_enforces_allowlist_and_catches_runtime_errors` used `Runtime.evaluate` as its "allowed command that fails at runtime" example. It now uses a genuinely read-only command, and additionally asserts both removed commands are rejected.

**873 → 886 passed**, 2 skipped, 199 subtests. `ruff check` clean, compose config validated both ways.