### PR TITLE
release: 1.7.0 — close the reported design issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ API_BEARER_TOKEN=
 # whenever the API is reachable from anywhere else — the controller then refuses
 # to start without an API_BEARER_TOKEN of at least 32 characters.
 API_BIND_SCOPE=loopback
+# Named credentials: `alice:token-a,bob:token-b`. A request authenticating with
+# one of these has a verified operator identity, so X-Operator-Id can no longer
+# claim to be someone else. The shared API_BEARER_TOKEN above still works, but
+# one credential cannot tell operators apart, so identity stays self-asserted.
+API_BEARER_TOKENS=
 BROWSER_WIDTH=1280
 BROWSER_HEIGHT=800
 BROWSER_URL=about:blank

--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,13 @@ OPENAI_AUTH_MODE=api
 OPENAI_CLI_PATH=codex
 OPENAI_CLI_MODEL=
 OPENAI_HOST_BRIDGE_SOCKET=/data/host-bridge/codex.sock
+# How the Codex CLI may execute. read-only | workspace-write | danger-full-access.
+# Codex is only asked for a JSON decision about a screenshot here, so read-only is
+# enough. CODEX_BRIDGE_ALLOW_HOST_EXEC=true restores the old behaviour of passing
+# --dangerously-bypass-approvals-and-sandbox: a model decision can then run any
+# command on the host. Only inside an environment that is itself sandboxed.
+CODEX_SANDBOX_MODE=read-only
+CODEX_BRIDGE_ALLOW_HOST_EXEC=false
 
 ANTHROPIC_API_KEY=
 ANTHROPIC_BASE_URL=https://api.anthropic.com/v1

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ NOVNC_PORT=6080
 VNC_PORT=5900
 
 API_BEARER_TOKEN=
+# loopback | exposed. The base compose publishes the API on 127.0.0.1 and
+# declares `loopback`, which is what lets it run with no token. Set `exposed`
+# whenever the API is reachable from anywhere else — the controller then refuses
+# to start without an API_BEARER_TOKEN of at least 32 characters.
+API_BIND_SCOPE=loopback
 BROWSER_WIDTH=1280
 BROWSER_HEIGHT=800
 BROWSER_URL=about:blank

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+## [1.7.0] — 2026-08-08
+
+Closes the design issues raised in
+[GHSA-xmh3-cw7j-9gp5](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-xmh3-cw7j-9gp5)
+that 1.6.1 fixed the patchable half of and listed the rest of as *Known and not
+yet addressed*, plus one item from the same report that list omitted. Two of the
+three witness limits documented in 1.6.0 are fixed as well.
+
+The thread running through all of it: a control that fails open is not a control.
+Authentication that switched itself off when no token was set, an operator
+identity anybody could assert, profiles with no owner, a signature nothing
+checked, and a sandbox flag that disabled the sandbox.
+
+**If you publish the API anywhere other than loopback, read the first entry
+before upgrading** — it is the one change that can stop an existing deployment
+from starting, deliberately.
+
 ### Security
 
 - **The API is no longer unauthenticated by default when it is reachable.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ All notable changes to auto-browser are documented here.
 
 ### Security
 
+- **The API is no longer unauthenticated by default when it is reachable.**
+  Three layers were supposed to answer "is this API authenticated?" and all
+  three failed open. `API_BEARER_TOKEN` defaulted to unset; the bearer
+  middleware returned early when it was unset, so the *absence* of a credential
+  disabled authentication instead of denying requests; and the only hard check
+  lived in startup validation, which downgraded to a warning unless
+  `APP_ENV=production` — while shipped compose set
+  `APP_ENV: ${APP_ENV:-development}`. The default was an open control plane
+  driving a browser that holds stored logins.
+
+  The switch is now reachability rather than an environment name, because
+  reachability is what decides whether an open control plane is a local
+  convenience or an account takeover. New setting **`API_BIND_SCOPE`**
+  (`loopback` | `exposed`) declares it, and the controller refuses to start when
+  the scope is `exposed` without a token of at least 32 characters — in any
+  `APP_ENV`.
+
+  It defaults to **`exposed`**, so a deployment that declares nothing is assumed
+  reachable and fails closed. The base `docker-compose.yml` declares `loopback`
+  to match its `127.0.0.1:8000:8000` publish mapping, so `docker compose up` on
+  a clean checkout still needs no token; the Codespaces overlay declares
+  `exposed`. A hand-rolled compose file that publishes on `0.0.0.0` without
+  saying so now refuses to start instead of silently serving an open API. If you
+  run the controller directly, a loopback bind host in `API_BIND_HOST`,
+  `UVICORN_HOST` or `HOST` is detected and treated as `loopback`.
+
+  Authentication is decided in one place (`app/auth_policy.py`) for both the
+  auth gate and the rate limiter, and the request path is what the tests assert:
+  a reachable, tokenless controller answers 401 to `/sessions` while `/healthz`
+  stays reachable for orchestrators.
+
+  **Upgrading:** if you publish the API anywhere other than loopback and were
+  relying on it being open, set `API_BEARER_TOKEN` (32+ characters). If you
+  publish only on loopback with a compose file of your own, add
+  `API_BIND_SCOPE=loopback`.
+
 - **A privately reported advisory can no longer sit unnoticed.**
   [GHSA-xmh3-cw7j-9gp5](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-xmh3-cw7j-9gp5)
   was reported on 2026-06-17 and sat in triage for seven weeks, because a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,27 @@ All notable changes to auto-browser are documented here.
   publish only on loopback with a compose file of your own, add
   `API_BIND_SCOPE=loopback`.
 
+- **Operator identity can now be proven instead of asserted.** `X-Operator-Id`
+  is a request header, and until now it was the only thing that ever set the
+  operator on an audit event — so the trail attributed actions to a string the
+  caller chose, which reads as identity while being a label.
+
+  New setting **`API_BEARER_TOKENS`** takes named credentials
+  (`alice:token-a,bob:token-b`). A request authenticating with one of those has
+  a verified identity recorded as `source: "token"`, and a `X-Operator-Id`
+  header that disagrees no longer wins — the credential does, and the false
+  claim is kept on the audit record as `asserted_id` rather than dropped. A
+  named credential also satisfies `REQUIRE_OPERATOR_ID` on its own.
+
+  The shared `API_BEARER_TOKEN` still works and still records
+  `source: "header"`, because one shared credential genuinely cannot tell
+  operators apart. That distinction is now explicit in the data, so
+  authorization can require `source: "token"` — which is what the next release
+  needs in order to scope auth profiles to an owner.
+
+  Every named token must also clear the 32-character floor; one weak entry in
+  `API_BEARER_TOKENS` is a way in.
+
 - **A privately reported advisory can no longer sit unnoticed.**
   [GHSA-xmh3-cw7j-9gp5](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-xmh3-cw7j-9gp5)
   was reported on 2026-06-17 and sat in triage for seven weeks, because a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ All notable changes to auto-browser are documented here.
   publish only on loopback with a compose file of your own, add
   `API_BIND_SCOPE=loopback`.
 
+- **Codex no longer runs on the host with approvals and sandboxing disabled.**
+  Both Codex paths — the `cli` provider adapter and the host bridge — passed
+  `--dangerously-bypass-approvals-and-sandbox`, a flag whose own help text reads
+  "EXTREMELY DANGEROUS. Intended solely for running in environments that are
+  externally sandboxed". A model decision could therefore run any command on the
+  host.
+
+  Nothing about the work needed it: both paths hand Codex a screenshot and a
+  prompt in an ephemeral temp directory and read back a JSON decision. Codex now
+  runs with `-s read-only` by default. **`CODEX_SANDBOX_MODE`** widens that to
+  `workspace-write` or `danger-full-access` if you need it, and
+  **`CODEX_BRIDGE_ALLOW_HOST_EXEC=true`** restores the bypass for the case its
+  help text actually describes — an environment that is itself sandboxed. That
+  opt-in logs a warning at startup and on the bridge's stderr.
+
 - **Auth profiles now belong to the operator who saved them.** Profiles lived in
   a flat root with no owner, so any caller who could reach the API could read
   one, export its cookie archive, or — the takeover that matters — open a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,25 @@ All notable changes to auto-browser are documented here.
   publish only on loopback with a compose file of your own, add
   `API_BIND_SCOPE=loopback`.
 
+- **Auth profiles now belong to the operator who saved them.** Profiles lived in
+  a flat root with no owner, so any caller who could reach the API could read
+  one, export its cookie archive, or — the takeover that matters — open a
+  session against it and drive a browser already logged in as somebody else.
+
+  A profile saved by a caller with a *proven* identity records that operator as
+  its owner. Reading, exporting, overwriting on import, saving over it, and
+  opening a session from it then require authenticating as that operator, and
+  listing hides profiles you cannot access rather than advertising which sites
+  someone else holds logins for. Refusals are `403`, including on export, where
+  the route's catch-all previously turned any refusal into a `500`.
+
+  Ownership keys on `source: "token"`, so *claiming* to be the owner in an
+  `X-Operator-Id` header does not work. It also means ownership starts applying
+  exactly when named credentials do: a profile saved without a proven identity
+  records no owner, so shared-token deployments and every profile written before
+  this release keep working, with no migration step and no way to be locked out
+  of your own logins.
+
 - **Operator identity can now be proven instead of asserted.** `X-Operator-Id`
   is a request header, and until now it was the only thing that ever set the
   operator on an audit event — so the trail attributed actions to a string the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,32 @@ All notable changes to auto-browser are documented here.
   publish only on loopback with a compose file of your own, add
   `API_BIND_SCOPE=loopback`.
 
+- **Two of the witness limits documented in 1.6.0 are now fixed.**
+
+  *Chain forking* was a correctness bug rather than a limit. Appends were
+  serialised with an `asyncio.Lock`, which orders tasks on one event loop —
+  not threads in this process, and not other processes. Two workers
+  (`AGENT_JOB_WORKER_COUNT > 1`, several uvicorn workers, or two replicas on a
+  shared volume) could read the same head and write two receipts claiming the
+  same predecessor. Reading the head, signing, and appending are now one
+  critical section under an OS-level lock on the chain file, with an in-process
+  thread lock inside it.
+
+  *Tail truncation* was undetectable: drop the last k receipts and what remains
+  is a shorter chain whose every signature still verifies. Each append now also
+  updates an anchor file beside the chain holding the head hash and receipt
+  count, and `verify()` compares them — the result gains an `anchor` block, and
+  a truncated or rewritten chain reports `valid: false` with the reason.
+  Chains written before this release report `anchor: {"status": "unanchored"}`
+  and keep verifying, because a missing anchor is not evidence of tampering.
+
+  This needs no third party. An attacker who rewrites the anchor as well still
+  defeats it, which is what a genuinely external anchor is for; the anchor is a
+  separate artifact so one can be added later without changing this shape.
+  Key compromise remains a stated limit.
+
+  Appends also stopped re-reading the whole chain to find its head.
+
 - **Staged skill candidates are verified on read, not just signed on write.**
   Induction could sign a candidate envelope, but nothing on the read side ever
   verified one — so the signature was an assertion the artifact made about

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to auto-browser are documented here.
 
 ## [Unreleased]
 
+### Security
+
+- **A privately reported advisory can no longer sit unnoticed.**
+  [GHSA-xmh3-cw7j-9gp5](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-xmh3-cw7j-9gp5)
+  was reported on 2026-06-17 and sat in triage for seven weeks, because a
+  private report appears in none of the views a maintainer opens day to day —
+  not issues, not pull requests — and was found only by listing advisories
+  through the API while publishing an unrelated one. `SECURITY.md` promises
+  reporters a quick acknowledgement.
+
+  `scripts/check_open_advisories.py` now fails the release audit while any
+  report is still waiting in triage. Accepted drafts are reported but do not
+  block, since accepted-and-being-fixed is a legitimate place to be mid-release.
+  The check attaches to cutting a release because that is the one process
+  guaranteed to run before users are affected by anything.
+
+  The blocking path is what the tests cover: a gate exercised only against a
+  clean repo is indistinguishable from one that always reports "all clear".
+
+### Notes
+
+The design items listed as *Known and not yet addressed* under 1.6.1 are the
+scope of 1.7.0, along with one more from the same report that the 1.6.1 list
+omitted: skill-candidate provenance is hashed but never signed or verified.
+
 ## [1.6.1] — 2026-08-04
 
 Security fixes from a **privately reported** vulnerability disclosure (received

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,26 @@ All notable changes to auto-browser are documented here.
   publish only on loopback with a compose file of your own, add
   `API_BIND_SCOPE=loopback`.
 
+- **Staged skill candidates are verified on read, not just signed on write.**
+  Induction could sign a candidate envelope, but nothing on the read side ever
+  verified one — so the signature was an assertion the artifact made about
+  itself, the same shape as the pre-1.6.0 witness chain. Anyone able to write to
+  the staging root could edit a staged skill, or drop a new one in, and it was
+  served as a governed candidate carrying provenance.
+
+  The registry now checks the signature before returning a candidate, and checks
+  that the envelope matches the artifact it sits in — a genuine signature lifted
+  from a different candidate is still a forgery. A candidate that fails is
+  refused; `list` omits what it cannot verify. Deployments with no signer
+  configured are unaffected: there is nothing to check, and `signed` on the
+  candidate now records which case it was, so an unsigned envelope is no longer
+  a dict shaped exactly like a signed one.
+
+  Candidates induced from a mock run are marked `simulated`, inside the
+  provenance hash and the envelope, so a skill that no browser ever executed
+  cannot present itself as converged. The README's "signed provenance" claim is
+  reworded to say what actually holds.
+
 - **Codex no longer runs on the host with approvals and sandboxing disabled.**
   Both Codex paths — the `cli` provider adapter and the host bridge — passed
   `--dangerously-bypass-approvals-and-sandbox`, a flag whose own help text reads

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Works with:
 - **Safety rails built in.** Approvals, operator identity, PII scrubbing, Witness receipts, and policy presets are all part of the product surface.
 - **Evidence you can hand to someone else.** Witness receipt chains are Ed25519-signed, and an exported bundle verifies with [`scripts/verify_witness_bundle.py`](./scripts/verify_witness_bundle.py) — which imports nothing from this project, so a recipient need not run or trust this controller to check it.
 - **We audit ourselves in public.** [`docs/audits/2026-08-execution-audit.md`](./docs/audits/2026-08-execution-audit.md) documents an adversarial audit of this repo that found safety controls which reported success while doing nothing, with reproductions, the fixes, and the gates that close the class.
-- **Governed skill induction.** Verified browser traces can become staged skill candidates with signed provenance, verifier adapters, and review-only graduation — agents that prove they can repeat themselves correctly, not just act once.
+- **Governed skill induction.** Verified browser traces can become staged skill candidates with provenance that is signed when a mesh identity is configured — and checked on read, not just produced — plus verifier adapters and review-only graduation — agents that prove they can repeat themselves correctly, not just act once.
 
 ## Release Highlights (v1.5.0)
 
@@ -179,7 +179,7 @@ see [`docs/mcp-clients.md#resources-and-subscriptions`](./docs/mcp-clients.md#re
 
 ## Convergence Harness
 
-Auto Browser ships a Stage 0 convergence harness for Agent Skill Induction. It runs a structured task contract, records tamper-checked traces, verifies completion, and writes a staged skill candidate with signed provenance. Generated skills are staged only — promotion stays explicit and reviewed.
+Auto Browser ships a Stage 0 convergence harness for Agent Skill Induction. It runs a structured task contract, records tamper-checked traces, verifies completion, and writes a staged skill candidate carrying provenance. With a mesh identity configured that provenance is signed, and the registry verifies the signature before serving a candidate — a candidate that fails the check, or that was dropped into the staging directory unsigned, is refused. Candidates induced from a mock run are marked `simulated` so they cannot pass as converged. Generated skills are staged only — promotion stays explicit and reviewed.
 
 Read-only inspection tools (`harness.list_runs`, `harness.get_status`, `harness.get_trace`) are exposed in the default `curated` MCP tool profile so agents can introspect harness state without elevated access. Convergence runs, drift checks, candidate management, and graduation require `MCP_TOOL_PROFILE=full`, or can be invoked directly over REST.
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ For a real private deployment, set at least:
 
 ```bash
 APP_ENV=production
+API_BIND_SCOPE=exposed
 API_BEARER_TOKEN=<strong-random-secret>
 REQUIRE_OPERATOR_ID=true
 AUTH_STATE_ENCRYPTION_KEY=<44-char-fernet-key>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,10 @@ Include:
 Issues found by the maintainers are disclosed the same way a reported one would
 be, and the audits that found them are published in full:
 
+- [GHSA-xmh3-cw7j-9gp5](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-xmh3-cw7j-9gp5)
+  — `Runtime.evaluate` reachable through the "safe" raw-CDP allowlist, plus a
+  Codespaces overlay that published the API unauthenticated (fixed in 1.6.1).
+  Reported privately by [@rafaelfiguereod-stack](https://github.com/rafaelfiguereod-stack)
 - [GHSA-32ph-8hp6-7qgj](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-32ph-8hp6-7qgj)
   — safety controls that reported success while not functioning (fixed in 1.5.1
   and 1.5.3). Write-up: [`docs/audits/2026-08-execution-audit.md`](./docs/audits/2026-08-execution-audit.md)
@@ -53,3 +57,10 @@ The project aims to:
 - confirm severity and scope
 - ship the smallest safe fix
 - document user-facing mitigation steps when needed
+
+"Quickly" was once seven weeks. GHSA-xmh3-cw7j-9gp5 was reported privately on
+2026-06-17 and sat in triage until 2026-08-08, because a private report shows up
+in none of the views a maintainer opens day to day. So acknowledgement is no
+longer left to attention: `scripts/check_open_advisories.py` fails the release
+audit while any report is still waiting in triage, which puts the check on the
+one process that is guaranteed to run before users are affected by anything.

--- a/browser-node/package-lock.json
+++ b/browser-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-browser-browser-node",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "dependencies": {
         "playwright": "1.62.0"
       }

--- a/browser-node/package.json
+++ b/browser-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-browser-browser-node",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/client/auto_browser_client/__init__.py
+++ b/client/auto_browser_client/__init__.py
@@ -3,4 +3,4 @@
 from .client import AutoBrowserClient
 
 __all__ = ["AutoBrowserClient"]
-__version__ = "1.6.1"
+__version__ = "1.7.0"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-client"
-version = "1.6.1"
+version = "1.7.0"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/controller/app/audit.py
+++ b/controller/app/audit.py
@@ -24,11 +24,18 @@ _CURRENT_OPERATOR: ContextVar[OperatorIdentity | None] = ContextVar(
 )
 
 
-def set_current_operator(operator_id: str | None, *, name: str | None = None, source: str = "header") -> Token:
+def set_current_operator(
+    operator_id: str | None,
+    *,
+    name: str | None = None,
+    source: str = "header",
+    asserted_id: str | None = None,
+) -> Token:
     identity = OperatorIdentity(
         id=(operator_id or "anonymous").strip() or "anonymous",
         name=(name or None),
         source=source if operator_id else "anonymous",
+        asserted_id=(asserted_id or None),
     )
     return _CURRENT_OPERATOR.set(identity)
 

--- a/controller/app/auth_policy.py
+++ b/controller/app/auth_policy.py
@@ -25,10 +25,12 @@ checkout still needs no token because the base compose declares `loopback`.
 
 from __future__ import annotations
 
+import hmac
 import ipaddress
 import os
 from dataclasses import dataclass
-from typing import Any, Mapping
+from functools import lru_cache
+from typing import Any, Mapping, Sequence
 
 BIND_SCOPE_LOOPBACK = "loopback"
 BIND_SCOPE_EXPOSED = "exposed"
@@ -98,19 +100,87 @@ def resolve_bind_scope(settings: Any, environ: Mapping[str, str] | None = None) 
     return declared
 
 
-def policy_for_scope(scope: str, token: str | None) -> AuthPolicy:
+@dataclass(frozen=True, slots=True)
+class Credential:
+    """A bearer token, and the operator it proves the holder to be — if any.
+
+    `operator_id is None` means the shared `API_BEARER_TOKEN`: it proves the
+    caller is authorised, and nothing at all about who they are. Named tokens
+    from `API_BEARER_TOKENS` prove both, which is the difference between
+    attribution and authentication.
+    """
+
+    token: str
+    operator_id: str | None = None
+
+    @property
+    def verifies_identity(self) -> bool:
+        return self.operator_id is not None
+
+
+def parse_operator_tokens(raw: str) -> tuple[Credential, ...]:
+    """Parse `alice:token-a,bob:token-b` into named credentials.
+
+    Split on the first colon only — a token may contain colons, an operator id
+    may not. Entries without a colon are skipped rather than guessed at: a
+    malformed pair that silently became a shared token would hand one operator's
+    identity to everyone holding it.
+    """
+    credentials: list[Credential] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry or ":" not in entry:
+            continue
+        operator_id, _, token = entry.partition(":")
+        operator_id, token = operator_id.strip(), token.strip()
+        if operator_id and token:
+            credentials.append(Credential(token=token, operator_id=operator_id))
+    return tuple(credentials)
+
+
+@lru_cache(maxsize=16)
+def _credentials(named: str, shared: str | None) -> tuple[Credential, ...]:
+    credentials = list(parse_operator_tokens(named))
+    if shared:
+        credentials.append(Credential(token=shared))
+    return tuple(credentials)
+
+
+def credentials_for(settings: Any) -> tuple[Credential, ...]:
+    return _credentials(
+        getattr(settings, "api_bearer_tokens", "") or "",
+        getattr(settings, "api_bearer_token", None),
+    )
+
+
+def match_credential(credentials: Sequence[Credential], authorization: str) -> Credential | None:
+    """The credential this request presented, or None.
+
+    Every candidate is compared even after a match, so the work does not depend
+    on which token was presented or how many are configured.
+    """
+    presented = authorization.encode()
+    matched: Credential | None = None
+    for credential in credentials:
+        expected = f"Bearer {credential.token}".encode()
+        if hmac.compare_digest(presented, expected) and matched is None:
+            matched = credential
+    return matched
+
+
+def policy_for_scope(scope: str, credentials: Sequence[Credential]) -> AuthPolicy:
     """The decision itself, split out from where its inputs come from.
 
-    Bind scope is fixed by the deployment and resolved once; the credential is
+    Bind scope is fixed by the deployment and resolved once; credentials are
     read from live settings on each request. Both callers — the auth gate and
     the rate limiter — go through here, so "is this authenticated?" cannot drift
     between them again.
     """
-    if token:
+    if credentials:
         return AuthPolicy(
             scope=scope,
             required=True,
-            reason="API_BEARER_TOKEN is set",
+            reason="at least one bearer credential is configured",
             has_credential=True,
         )
 
@@ -119,8 +189,8 @@ def policy_for_scope(scope: str, token: str | None) -> AuthPolicy:
             scope=scope,
             required=True,
             reason=(
-                "the API is reachable off-box (API_BIND_SCOPE=exposed) and no API_BEARER_TOKEN "
-                "is set, so no request can be authorised"
+                "the API is reachable off-box (API_BIND_SCOPE=exposed) and no bearer credential "
+                "is configured, so no request can be authorised"
             ),
             has_credential=False,
         )
@@ -128,13 +198,10 @@ def policy_for_scope(scope: str, token: str | None) -> AuthPolicy:
     return AuthPolicy(
         scope=scope,
         required=False,
-        reason="loopback-only bind with no API_BEARER_TOKEN set",
+        reason="loopback-only bind with no bearer credential configured",
         has_credential=False,
     )
 
 
 def resolve_auth_policy(settings: Any, environ: Mapping[str, str] | None = None) -> AuthPolicy:
-    return policy_for_scope(
-        resolve_bind_scope(settings, environ),
-        getattr(settings, "api_bearer_token", None),
-    )
+    return policy_for_scope(resolve_bind_scope(settings, environ), credentials_for(settings))

--- a/controller/app/auth_policy.py
+++ b/controller/app/auth_policy.py
@@ -1,0 +1,140 @@
+"""One answer to "is this API authenticated?", resolved once at startup.
+
+The question used to have three answers that disagreed. `API_BEARER_TOKEN`
+defaulted to unset; the bearer middleware returned early when it was unset, so
+the *absence* of a token disabled authentication rather than denying requests;
+and the only hard enforcement lived in `validate_runtime_policy`, which
+downgraded to a warning and returned unless `APP_ENV=production` — while shipped
+compose set `APP_ENV: ${APP_ENV:-development}`. Three layers, each failing open,
+so the shipped default was an unauthenticated control plane driving a browser
+that holds stored logins (GHSA-xmh3-cw7j-9gp5).
+
+The switch is now reachability rather than an environment name, because
+reachability is what decides whether an open control plane is a local
+convenience or an account takeover. `APP_ENV` describes intent; a publish
+mapping describes exposure.
+
+The controller cannot observe its own reachability: inside Docker it always
+binds `0.0.0.0`, and it is the host publish mapping — `127.0.0.1:8000:8000` in
+the base compose — that makes it loopback-only. So the scope is *declared*, and
+declared fail-safe: a deployment that says nothing is assumed reachable. Someone
+hand-rolling a compose file that publishes on `0.0.0.0` gets a refusal to start
+instead of a silent open control plane, and `docker compose up` on a clean
+checkout still needs no token because the base compose declares `loopback`.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+BIND_SCOPE_LOOPBACK = "loopback"
+BIND_SCOPE_EXPOSED = "exposed"
+BIND_SCOPES = (BIND_SCOPE_LOOPBACK, BIND_SCOPE_EXPOSED)
+
+# Consulted only when API_BIND_SCOPE is not set explicitly, so that a bare
+# `uvicorn --host 127.0.0.1` dev run stays frictionless without the developer
+# having to learn a new variable.
+BIND_HOST_ENV_VARS = ("API_BIND_HOST", "UVICORN_HOST", "HOST")
+
+
+@dataclass(frozen=True, slots=True)
+class AuthPolicy:
+    """The resolved authentication stance for this process."""
+
+    scope: str
+    required: bool
+    reason: str
+    has_credential: bool = False
+
+    @property
+    def satisfiable(self) -> bool:
+        """False when auth is required but no credential exists to satisfy it.
+
+        Startup refuses this configuration, so it should be unreachable in a
+        running server. The middleware checks anyway, because "the other layer
+        already prevented it" is exactly the assumption that produced the
+        original defect.
+        """
+        return not self.required or self.has_credential
+
+
+def is_loopback_host(host: str) -> bool:
+    candidate = host.strip()
+    if candidate.startswith("["):  # [::1] or [::1]:8000
+        candidate = candidate[1:].partition("]")[0]
+    elif candidate.count(":") == 1:  # host:port — a bare IPv6 literal has more
+        candidate = candidate.partition(":")[0]
+    if not candidate:
+        return False
+    if candidate.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        return False
+
+
+def resolve_bind_scope(settings: Any, environ: Mapping[str, str] | None = None) -> str:
+    """Where this API is reachable from: an explicit declaration, else inferred.
+
+    An explicit `API_BIND_SCOPE` always wins. Otherwise a loopback bind host in
+    the environment counts as a loopback deployment, and anything else — an
+    unknown or absent bind host — falls back to the fail-safe default.
+    """
+    env = os.environ if environ is None else environ
+    declared = getattr(settings, "api_bind_scope", BIND_SCOPE_EXPOSED)
+
+    if "api_bind_scope" in getattr(settings, "model_fields_set", ()):
+        return declared
+
+    for name in BIND_HOST_ENV_VARS:
+        host = env.get(name)
+        if host and is_loopback_host(host):
+            return BIND_SCOPE_LOOPBACK
+
+    return declared
+
+
+def policy_for_scope(scope: str, token: str | None) -> AuthPolicy:
+    """The decision itself, split out from where its inputs come from.
+
+    Bind scope is fixed by the deployment and resolved once; the credential is
+    read from live settings on each request. Both callers — the auth gate and
+    the rate limiter — go through here, so "is this authenticated?" cannot drift
+    between them again.
+    """
+    if token:
+        return AuthPolicy(
+            scope=scope,
+            required=True,
+            reason="API_BEARER_TOKEN is set",
+            has_credential=True,
+        )
+
+    if scope == BIND_SCOPE_EXPOSED:
+        return AuthPolicy(
+            scope=scope,
+            required=True,
+            reason=(
+                "the API is reachable off-box (API_BIND_SCOPE=exposed) and no API_BEARER_TOKEN "
+                "is set, so no request can be authorised"
+            ),
+            has_credential=False,
+        )
+
+    return AuthPolicy(
+        scope=scope,
+        required=False,
+        reason="loopback-only bind with no API_BEARER_TOKEN set",
+        has_credential=False,
+    )
+
+
+def resolve_auth_policy(settings: Any, environ: Mapping[str, str] | None = None) -> AuthPolicy:
+    return policy_for_scope(
+        resolve_bind_scope(settings, environ),
+        getattr(settings, "api_bearer_token", None),
+    )

--- a/controller/app/browser/services/auth_profiles.py
+++ b/controller/app/browser/services/auth_profiles.py
@@ -185,6 +185,10 @@ class BrowserAuthProfileService:
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         normalized = self.normalize_name(profile_name)
+        # Before writing anything: saving over a profile you do not own is the
+        # same takeover as reading it, and this method rewrites the metadata
+        # file wholesale, so the owner has to be carried across explicitly.
+        owner = self.require_access(normalized, action="saving an auth profile")
         profile_state_path = self.state_base_path(normalized, create=True)
         auth_info = await self.manager.auth_state.write_storage_state(session.context, profile_state_path)
         session.last_auth_state_path = Path(auth_info["path"]) if auth_info["path"] else None
@@ -198,6 +202,8 @@ class BrowserAuthProfileService:
             "saved_from_title": await session.page.title(),
             "platform": self.current_platform(session),
         }
+        if owner:
+            profile_payload["owner"] = owner
         if metadata:
             profile_payload.update(metadata)
 
@@ -282,6 +288,7 @@ class BrowserAuthProfileService:
 
     async def get(self, profile_name: str) -> dict[str, Any]:
         normalized = self.normalize_name(profile_name)
+        self.require_access(normalized, action="reading an auth profile")
         profile_dir = self.dir(normalized, create=False)
         metadata = self.read_metadata(normalized)
         state_path = self.resolve_state_path(normalized, must_exist=False)
@@ -307,6 +314,11 @@ class BrowserAuthProfileService:
             return []
         profiles: list[dict[str, Any]] = []
         for directory in sorted((item for item in root.iterdir() if item.is_dir()), key=lambda item: item.name.lower()):
+            # Listing another operator's profiles would leak both their existence
+            # and the sites they hold logins for. Checked before `get` so that a
+            # genuine containment error still raises instead of being skipped.
+            if not self.accessible(directory.name):
+                continue
             try:
                 profiles.append(await self.get(directory.name))
             except KeyError:
@@ -319,6 +331,7 @@ class BrowserAuthProfileService:
 
     async def export(self, profile_name: str) -> dict[str, Any]:
         normalized = self.normalize_name(profile_name)
+        self.require_access(normalized, action="exporting an auth profile")
         auth_root = Path(self.manager.settings.auth_root).resolve()
         profile_root = self.root()
         profile_dir = self.dir(normalized, create=False)
@@ -426,8 +439,11 @@ class BrowserAuthProfileService:
 
                 profile_name = self.normalize_name(top_level)
                 dest_dir = self.resolve_contained_path(profile_root, profile_name)
-                if dest_dir.exists() and not overwrite:
-                    raise FileExistsError(f"profile '{profile_name}' already exists; pass overwrite=true")
+                if dest_dir.exists():
+                    if not overwrite:
+                        raise FileExistsError(f"profile '{profile_name}' already exists; pass overwrite=true")
+                    # Overwriting is a write to somebody's stored logins.
+                    self.require_access(profile_name, action="overwriting an auth profile")
                 if dest_dir.exists():
                     shutil.rmtree(dest_dir)
 
@@ -482,6 +498,50 @@ class BrowserAuthProfileService:
             "profile_path": str(profile_root / profile_name),
             "imported": True,
         }
+
+    def owner_of(self, profile_name: str) -> str | None:
+        owner = self.read_metadata(self.normalize_name(profile_name)).get("owner")
+        return owner.strip() if isinstance(owner, str) and owner.strip() else None
+
+    @staticmethod
+    def verified_operator() -> str | None:
+        """The current operator, but only when it was actually proven.
+
+        `source: "header"` is a self-asserted label (see app/auth_policy.py), so
+        it can never grant access to a profile — anyone able to reach the API
+        could set it to any value.
+        """
+        operator = get_current_operator()
+        return operator.id if operator.source == "token" else None
+
+    def require_access(self, profile_name: str, *, action: str) -> str | None:
+        """Authorize this operator against a profile; return who now owns it.
+
+        A profile is owned only if it was saved by a caller with a proven
+        identity. Deployments using the shared `API_BEARER_TOKEN` therefore
+        record no owner and are unaffected, and profiles that pre-date this
+        release stay usable — ownership starts applying the moment named
+        credentials do, with no migration and no risk of locking anyone out of
+        their own logins.
+        """
+        normalized = self.normalize_name(profile_name)
+        owner = self.owner_of(normalized)
+        operator = self.verified_operator()
+        if owner is None:
+            return operator
+        if operator is not None and operator == owner:
+            return owner
+        raise PermissionError(
+            f"auth profile '{normalized}' belongs to operator '{owner}'; "
+            f"{action} requires authenticating as that operator"
+        )
+
+    def accessible(self, profile_name: str) -> bool:
+        try:
+            self.require_access(profile_name, action="access")
+        except PermissionError:
+            return False
+        return True
 
     def root(self) -> Path:
         root = Path(self.manager.settings.auth_root).resolve() / "profiles"

--- a/controller/app/browser/services/sessions.py
+++ b/controller/app/browser/services/sessions.py
@@ -84,6 +84,10 @@ class BrowserSessionService:
         context_kwargs = self.manager._build_context_kwargs(user_agent, proxy_server, proxy_username, proxy_password)
 
         if auth_profile:
+            # The takeover the report described: opening a session against
+            # someone else's stored profile drives a browser already logged in
+            # as them. Authorize before the state is ever loaded.
+            self.manager.auth_profiles.require_access(auth_profile, action="opening a session from an auth profile")
             source_path = self.manager.auth_profiles.resolve_state_path(auth_profile, must_exist=True)
         elif storage_state_path:
             source_path = self.manager.auth_profiles.safe_auth_path(storage_state_path, must_exist=True)

--- a/controller/app/codex_sandbox.py
+++ b/controller/app/codex_sandbox.py
@@ -1,0 +1,47 @@
+"""How the Codex CLI is allowed to execute on the host.
+
+Both Codex call paths — the `cli` provider adapter and the host bridge — passed
+`--dangerously-bypass-approvals-and-sandbox`, whose own help text reads "Skip all
+confirmation prompts and execute commands without sandboxing. EXTREMELY
+DANGEROUS. Intended solely for running in environments that are externally
+sandboxed." Reported in GHSA-xmh3-cw7j-9gp5: a model decision could run arbitrary
+commands on the host with no approval and no sandbox.
+
+Nothing about the work needs it. Both paths hand Codex a screenshot and a prompt
+and read back a JSON decision, in an ephemeral temp directory — Codex is being
+used as a vision model, not as a shell. So the default is now `-s read-only`, and
+the bypass survives only as a deliberate opt-in for people who really are running
+inside an externally sandboxed environment, which is the case its own help text
+describes.
+
+Failure mode if `read-only` turns out to be too strict for someone's setup: the
+Codex call fails loudly with Codex's own error, and one environment variable
+restores the previous behaviour. That is the right way round — the old default
+failed silently in the other direction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SANDBOX_MODES = ("read-only", "workspace-write", "danger-full-access")
+DEFAULT_SANDBOX_MODE = "read-only"
+
+BYPASS_FLAG = "--dangerously-bypass-approvals-and-sandbox"
+
+
+def codex_sandbox_flags(settings: Any) -> list[str]:
+    """The sandbox portion of a `codex exec` command line."""
+    return build_sandbox_flags(
+        allow_host_exec=bool(getattr(settings, "codex_allow_host_exec", False)),
+        sandbox_mode=str(getattr(settings, "codex_sandbox_mode", DEFAULT_SANDBOX_MODE) or DEFAULT_SANDBOX_MODE),
+    )
+
+
+def build_sandbox_flags(*, allow_host_exec: bool, sandbox_mode: str) -> list[str]:
+    if allow_host_exec:
+        return [BYPASS_FLAG]
+    mode = sandbox_mode.strip() or DEFAULT_SANDBOX_MODE
+    if mode not in SANDBOX_MODES:
+        raise ValueError(f"CODEX_SANDBOX_MODE must be one of {', '.join(SANDBOX_MODES)} (got {mode!r})")
+    return ["-s", mode]

--- a/controller/app/config.py
+++ b/controller/app/config.py
@@ -221,9 +221,14 @@ class Settings(BaseSettings):
     openai_cli_path: str = Field("codex", alias="OPENAI_CLI_PATH")
     openai_cli_model: str | None = Field(None, alias="OPENAI_CLI_MODEL")
     openai_host_bridge_socket: str = Field(
+    # How the Codex CLI is allowed to execute on the host. Both Codex paths used
+    # to pass --dangerously-bypass-approvals-and-sandbox unconditionally; they
+    # now run sandboxed unless a deployment opts back in. See app/codex_sandbox.py.
         "/data/host-bridge/codex.sock",
         alias="OPENAI_HOST_BRIDGE_SOCKET",
     )
+    codex_sandbox_mode: str = Field("read-only", alias="CODEX_SANDBOX_MODE")
+    codex_allow_host_exec: bool = Field(False, alias="CODEX_BRIDGE_ALLOW_HOST_EXEC")
 
     anthropic_api_key: str | None = Field(None, alias="ANTHROPIC_API_KEY")
     anthropic_base_url: str = Field("https://api.anthropic.com/v1", alias="ANTHROPIC_BASE_URL")

--- a/controller/app/config.py
+++ b/controller/app/config.py
@@ -11,6 +11,12 @@ from .stealth.fingerprint import CHROME_UA_POOL
 class Settings(BaseSettings):
     app_env: str = Field("development", validation_alias=AliasChoices("APP_ENV", "ENVIRONMENT"))
     api_bearer_token: str | None = Field(None, alias="API_BEARER_TOKEN")
+    # Whether this API is reachable off-box. Defaults to `exposed` on purpose:
+    # an undeclared deployment is assumed reachable and must carry a token, so a
+    # hand-rolled compose file that publishes on 0.0.0.0 fails closed. The base
+    # compose declares `loopback` to match its 127.0.0.1 publish mapping.
+    # See app/auth_policy.py.
+    api_bind_scope: Literal["loopback", "exposed"] = Field("exposed", alias="API_BIND_SCOPE")
     log_level: str = Field("INFO", alias="LOG_LEVEL")
     browser_ws_endpoint: str | None = Field(
         None,

--- a/controller/app/config.py
+++ b/controller/app/config.py
@@ -11,6 +11,11 @@ from .stealth.fingerprint import CHROME_UA_POOL
 class Settings(BaseSettings):
     app_env: str = Field("development", validation_alias=AliasChoices("APP_ENV", "ENVIRONMENT"))
     api_bearer_token: str | None = Field(None, alias="API_BEARER_TOKEN")
+    # Named credentials: `alice:token-a,bob:token-b`. A request authenticating
+    # against one of these has a *verified* operator identity, as opposed to the
+    # self-asserted X-Operator-Id header. The shared API_BEARER_TOKEN above
+    # still works and still leaves identity unverified.
+    api_bearer_tokens: str = Field("", alias="API_BEARER_TOKENS")
     # Whether this API is reachable off-box. Defaults to `exposed` on purpose:
     # an undeclared deployment is assumed reachable and must carry a token, so a
     # hand-rolled compose file that publishes on 0.0.0.0 fails closed. The base

--- a/controller/app/harness/induce.py
+++ b/controller/app/harness/induce.py
@@ -32,6 +32,14 @@ class SkillCandidate(BaseModel):
     cost_usd: float = 0.0
     model_tiers: dict[str, str] = Field(default_factory=dict)
     created_at: float = Field(default_factory=time.time)
+    # Whether the envelope carries a real signature. Without this, an unsigned
+    # envelope is just a dict that looks like a signed one — which is how a
+    # candidate could claim "signed provenance" while being unsigned.
+    signed: bool = False
+    # Induced from a mock trace: no browser ever ran. Recorded on the candidate,
+    # inside the provenance hash, and in the envelope, so a simulated skill
+    # cannot quietly present itself as a converged one.
+    simulated: bool = False
     files: dict[str, str] = Field(default_factory=dict)
     envelope: dict[str, Any] | None = None
 
@@ -73,6 +81,8 @@ class SkillInducer:
             attempts=attempts,
             cost_usd=cost_usd,
             model_tiers={key: value for key, value in (model_tiers or {}).items() if value},
+            signed=self.signer is not None,
+            simulated=str(trace.metadata.get("mode") or "").lower() == "mock",
         )
         skill_md = _render_skill_markdown(contract, candidate, verification)
         helper_py = _render_helper(contract)
@@ -85,6 +95,7 @@ class SkillInducer:
                 "trace_hash": trace_hash,
                 "event_count": len(trace.events),
                 "evidence": trace.evidence,
+                "simulated": candidate.simulated,
             },
             "verification": verification.model_dump(mode="json"),
         }
@@ -107,12 +118,16 @@ class SkillInducer:
                 "model_tiers": candidate.model_tiers,
                 "validated_executor_model": candidate.model_tiers.get("executor", ""),
                 "credential_free": True,
+                "simulated": candidate.simulated,
             },
         }
         if self.signer is not None:
             candidate.envelope = self.signer(envelope_payload)
         else:
-            candidate.envelope = envelope_payload
+            # Say so, in the artifact itself. An unsigned payload that is shaped
+            # exactly like a signed one is how "signed provenance" becomes a
+            # claim nobody can check.
+            candidate.envelope = {**envelope_payload, "signed": False}
 
         files = {
             "SKILL.md": skill_md,

--- a/controller/app/harness/iterate.py
+++ b/controller/app/harness/iterate.py
@@ -95,13 +95,16 @@ class HarnessService:
         *,
         verifier: VerifierAdapter | None = None,
         signer=None,
+        envelope_verifier=None,
         model_tiers: dict[str, str] | None = None,
     ):
         self.store = HarnessRunStore(root)
         self.verifier = verifier or ProgrammaticVerifier()
         self.model_tiers = {key: value for key, value in (model_tiers or {}).items() if value}
         self.inducer = SkillInducer(self.store.staging_root, signer=signer)
-        self.registry = SkillStagingRegistry(self.store.staging_root)
+        # Signing without a matching check is decoration; the registry gets the
+        # counterpart to whatever the inducer signs with.
+        self.registry = SkillStagingRegistry(self.store.staging_root, verifier=envelope_verifier)
         self.drift_monitor = SkillDriftMonitor(self.registry, verifier=self.verifier)
 
     async def start_convergence(

--- a/controller/app/harness/register.py
+++ b/controller/app/harness/register.py
@@ -2,16 +2,34 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from .induce import SkillCandidate
 
 logger = logging.getLogger(__name__)
 
+# Takes a stored envelope, returns the payload it attests to, raises if invalid.
+Verifier = Callable[[dict[str, Any]], dict[str, Any]]
+
 
 class SkillStagingRegistry:
-    def __init__(self, staging_root: str | Path):
+    """Staged skill candidates, read back with their signatures checked.
+
+    Induction could sign a candidate envelope, but nothing on the read side ever
+    verified one — so a signature was an assertion the artifact made about
+    itself, exactly like the pre-1.6.0 witness chain. Anyone who could write to
+    the staging root could edit a staged skill, or drop in a new one, and it
+    would be served as a governed, provenance-carrying candidate
+    (GHSA-xmh3-cw7j-9gp5).
+
+    `verifier` takes the stored envelope and returns the payload it actually
+    attests to, raising if it does not verify. When one is configured, a
+    candidate that fails to verify is refused rather than downgraded.
+    """
+
+    def __init__(self, staging_root: str | Path, verifier: Verifier | None = None):
         self.staging_root = Path(staging_root)
+        self.verifier = verifier
 
     def list_candidates(self) -> list[dict[str, Any]]:
         if not self.staging_root.exists():
@@ -19,17 +37,45 @@ class SkillStagingRegistry:
         candidates: list[dict[str, Any]] = []
         for path in sorted(self.staging_root.glob("*/candidate.json")):
             try:
-                candidates.append(SkillCandidate.model_validate_json(path.read_text(encoding="utf-8")).model_dump())
+                candidate = SkillCandidate.model_validate_json(path.read_text(encoding="utf-8"))
             except Exception as exc:
                 logger.debug("skipping unreadable staged skill candidate %s: %s", path, exc)
                 continue
+            try:
+                self._verify(candidate)
+            except PermissionError as exc:
+                logger.warning("skipping unverifiable staged skill candidate %s: %s", path, exc)
+                continue
+            candidates.append(candidate.model_dump())
         return candidates
 
     def get_candidate(self, skill_id: str) -> SkillCandidate:
         path = self._candidate_path(skill_id)
         if not path.exists():
             raise KeyError(skill_id)
-        return SkillCandidate.model_validate_json(path.read_text(encoding="utf-8"))
+        candidate = SkillCandidate.model_validate_json(path.read_text(encoding="utf-8"))
+        self._verify(candidate)
+        return candidate
+
+    def _verify(self, candidate: SkillCandidate) -> None:
+        if self.verifier is None:
+            # Nothing was ever signed in this deployment, so there is nothing to
+            # check. `candidate.signed` still records which it was.
+            return
+        envelope = candidate.envelope
+        if not envelope or envelope.get("signed") is False:
+            raise PermissionError(f"staged skill candidate {candidate.skill_id} carries no signature")
+        try:
+            payload = self.verifier(envelope)
+        except Exception as exc:
+            raise PermissionError(f"staged skill candidate {candidate.skill_id} failed signature check: {exc}") from exc
+        for field, expected in (("contract_hash", candidate.contract_hash), ("trace_hash", candidate.trace_hash)):
+            if payload.get(field) != expected:
+                # A valid signature over a different candidate is still a forged
+                # candidate, so the envelope has to match the artifact it sits in.
+                raise PermissionError(
+                    f"staged skill candidate {candidate.skill_id} does not match its signed envelope ({field})"
+                )
 
     def candidate_dir(self, skill_id: str) -> Path:
         path = self._candidate_path(skill_id).parent
@@ -60,3 +106,15 @@ def mesh_identity_signer(identity) -> Any:
         return envelope.model_dump(mode="json")
 
     return sign
+
+
+def mesh_identity_verifier(identity) -> Verifier:
+    """Counterpart to mesh_identity_signer: check what induction signed."""
+    from app.mesh.models import PeerRecord, SignedEnvelope
+    from app.mesh.transport import verify_envelope
+
+    def verify(envelope: dict[str, Any]) -> dict[str, Any]:
+        peer = PeerRecord(node_id=identity.node_id, pubkey_b64=identity.pubkey_b64)
+        return verify_envelope(SignedEnvelope.model_validate(envelope), peer, expected_recipient_node_id="")
+
+    return verify

--- a/controller/app/middleware/http.py
+++ b/controller/app/middleware/http.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from ..audit import reset_current_operator, set_current_operator
+from ..auth_policy import AuthPolicy, policy_for_scope, resolve_bind_scope
 from ..rate_limits import build_rate_limit_key, is_exempt_path
 
 
@@ -18,6 +19,16 @@ def install_controller_http_middleware(
     rate_limiter: Any,
     metrics: Any,
 ) -> None:
+    # Where this API is reachable from is fixed by the deployment, so it is
+    # resolved once. Whether a request is authenticated is then one function of
+    # that scope and the configured credential — the same function for the auth
+    # gate and the rate limiter, rather than each layer re-deciding from the
+    # presence of a token (GHSA-xmh3-cw7j-9gp5).
+    bind_scope = resolve_bind_scope(settings)
+
+    def _auth_policy() -> AuthPolicy:
+        return policy_for_scope(bind_scope, settings.api_bearer_token)
+
     def _has_valid_bearer_token(request: Request) -> bool:
         """Whether this request has proven it holds the configured bearer token.
 
@@ -26,8 +37,13 @@ def install_controller_http_middleware(
         traffic is exactly what must be throttled) and so cannot assume the
         caller is who their headers claim.
         """
-        if not settings.api_bearer_token:
+        if not _auth_policy().required:
             return True
+        if not settings.api_bearer_token:
+            # Auth is required and there is no credential that could satisfy it.
+            # Startup refuses this configuration; if it is somehow reached, the
+            # answer is "no", never "everyone".
+            return False
         header = request.headers.get("authorization", "")
         expected = f"Bearer {settings.api_bearer_token}"
         return hmac.compare_digest(header.encode(), expected.encode())
@@ -35,7 +51,7 @@ def install_controller_http_middleware(
     @application.middleware("http")
     async def require_api_bearer_token(request: Request, call_next):
         path = _request_path(request)
-        if not settings.api_bearer_token or _is_bearer_token_exempt_path(path):
+        if not _auth_policy().required or _is_bearer_token_exempt_path(path):
             return await call_next(request)
 
         if not _has_valid_bearer_token(request):

--- a/controller/app/middleware/http.py
+++ b/controller/app/middleware/http.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import hmac
+import logging
 import time
 from typing import Any
 
@@ -8,8 +8,17 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from ..audit import reset_current_operator, set_current_operator
-from ..auth_policy import AuthPolicy, policy_for_scope, resolve_bind_scope
+from ..auth_policy import (
+    AuthPolicy,
+    Credential,
+    credentials_for,
+    match_credential,
+    policy_for_scope,
+    resolve_bind_scope,
+)
 from ..rate_limits import build_rate_limit_key, is_exempt_path
+
+logger = logging.getLogger(__name__)
 
 
 def install_controller_http_middleware(
@@ -27,7 +36,10 @@ def install_controller_http_middleware(
     bind_scope = resolve_bind_scope(settings)
 
     def _auth_policy() -> AuthPolicy:
-        return policy_for_scope(bind_scope, settings.api_bearer_token)
+        return policy_for_scope(bind_scope, credentials_for(settings))
+
+    def _matched_credential(request: Request) -> Credential | None:
+        return match_credential(credentials_for(settings), request.headers.get("authorization", ""))
 
     def _has_valid_bearer_token(request: Request) -> bool:
         """Whether this request has proven it holds the configured bearer token.
@@ -37,16 +49,15 @@ def install_controller_http_middleware(
         traffic is exactly what must be throttled) and so cannot assume the
         caller is who their headers claim.
         """
-        if not _auth_policy().required:
+        policy = _auth_policy()
+        if not policy.required:
             return True
-        if not settings.api_bearer_token:
+        if not policy.has_credential:
             # Auth is required and there is no credential that could satisfy it.
             # Startup refuses this configuration; if it is somehow reached, the
             # answer is "no", never "everyone".
             return False
-        header = request.headers.get("authorization", "")
-        expected = f"Bearer {settings.api_bearer_token}"
-        return hmac.compare_digest(header.encode(), expected.encode())
+        return _matched_credential(request) is not None
 
     @application.middleware("http")
     async def require_api_bearer_token(request: Request, call_next):
@@ -117,8 +128,29 @@ def install_controller_http_middleware(
             "/ui",
             "/mesh/receive",
         )
-        operator_id = request.headers.get(settings.operator_id_header)
+        asserted_id = request.headers.get(settings.operator_id_header)
         operator_name = request.headers.get(settings.operator_name_header)
+
+        # A named credential proves who the caller is. The header only ever
+        # claims it, so when the two disagree the credential wins and the claim
+        # is recorded — a caller asserting someone else's id belongs in the
+        # audit trail, not in the identity.
+        credential = _matched_credential(request)
+        if credential is not None and credential.verifies_identity:
+            operator_id = credential.operator_id
+            source = "token"
+            conflicting = asserted_id if asserted_id and asserted_id != operator_id else None
+            if conflicting:
+                logger.warning(
+                    "operator header %s=%r conflicts with the authenticated operator %r; using the credential",
+                    settings.operator_id_header,
+                    conflicting,
+                    operator_id,
+                )
+        else:
+            operator_id = asserted_id
+            source = "header"
+            conflicting = None
 
         if settings.require_operator_id and not path.startswith(exempt_prefixes) and not operator_id:
             return JSONResponse(
@@ -128,7 +160,12 @@ def install_controller_http_middleware(
                 },
             )
 
-        token = set_current_operator(operator_id, name=operator_name, source="header")
+        token = set_current_operator(
+            operator_id,
+            name=operator_name,
+            source=source,
+            asserted_id=conflicting,
+        )
         try:
             return await call_next(request)
         finally:

--- a/controller/app/models.py
+++ b/controller/app/models.py
@@ -480,7 +480,14 @@ class ApprovalDecisionRequest(StrictInputModel):
 class OperatorIdentity(BaseModel):
     id: str
     name: str | None = None
+    # "token" — proven by a named bearer credential. "header" — asserted by the
+    # caller and not verified. "anonymous" — not claimed at all. Authorization
+    # may only ever rely on "token"; the other two are attribution.
     source: str = "anonymous"
+    # What X-Operator-Id claimed, when it disagreed with the verified identity.
+    # Recorded rather than dropped: a caller asserting someone else's id is a
+    # fact worth having in the audit trail.
+    asserted_id: str | None = None
 
 
 class WitnessRemoteState(BaseModel):

--- a/controller/app/providers/openai_adapter.py
+++ b/controller/app/providers/openai_adapter.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 
+from ..codex_sandbox import codex_sandbox_flags
 from ..models import BrowserActionDecision
 from .base import BaseProviderAdapter, ProviderAPIError, ProviderDecision
 
@@ -206,11 +207,10 @@ class OpenAIAdapter(BaseProviderAdapter):
                 command.extend(["--model", model])
             for override in config_overrides:
                 command.extend(["-c", override])
+            command.extend(["exec", "--skip-git-repo-check"])
+            command.extend(codex_sandbox_flags(self.settings))
             command.extend(
                 [
-                    "exec",
-                    "--skip-git-repo-check",
-                    "--dangerously-bypass-approvals-and-sandbox",
                     "--cd",
                     tempdir,
                     "--ephemeral",

--- a/controller/app/routes/auth_profiles.py
+++ b/controller/app/routes/auth_profiles.py
@@ -30,6 +30,8 @@ def create_auth_profiles_router(*, manager: Any, settings: Any) -> APIRouter:
             return await manager.get_auth_profile(profile_name)
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid request") from None
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="Not permitted") from None
 
     @router.post("/sessions/{session_id}/storage-state")
     async def save_storage_state(session_id: str, payload: SaveStorageStateRequest) -> dict[str, Any]:
@@ -54,6 +56,10 @@ def create_auth_profiles_router(*, manager: Any, settings: Any) -> APIRouter:
             result = await manager.export_auth_profile(safe_profile_name)
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail="Not found") from None
+        except PermissionError:
+            # Must precede the catch-all below, which would otherwise turn a
+            # refusal to hand over someone else's cookies into a 500.
+            raise HTTPException(status_code=403, detail="Not permitted") from None
         except Exception:
             raise internal_error(logger, "auth profile export failed for profile %s", profile_name) from None
 

--- a/controller/app/runtime_policy.py
+++ b/controller/app/runtime_policy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from shutil import which
 from urllib.parse import urlparse
 
+from .auth_policy import BIND_SCOPE_EXPOSED, resolve_bind_scope
 from .config import Settings
 from .providers.base import BaseProviderAdapter
 
@@ -129,27 +130,48 @@ def _validate_provider_runtime(settings: Settings, report: RuntimePolicyReport) 
         )
 
 
-def validate_runtime_policy(settings: Settings) -> RuntimePolicyReport:
-    report = RuntimePolicyReport()
+def _validate_api_authentication(settings: Settings, report: RuntimePolicyReport) -> None:
+    """The API must carry a token whenever it is reachable, or in production.
 
-    if not settings.is_production:
+    Reachability is the load-bearing half. `APP_ENV=production` was the only
+    trigger until 1.7.0, and shipped compose defaulted it to `development`, so
+    the check that was supposed to guarantee authentication never ran on the
+    configuration people actually deployed.
+    """
+    scope = resolve_bind_scope(settings)
+    exposed = scope == BIND_SCOPE_EXPOSED
+    if not (exposed or settings.is_production):
         if not settings.api_bearer_token:
             report.warnings.append(
                 "API_BEARER_TOKEN is unset; the controller serves every route unauthenticated. "
-                "Set it before exposing this instance on a non-loopback address."
+                "That is allowed only because API_BIND_SCOPE=loopback declares this instance "
+                "unreachable off-box — set a token before publishing it anywhere else."
             )
-        return report
+        return
 
+    trigger = "the API is reachable off-box (API_BIND_SCOPE=exposed)" if exposed else "APP_ENV=production"
     if not settings.api_bearer_token:
-        report.errors.append("API_BEARER_TOKEN is required when APP_ENV=production")
+        report.errors.append(
+            f"API_BEARER_TOKEN is required when {trigger}. Set a token, or set "
+            "API_BIND_SCOPE=loopback if this instance is only published on 127.0.0.1."
+        )
     elif len(settings.api_bearer_token) < MIN_PRODUCTION_BEARER_TOKEN_LENGTH:
         # "Required" was satisfied by API_BEARER_TOKEN=x. A one-character token
         # is not meaningfully different from no token, and unauthenticated
         # requests are only throttled per-IP, so a weak token is guessable.
         report.errors.append(
             f"API_BEARER_TOKEN must be at least {MIN_PRODUCTION_BEARER_TOKEN_LENGTH} characters "
-            f"when APP_ENV=production (got {len(settings.api_bearer_token)})"
+            f"when {trigger} (got {len(settings.api_bearer_token)})"
         )
+
+
+def validate_runtime_policy(settings: Settings) -> RuntimePolicyReport:
+    report = RuntimePolicyReport()
+
+    _validate_api_authentication(settings, report)
+
+    if not settings.is_production:
+        return report
 
     if not settings.share_token_secret:
         # There is no flag that disables sharing, so the endpoint is always

--- a/controller/app/runtime_policy.py
+++ b/controller/app/runtime_policy.py
@@ -177,6 +177,13 @@ def validate_runtime_policy(settings: Settings) -> RuntimePolicyReport:
 
     _validate_api_authentication(settings, report)
 
+    if getattr(settings, "codex_allow_host_exec", False):
+        report.warnings.append(
+            "CODEX_BRIDGE_ALLOW_HOST_EXEC is set; Codex runs with approvals and sandboxing "
+            "disabled, so a model decision can execute arbitrary commands on the host. Only "
+            "use this inside an environment that is itself sandboxed."
+        )
+
     if not settings.is_production:
         return report
 

--- a/controller/app/runtime_policy.py
+++ b/controller/app/runtime_policy.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from shutil import which
 from urllib.parse import urlparse
 
-from .auth_policy import BIND_SCOPE_EXPOSED, resolve_bind_scope
+from .auth_policy import BIND_SCOPE_EXPOSED, credentials_for, resolve_bind_scope
 from .config import Settings
 from .providers.base import BaseProviderAdapter
 
@@ -150,18 +150,25 @@ def _validate_api_authentication(settings: Settings, report: RuntimePolicyReport
         return
 
     trigger = "the API is reachable off-box (API_BIND_SCOPE=exposed)" if exposed else "APP_ENV=production"
-    if not settings.api_bearer_token:
+    credentials = credentials_for(settings)
+    if not credentials:
         report.errors.append(
             f"API_BEARER_TOKEN is required when {trigger}. Set a token, or set "
             "API_BIND_SCOPE=loopback if this instance is only published on 127.0.0.1."
         )
-    elif len(settings.api_bearer_token) < MIN_PRODUCTION_BEARER_TOKEN_LENGTH:
-        # "Required" was satisfied by API_BEARER_TOKEN=x. A one-character token
-        # is not meaningfully different from no token, and unauthenticated
-        # requests are only throttled per-IP, so a weak token is guessable.
+        return
+
+    # "Required" was satisfied by API_BEARER_TOKEN=x. A one-character token is
+    # not meaningfully different from no token, and unauthenticated requests are
+    # only throttled per-IP, so a weak token is guessable. Every credential has
+    # to clear the floor — one weak entry in API_BEARER_TOKENS is a way in.
+    for credential in credentials:
+        if len(credential.token) >= MIN_PRODUCTION_BEARER_TOKEN_LENGTH:
+            continue
+        name = f"the token for operator '{credential.operator_id}'" if credential.operator_id else "API_BEARER_TOKEN"
         report.errors.append(
-            f"API_BEARER_TOKEN must be at least {MIN_PRODUCTION_BEARER_TOKEN_LENGTH} characters "
-            f"when {trigger} (got {len(settings.api_bearer_token)})"
+            f"{name} must be at least {MIN_PRODUCTION_BEARER_TOKEN_LENGTH} characters "
+            f"when {trigger} (got {len(credential.token)})"
         )
 
 

--- a/controller/app/startup/extensions.py
+++ b/controller/app/startup/extensions.py
@@ -110,7 +110,7 @@ def _init_mesh(app) -> None:
 def _init_harness(app) -> None:
     try:
         from app.harness.iterate import HarnessService
-        from app.harness.register import mesh_identity_signer
+        from app.harness.register import mesh_identity_signer, mesh_identity_verifier
 
         settings = getattr(app.state, "settings", None)
         root = Path(getattr(settings, "harness_root", None) or os.environ.get("HARNESS_ROOT", "/data/harness"))
@@ -120,6 +120,7 @@ def _init_harness(app) -> None:
             root,
             verifier=_build_harness_verifier(settings),
             signer=signer,
+            envelope_verifier=mesh_identity_verifier(identity) if identity is not None else None,
             model_tiers=_harness_model_tiers(settings),
         )
         app.state.harness_service = service

--- a/controller/app/version.py
+++ b/controller/app/version.py
@@ -4,4 +4,4 @@ Bump together with the package versions in */pyproject.toml and
 browser-node/package.json during release prep.
 """
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"

--- a/controller/app/witness.py
+++ b/controller/app/witness.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import threading
 from hashlib import sha256
 from pathlib import Path
 from typing import Any, Literal
@@ -13,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from .models import OperatorIdentity, ProtectionMode
 from .utils import utc_now
+from .witness_anchor import compare_to_anchor, exclusive_lock, read_anchor, read_tail_line, write_anchor
 from .witness_signing import SIGNATURE_ALGORITHM
 
 logger = logging.getLogger(__name__)
@@ -284,6 +287,12 @@ class WitnessRecorder:
     def __init__(self, root: str | Path, *, signer: Any = None):
         self.root = Path(root)
         self._lock = asyncio.Lock()
+        # Three scopes, because each covers what the next cannot: the asyncio
+        # lock orders tasks on one event loop, this one orders threads inside
+        # this process (appends run in a worker thread, and Windows byte-range
+        # locks are owned per process, so two threads contending for the file
+        # lock deadlock rather than queue), and the file lock orders processes.
+        self._thread_lock = threading.Lock()
         self._heads: dict[str, str] = {}
         self.signer = signer
 
@@ -302,10 +311,23 @@ class WitnessRecorder:
     async def append(self, scope: str, receipt: WitnessReceipt) -> WitnessReceipt:
         async with self._lock:
             path = self._path(scope)
-            previous = self._heads.get(scope) or await asyncio.to_thread(self._read_last_hash, path)
             item = receipt.model_copy(deep=True)
             item.scope = scope
-            item.chain_prev_hash = previous
+            # Reading the head, signing, and appending are one critical section
+            # under a lock on the chain file. The asyncio lock above only orders
+            # this process; two workers on a shared volume could otherwise read
+            # the same head and write two receipts claiming the same
+            # predecessor, forking the chain.
+            item = await asyncio.to_thread(self._append_locked, path, item)
+            self._heads[scope] = item.chain_hash
+            return item
+
+    def _append_locked(self, path: Path, item: WitnessReceipt) -> WitnessReceipt:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with self._thread_lock, open(path, "a+", encoding="utf-8") as handle, exclusive_lock(handle):
+            last_line = read_tail_line(handle)
+            item.chain_prev_hash = WitnessReceipt.model_validate_json(last_line).chain_hash if last_line else None
+            previous_count = self._previous_count(path, handle, item.chain_prev_hash)
             item.chain_hash = self._compute_hash(item)
             if self.signer is not None:
                 try:
@@ -318,9 +340,32 @@ class WitnessRecorder:
                     # false assurance signing exists to remove. verify() reports
                     # unsigned receipts, so the gap stays visible downstream.
                     logger.exception("witness: failed to sign receipt %s; recording it unsigned", item.receipt_id)
-            await asyncio.to_thread(self._append_text, path, item.model_dump_json() + "\n")
-            self._heads[scope] = item.chain_hash
-            return item
+            handle.seek(0, os.SEEK_END)
+            handle.write(item.model_dump_json() + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            write_anchor(path, head_hash=item.chain_hash, receipt_count=previous_count + 1)
+        return item
+
+    @staticmethod
+    def _previous_count(path: Path, handle: Any, previous_hash: str | None) -> int:
+        """How many receipts precede this one.
+
+        Read through the already-open handle, never a second one: a Windows
+        byte-range lock excludes every other handle, including this process's
+        own, so reopening the chain inside the lock fails with EACCES.
+
+        The anchor supplies the count in the steady state; a full count is only
+        needed when the anchor is missing or stale, which is a chain written
+        before this release or one appended to by an older build.
+        """
+        if previous_hash is None:
+            return 0
+        anchor = read_anchor(path)
+        if anchor and anchor.get("head_hash") == previous_hash and isinstance(anchor.get("receipt_count"), int):
+            return anchor["receipt_count"]
+        handle.seek(0)
+        return sum(1 for line in handle if line.strip())
 
     async def list(self, scope: str, *, limit: int = 100) -> list[WitnessReceipt]:
         return await asyncio.to_thread(self._list_sync, self._path(scope), limit)
@@ -469,6 +514,20 @@ class WitnessRecorder:
                 result["signed_count"] += 1
             else:
                 result["unsigned_count"] += 1
+
+        # Signing cannot detect tail truncation: drop the last k receipts and
+        # what remains is a shorter chain whose signatures all still verify. The
+        # anchor is a separate record of where the chain had got to, so a short
+        # chain stops being indistinguishable from a complete one.
+        anchor = compare_to_anchor(
+            path,
+            head_hash=result["head_hash"],
+            receipt_count=result["receipt_count"],
+        )
+        result["anchor"] = anchor
+        if anchor["status"] in {"truncated", "diverged"}:
+            result["valid"] = False
+            result["reason"] = anchor.get("reason")
         return result
 
     @staticmethod

--- a/controller/app/witness_anchor.py
+++ b/controller/app/witness_anchor.py
@@ -1,0 +1,148 @@
+"""Cross-process append locking, and an anchor that makes truncation visible.
+
+Two limits `witness_signing.py` documented in 1.6.0, both addressed here.
+
+**Chain forking.** `WitnessRecorder` serialised appends with an `asyncio.Lock`,
+which is process-local. Two workers — `AGENT_JOB_WORKER_COUNT > 1`, several
+uvicorn workers, or two replicas on a shared volume — could read the same head
+and write two receipts claiming the same predecessor. That is a correctness bug,
+not a limit, so the read-head-and-append critical section now runs under an
+OS-level lock on the chain file itself.
+
+**Tail truncation.** Signing cannot detect it: drop the last k receipts and what
+remains is a shorter chain whose signatures all still verify. Detecting it needs
+a record kept somewhere the chain is not, so each append also updates a small
+anchor file holding the head hash and receipt count. `verify()` compares the two.
+
+An attacker who rewrites the anchor as well as the chain still defeats this —
+that is what an *external* anchor is for, and the anchor file is deliberately a
+separate artifact so one can be shipped elsewhere without changing the shape of
+this. It is strictly better than "undetectable", and it needs no third party.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import IO, Any, Iterator
+
+# How much of the chain tail to read when looking for the last receipt. Reading
+# the whole file per append was O(n) in chain length; a receipt is well under
+# this, so one read finds the last line in every realistic case.
+TAIL_READ_BYTES = 64 * 1024
+
+try:  # POSIX — the container
+    import fcntl
+
+    _HAVE_FCNTL = True
+except ImportError:  # Windows — developer machines
+    fcntl = None  # type: ignore[assignment]
+    _HAVE_FCNTL = False
+
+if not _HAVE_FCNTL:
+    import msvcrt
+
+
+@contextmanager
+def exclusive_lock(handle: IO[Any]) -> Iterator[None]:
+    """Hold an exclusive OS lock on an open file for the block's duration.
+
+    Blocking on purpose: appends are short, and an append that gave up would
+    either lose a receipt or fork the chain, which are the two outcomes this
+    exists to prevent.
+    """
+    if _HAVE_FCNTL:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return
+
+    handle.seek(0, os.SEEK_END)
+    position = handle.tell()
+    handle.seek(0)
+    # Windows locks a byte range rather than the file. Byte 0 is arbitrary but
+    # consistent, so every process contends for the same range.
+    msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    try:
+        yield
+    finally:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        handle.seek(position)
+
+
+def read_tail_line(handle: IO[Any]) -> str | None:
+    """The last non-empty line of an open text file, without reading all of it."""
+    handle.seek(0, os.SEEK_END)
+    size = handle.tell()
+    if size == 0:
+        return None
+    start = max(0, size - TAIL_READ_BYTES)
+    handle.seek(start)
+    chunk = handle.read()
+    lines = [line for line in chunk.splitlines() if line.strip()]
+    if not lines:
+        return None
+    if start > 0 and len(lines) == 1:
+        # The tail window landed mid-record; fall back to a full read rather
+        # than returning a fragment that would not parse.
+        handle.seek(0)
+        lines = [line for line in handle.read().splitlines() if line.strip()]
+    return lines[-1] if lines else None
+
+
+def anchor_path(chain_path: Path) -> Path:
+    return chain_path.with_suffix(chain_path.suffix + ".anchor.json")
+
+
+def write_anchor(chain_path: Path, *, head_hash: str, receipt_count: int) -> None:
+    payload = {"head_hash": head_hash, "receipt_count": receipt_count}
+    path = anchor_path(chain_path)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def read_anchor(chain_path: Path) -> dict[str, Any] | None:
+    path = anchor_path(chain_path)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def compare_to_anchor(chain_path: Path, *, head_hash: str | None, receipt_count: int) -> dict[str, Any]:
+    """How the chain on disk stands against its anchor.
+
+    `status` is `"unanchored"` for chains written before this release — absence
+    of an anchor is not evidence of tampering, and must not be reported as if it
+    were.
+    """
+    anchor = read_anchor(chain_path)
+    if anchor is None:
+        return {"status": "unanchored", "expected_head_hash": None, "expected_receipt_count": None}
+
+    expected_head = anchor.get("head_hash")
+    expected_count = anchor.get("receipt_count")
+    result = {
+        "status": "ok",
+        "expected_head_hash": expected_head,
+        "expected_receipt_count": expected_count,
+    }
+    if isinstance(expected_count, int) and receipt_count < expected_count:
+        result["status"] = "truncated"
+        result["reason"] = (
+            f"chain holds {receipt_count} receipts but the anchor records {expected_count}; "
+            "receipts have been removed from the end"
+        )
+    elif expected_head and head_hash != expected_head:
+        result["status"] = "diverged"
+        result["reason"] = "chain head does not match the anchor; the chain was rewritten or forked"
+    return result

--- a/controller/app/witness_signing.py
+++ b/controller/app/witness_signing.py
@@ -12,9 +12,15 @@ receipt and its whole history up to that point.
 Deliberately not solved here — state it rather than let a reader assume it:
 
 * **Tail truncation.** Dropping the last k receipts leaves a shorter chain whose
-  every signature is still valid. Detecting that needs an external anchor (a
-  published head, a countersigning peer). `verify()` reports the signed head so
-  a caller holding a previously-published head can check for themselves.
+  every signature is still valid — signing cannot see it at all. Since 1.7.0 an
+  anchor file kept beside each chain records the head hash and receipt count on
+  every append, and `verify()` compares the two, so truncation is detected
+  without any third party (`app/witness_anchor.py`). An attacker who rewrites the
+  anchor along with the chain still defeats it: that is what a genuinely
+  *external* anchor — a published head, a countersigning peer — is for, and the
+  anchor is a separate artifact precisely so one can be shipped elsewhere.
+  `verify()` also still reports the signed head for a caller holding a
+  previously published one.
 * **Key compromise.** A holder of the private key can rewrite history and
   re-sign it. This raises the bar from "anyone with the file" to "anyone with
   the key", which is the point, but it is not tamper-proof storage.

--- a/controller/conftest.py
+++ b/controller/conftest.py
@@ -1,7 +1,15 @@
 """pytest configuration — ensure app package is importable from tests."""
 
+import os
 import sys
 from pathlib import Path
 
 # Add controller directory to sys.path so `from app.xxx import ...` works
 sys.path.insert(0, str(Path(__file__).parent))
+
+# API_BIND_SCOPE defaults to `exposed` so that an undeclared deployment fails
+# closed (app/auth_policy.py). A TestClient run is loopback by construction and
+# never publishes anything, so the suite declares that rather than inheriting a
+# production-safety default it does not model. Tests that exercise the exposed
+# path build their own Settings and must not rely on this.
+os.environ.setdefault("API_BIND_SCOPE", "loopback")

--- a/controller/conftest.py
+++ b/controller/conftest.py
@@ -1,15 +1,10 @@
 """pytest configuration — ensure app package is importable from tests."""
 
-import os
 import sys
 from pathlib import Path
 
 # Add controller directory to sys.path so `from app.xxx import ...` works
 sys.path.insert(0, str(Path(__file__).parent))
 
-# API_BIND_SCOPE defaults to `exposed` so that an undeclared deployment fails
-# closed (app/auth_policy.py). A TestClient run is loopback by construction and
-# never publishes anything, so the suite declares that rather than inheriting a
-# production-safety default it does not model. Tests that exercise the exposed
-# path build their own Settings and must not rely on this.
-os.environ.setdefault("API_BIND_SCOPE", "loopback")
+# The suite's environment defaults live in tests/__init__.py, which ships in
+# the controller image; conftest.py does not.

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "auto-browser-controller"
-version = "1.6.1"
+version = "1.7.0"
 description = "Controller API for auto-browser"
 # 3.11, not 3.10: CI tests 3.11 and 3.14, the Dockerfile pins python:3.11-slim,
 # and the published packages were corrected to >=3.11 in 1.5.2. A floor nothing

--- a/controller/tests/__init__.py
+++ b/controller/tests/__init__.py
@@ -1,1 +1,18 @@
+"""Test-suite defaults that must hold wherever the suite runs.
 
+The controller image COPYs `app/` and `tests/` and nothing else — not
+`conftest.py` — so anything the suite needs in the Docker `controller-tests` job
+has to live inside this package. Putting it in conftest.py instead produced 147
+failures in a container-shaped run while passing on the host, which is the same
+shape as the August-2026 finding that the Docker job silently ran 566 of 637
+tests.
+"""
+
+import os
+
+# API_BIND_SCOPE defaults to `exposed` so that an undeclared deployment fails
+# closed (app/auth_policy.py). A TestClient run is loopback by construction and
+# publishes nothing, so the suite declares that rather than inheriting a
+# production-safety default it does not model. Tests that exercise the exposed
+# path build their own Settings and must not rely on this.
+os.environ.setdefault("API_BIND_SCOPE", "loopback")

--- a/controller/tests/test_api_bind_scope_auth.py
+++ b/controller/tests/test_api_bind_scope_auth.py
@@ -1,0 +1,224 @@
+"""Authentication is required whenever the API is reachable off-box.
+
+GHSA-xmh3-cw7j-9gp5: the controller shipped an unauthenticated control plane
+because every layer that could have required a token failed open, and the one
+hard check was gated on `APP_ENV=production` while compose defaulted `APP_ENV`
+to `development`. The regression test that matters is therefore a *development*
+configuration that is reachable: it must refuse to start.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.auth_policy import (
+    BIND_SCOPE_EXPOSED,
+    BIND_SCOPE_LOOPBACK,
+    is_loopback_host,
+    resolve_auth_policy,
+    resolve_bind_scope,
+)
+from app.config import Settings
+from app.middleware.http import install_controller_http_middleware
+from app.runtime_policy import MIN_PRODUCTION_BEARER_TOKEN_LENGTH, validate_runtime_policy
+
+STRONG_TOKEN = "t" * MIN_PRODUCTION_BEARER_TOKEN_LENGTH
+
+
+def settings(**overrides) -> Settings:
+    """A real Settings instance built the way the rest of the suite builds one.
+
+    Fields carry aliases, so `Settings(...)` takes the UPPER_CASE alias — passing
+    the snake_case field name is silently ignored, which is a trap worth failing
+    loudly on rather than writing a test that quietly asserts the default.
+    """
+    return Settings(_env_file=None, **overrides)
+
+
+def undeclared(scope: str = BIND_SCOPE_EXPOSED, **fields) -> SimpleNamespace:
+    """A settings stand-in whose bind scope is the default, not a declaration.
+
+    `Settings()` would inherit `API_BIND_SCOPE` from the ambient environment —
+    conftest sets it — and that is exactly the distinction under test here, so
+    these cases state `model_fields_set` directly instead.
+    """
+    return SimpleNamespace(api_bind_scope=scope, model_fields_set=frozenset(), **fields)
+
+
+class BindScopeResolutionTests(unittest.TestCase):
+    def test_explicit_scope_wins_over_the_environment(self) -> None:
+        resolved = resolve_bind_scope(
+            settings(API_BIND_SCOPE=BIND_SCOPE_EXPOSED),
+            {"HOST": "127.0.0.1"},
+        )
+        self.assertEqual(resolved, BIND_SCOPE_EXPOSED)
+
+    def test_an_env_provided_scope_counts_as_explicit(self) -> None:
+        """conftest sets API_BIND_SCOPE, so this also pins the mechanism itself:
+        pydantic-settings must record env-sourced values in model_fields_set."""
+        self.assertIn("api_bind_scope", settings().model_fields_set)
+
+    def test_loopback_bind_host_is_inferred_when_scope_is_not_declared(self) -> None:
+        self.assertEqual(resolve_bind_scope(undeclared(), {"HOST": "127.0.0.1"}), BIND_SCOPE_LOOPBACK)
+        self.assertEqual(resolve_bind_scope(undeclared(), {"UVICORN_HOST": "localhost"}), BIND_SCOPE_LOOPBACK)
+
+    def test_undeclared_deployment_is_assumed_reachable(self) -> None:
+        """The whole point of the default: silence must not mean 'safe'."""
+        self.assertEqual(resolve_bind_scope(undeclared(), {}), BIND_SCOPE_EXPOSED)
+        self.assertEqual(resolve_bind_scope(undeclared(), {"HOST": "0.0.0.0"}), BIND_SCOPE_EXPOSED)
+
+    def test_an_undeclared_reachable_deployment_has_no_usable_credential(self) -> None:
+        policy = resolve_auth_policy(undeclared(api_bearer_token=None), {})
+        self.assertTrue(policy.required)
+        self.assertFalse(policy.satisfiable)
+
+    def test_loopback_host_forms(self) -> None:
+        for host in ("127.0.0.1", "127.0.0.1:8000", "localhost", "localhost:8000", "::1", "[::1]", "[::1]:8000"):
+            with self.subTest(host=host):
+                self.assertTrue(is_loopback_host(host))
+        for host in ("0.0.0.0", "10.0.0.5", "example.com", "", "  "):
+            with self.subTest(host=host):
+                self.assertFalse(is_loopback_host(host))
+
+
+class AuthPolicyTests(unittest.TestCase):
+    def test_a_configured_token_is_always_enforced(self) -> None:
+        policy = resolve_auth_policy(settings(API_BIND_SCOPE=BIND_SCOPE_LOOPBACK, API_BEARER_TOKEN=STRONG_TOKEN))
+        self.assertTrue(policy.required)
+        self.assertTrue(policy.satisfiable)
+
+    def test_loopback_without_a_token_stays_open_for_local_development(self) -> None:
+        policy = resolve_auth_policy(settings(API_BIND_SCOPE=BIND_SCOPE_LOOPBACK))
+        self.assertFalse(policy.required)
+        self.assertTrue(policy.satisfiable)
+
+    def test_exposed_without_a_token_is_required_and_unsatisfiable(self) -> None:
+        policy = resolve_auth_policy(settings(API_BIND_SCOPE=BIND_SCOPE_EXPOSED))
+        self.assertTrue(policy.required)
+        self.assertFalse(policy.satisfiable)
+
+
+class RuntimePolicyAuthTests(unittest.TestCase):
+    def test_exposed_and_tokenless_is_a_startup_error_in_development(self) -> None:
+        report = validate_runtime_policy(
+            settings(APP_ENV="development", API_BIND_SCOPE=BIND_SCOPE_EXPOSED)
+        )
+        self.assertFalse(report.ok)
+        self.assertTrue(any("API_BEARER_TOKEN is required" in error for error in report.errors))
+
+    def test_exposed_rejects_a_token_too_short_to_matter(self) -> None:
+        report = validate_runtime_policy(
+            settings(APP_ENV="development", API_BIND_SCOPE=BIND_SCOPE_EXPOSED, API_BEARER_TOKEN="x")
+        )
+        self.assertFalse(report.ok)
+        self.assertTrue(any("at least" in error for error in report.errors))
+
+    def test_exposed_with_a_strong_token_raises_no_auth_error(self) -> None:
+        report = validate_runtime_policy(
+            settings(APP_ENV="development", API_BIND_SCOPE=BIND_SCOPE_EXPOSED, API_BEARER_TOKEN=STRONG_TOKEN)
+        )
+        self.assertEqual([e for e in report.errors if "API_BEARER_TOKEN" in e], [])
+
+    def test_loopback_without_a_token_warns_but_starts(self) -> None:
+        report = validate_runtime_policy(
+            settings(APP_ENV="development", API_BIND_SCOPE=BIND_SCOPE_LOOPBACK)
+        )
+        self.assertTrue(report.ok)
+        self.assertTrue(any("API_BEARER_TOKEN is unset" in warning for warning in report.warnings))
+
+    def test_production_still_requires_a_token_on_a_loopback_bind(self) -> None:
+        """APP_ENV=production keeps its own floor; bind scope only widens it."""
+        report = validate_runtime_policy(
+            settings(APP_ENV="production", API_BIND_SCOPE=BIND_SCOPE_LOOPBACK)
+        )
+        self.assertTrue(any("API_BEARER_TOKEN is required" in error for error in report.errors))
+
+    def test_the_auth_error_is_reported_once_not_twice(self) -> None:
+        report = validate_runtime_policy(
+            settings(APP_ENV="production", API_BIND_SCOPE=BIND_SCOPE_EXPOSED)
+        )
+        matching = [error for error in report.errors if "API_BEARER_TOKEN is required" in error]
+        self.assertEqual(len(matching), 1)
+
+
+class ServedRequestTests(unittest.TestCase):
+    """What the gate does to real requests, not just what the policy object says.
+
+    The original defect was a policy layer that reported the right thing while
+    the request path did something else, so the effect is what gets asserted.
+    """
+
+    def _client(self, **overrides) -> TestClient:
+        application = FastAPI()
+
+        @application.get("/sessions")
+        def sessions() -> dict:
+            return {"ok": True}
+
+        @application.get("/healthz")
+        def healthz() -> dict:
+            return {"ok": True}
+
+        install_controller_http_middleware(
+            application,
+            settings=settings(**overrides),
+            rate_limiter=None,
+            metrics=SimpleNamespace(enabled=False),
+        )
+        return TestClient(application)
+
+    def test_reachable_and_tokenless_refuses_every_protected_request(self) -> None:
+        response = self._client(API_BIND_SCOPE=BIND_SCOPE_EXPOSED).get("/sessions")
+        self.assertEqual(response.status_code, 401)
+
+    def test_health_stays_reachable_so_orchestrators_still_work(self) -> None:
+        response = self._client(API_BIND_SCOPE=BIND_SCOPE_EXPOSED).get("/healthz")
+        self.assertEqual(response.status_code, 200)
+
+    def test_loopback_and_tokenless_still_serves_local_development(self) -> None:
+        response = self._client(API_BIND_SCOPE=BIND_SCOPE_LOOPBACK).get("/sessions")
+        self.assertEqual(response.status_code, 200)
+
+    def test_a_configured_token_is_demanded_and_accepted(self) -> None:
+        client = self._client(API_BIND_SCOPE=BIND_SCOPE_EXPOSED, API_BEARER_TOKEN=STRONG_TOKEN)
+        self.assertEqual(client.get("/sessions").status_code, 401)
+        self.assertEqual(
+            client.get("/sessions", headers={"Authorization": f"Bearer {STRONG_TOKEN}"}).status_code,
+            200,
+        )
+
+
+class ShippedComposeDeclarationTests(unittest.TestCase):
+    """Each shipped compose file must declare the scope its publish mapping creates.
+
+    The Codespaces overlay is the security-relevant direction: drop its
+    declaration and it silently inherits `loopback` from the base file, so the
+    controller-side guard disappears while the file still publishes on 0.0.0.0.
+    """
+
+    REPO_ROOT = Path(__file__).resolve().parents[2]
+
+    def _compose(self, name: str) -> str:
+        path = self.REPO_ROOT / name
+        if not path.is_file():  # not shipped inside the controller image
+            self.skipTest(f"{name} is not present in this checkout")
+        return path.read_text(encoding="utf-8")
+
+    def test_base_compose_declares_loopback_and_publishes_on_loopback(self) -> None:
+        text = self._compose("docker-compose.yml")
+        self.assertIn("API_BIND_SCOPE: ${API_BIND_SCOPE:-loopback}", text)
+        self.assertIn('"127.0.0.1:${API_PORT:-8000}:8000"', text)
+
+    def test_codespaces_overlay_declares_exposed_because_it_publishes_widely(self) -> None:
+        text = self._compose("docker-compose.codespaces.yml")
+        self.assertIn('"0.0.0.0:${API_PORT:-8000}:8000"', text)
+        self.assertIn("API_BIND_SCOPE: exposed", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_auth_profile_ownership.py
+++ b/controller/tests/test_auth_profile_ownership.py
@@ -1,0 +1,150 @@
+"""An auth profile belongs to the operator who saved it.
+
+GHSA-xmh3-cw7j-9gp5: profiles lived in a flat root with no owner, so any caller
+who could reach the API could read, export, or open a session against anybody
+else's stored logins. Ownership only means something once identity is provable,
+which is why it is keyed on `source: "token"` — a profile must not be reachable
+by a caller who merely *claims* to be its owner in a header.
+
+Ownership activates with named credentials and not before: a profile saved
+without a proven identity records no owner, so shared-token deployments and
+profiles that pre-date this release keep working untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.audit import reset_current_operator, set_current_operator
+from app.browser.services.auth_profiles import BrowserAuthProfileService
+
+
+class StubAuthState:
+    def inspect(self, path: Path | None) -> dict:
+        return {"path": str(path) if path else None, "encrypted": False}
+
+    async def write_storage_state(self, context, destination: Path) -> dict:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text("{}", encoding="utf-8")
+        return {"path": str(destination), "encrypted": False}
+
+
+class StubPage:
+    url = "https://example.com/"
+
+    async def title(self) -> str:
+        return "Example"
+
+
+class StubSession:
+    id = "session-1"
+    context = object()
+    page = StubPage()
+    last_auth_state_path = None
+    auth_profile_name = None
+
+
+class AuthProfileOwnershipTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="auto-browser-profile-owner-"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        manager = SimpleNamespace(
+            settings=SimpleNamespace(auth_root=str(self.root), auth_state_encryption_key=None),
+            auth_state=StubAuthState(),
+        )
+        self.service = BrowserAuthProfileService(manager)
+        self._operator_token = None
+
+    def tearDown(self) -> None:
+        if self._operator_token is not None:
+            reset_current_operator(self._operator_token)
+
+    def as_operator(self, operator_id: str | None, *, source: str = "token") -> None:
+        if self._operator_token is not None:
+            reset_current_operator(self._operator_token)
+            self._operator_token = None
+        if operator_id is not None:
+            self._operator_token = set_current_operator(operator_id, source=source)
+
+    def save(self, profile_name: str) -> dict:
+        return asyncio.run(self.service.save_for_session(StubSession(), profile_name))
+
+    def owner_recorded(self, profile_name: str) -> str | None:
+        metadata_path = self.root / "profiles" / profile_name / "profile.json"
+        return json.loads(metadata_path.read_text(encoding="utf-8")).get("owner")
+
+    def test_a_proven_identity_is_stamped_as_the_owner(self) -> None:
+        self.as_operator("alice")
+        self.save("shared-login")
+        self.assertEqual(self.owner_recorded("shared-login"), "alice")
+
+    def test_an_unproven_identity_records_no_owner(self) -> None:
+        """Shared-token deployments must be unaffected — nothing to lock out."""
+        self.as_operator("alice", source="header")
+        self.save("shared-login")
+        self.assertIsNone(self.owner_recorded("shared-login"))
+
+    def test_another_operator_cannot_read_export_or_open_it(self) -> None:
+        self.as_operator("alice")
+        self.save("alice-login")
+
+        self.as_operator("bob")
+        for action in ("reading", "exporting", "opening a session from"):
+            with self.subTest(action=action), self.assertRaises(PermissionError):
+                self.service.require_access("alice-login", action=action)
+
+    def test_claiming_to_be_the_owner_in_a_header_is_not_enough(self) -> None:
+        """The whole point: the header is a claim, the credential is proof."""
+        self.as_operator("alice")
+        self.save("alice-login")
+
+        self.as_operator("alice", source="header")
+        with self.assertRaises(PermissionError):
+            self.service.require_access("alice-login", action="reading")
+
+    def test_the_owner_keeps_access(self) -> None:
+        self.as_operator("alice")
+        self.save("alice-login")
+        self.assertEqual(self.service.require_access("alice-login", action="reading"), "alice")
+
+    def test_ownership_survives_the_owner_saving_again(self) -> None:
+        """save_for_session rewrites profile.json wholesale — owner must persist."""
+        self.as_operator("alice")
+        self.save("alice-login")
+        self.save("alice-login")
+        self.assertEqual(self.owner_recorded("alice-login"), "alice")
+
+        self.as_operator("bob")
+        with self.assertRaises(PermissionError):
+            self.save("alice-login")
+
+    def test_an_unowned_profile_stays_accessible_to_everyone(self) -> None:
+        """Profiles written before this release have no owner and must not break."""
+        self.as_operator(None)
+        self.save("legacy")
+        self.assertIsNone(self.owner_recorded("legacy"))
+
+        self.as_operator("bob")
+        self.assertTrue(self.service.accessible("legacy"))
+
+    def test_listing_hides_profiles_you_cannot_access(self) -> None:
+        self.as_operator("alice")
+        self.save("alice-login")
+        self.as_operator("bob")
+        self.save("bob-login")
+        self.as_operator(None)
+        self.save("legacy")
+
+        self.as_operator("bob")
+        listed = {entry["profile_name"] for entry in asyncio.run(self.service.list())}
+        self.assertEqual(listed, {"bob-login", "legacy"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_codex_sandbox.py
+++ b/controller/tests/test_codex_sandbox.py
@@ -1,0 +1,81 @@
+"""Codex must not run on the host with approvals and sandboxing disabled.
+
+GHSA-xmh3-cw7j-9gp5. Both Codex paths passed
+`--dangerously-bypass-approvals-and-sandbox`, a flag whose own help text calls it
+"EXTREMELY DANGEROUS. Intended solely for running in environments that are
+externally sandboxed". Neither path needs it: Codex is handed a screenshot and a
+prompt in an ephemeral temp directory and asked for a JSON decision.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+from app.codex_sandbox import BYPASS_FLAG, build_sandbox_flags, codex_sandbox_flags
+from app.config import Settings
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+ADAPTER_SOURCE = Path(__file__).resolve().parents[1] / "app" / "providers" / "openai_adapter.py"
+
+
+class SandboxFlagTests(unittest.TestCase):
+    def test_the_default_is_a_read_only_sandbox(self) -> None:
+        self.assertEqual(codex_sandbox_flags(Settings(_env_file=None)), ["-s", "read-only"])
+
+    def test_the_bypass_requires_an_explicit_opt_in(self) -> None:
+        settings = Settings(_env_file=None, CODEX_BRIDGE_ALLOW_HOST_EXEC="true")
+        self.assertEqual(codex_sandbox_flags(settings), [BYPASS_FLAG])
+
+    def test_an_operator_may_widen_the_sandbox_without_disabling_it(self) -> None:
+        settings = Settings(_env_file=None, CODEX_SANDBOX_MODE="workspace-write")
+        self.assertEqual(codex_sandbox_flags(settings), ["-s", "workspace-write"])
+
+    def test_an_unknown_mode_is_refused_rather_than_passed_through(self) -> None:
+        with self.assertRaises(ValueError):
+            build_sandbox_flags(allow_host_exec=False, sandbox_mode="wide-open")
+
+    def test_the_adapter_no_longer_hardcodes_the_bypass(self) -> None:
+        """The flag must reach the command line only through the helper."""
+        self.assertNotIn(BYPASS_FLAG, ADAPTER_SOURCE.read_text(encoding="utf-8"))
+
+
+class HostBridgeTests(unittest.TestCase):
+    """The bridge is a standalone script, so it carries its own copy of the rule."""
+
+    def setUp(self) -> None:
+        try:
+            import codex_host_bridge
+        except Exception as exc:  # pragma: no cover - platform dependent
+            raise unittest.SkipTest(f"codex_host_bridge unavailable: {exc}") from exc
+        self.module = codex_host_bridge
+
+    def service(self, **kwargs):
+        return self.module.CodexBridgeService(codex_path="codex", **kwargs)
+
+    def test_the_bridge_defaults_to_a_read_only_sandbox(self) -> None:
+        self.assertEqual(self.service().sandbox_flags, ["-s", "read-only"])
+
+    def test_the_bridge_bypass_requires_an_explicit_opt_in(self) -> None:
+        self.assertEqual(
+            self.service(allow_host_exec=True).sandbox_flags,
+            ["--dangerously-bypass-approvals-and-sandbox"],
+        )
+
+    def test_the_two_implementations_agree(self) -> None:
+        """Duplicated rule, so drift between them is what gets pinned."""
+        for allow in (False, True):
+            for mode in ("read-only", "workspace-write", "danger-full-access"):
+                with self.subTest(allow=allow, mode=mode):
+                    self.assertEqual(
+                        build_sandbox_flags(allow_host_exec=allow, sandbox_mode=mode),
+                        self.module.build_sandbox_flags(allow_host_exec=allow, sandbox_mode=mode),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_open_advisory_gate.py
+++ b/controller/tests/test_open_advisory_gate.py
@@ -1,0 +1,78 @@
+"""The release gate must actually block on an advisory left in triage.
+
+A gate that only ever runs against a clean repo proves nothing: it looks
+identical to a gate that returns "all clear" unconditionally. GHSA-xmh3-cw7j-9gp5
+sat unacknowledged for seven weeks, so the blocking case is the one under test
+here, with the API response shape taken from a real
+`GET /repos/{owner}/{repo}/security-advisories` payload.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+try:
+    from check_open_advisories import age_days, report  # noqa: E402
+except ModuleNotFoundError as exc:  # scripts/ is not shipped in the controller image
+    raise unittest.SkipTest(f"check_open_advisories unavailable: {exc}") from exc
+
+NOW = datetime(2026, 8, 8, tzinfo=timezone.utc)
+
+
+def advisory(state: str, *, created: datetime = NOW, ghsa_id: str = "GHSA-test-0000") -> dict:
+    return {
+        "ghsa_id": ghsa_id,
+        "state": state,
+        "severity": "critical",
+        "summary": "Test advisory",
+        "html_url": f"https://github.com/o/r/security/advisories/{ghsa_id}",
+        "created_at": created.isoformat().replace("+00:00", "Z"),
+    }
+
+
+class OpenAdvisoryGateTests(unittest.TestCase):
+    def test_triage_advisory_blocks_the_release(self) -> None:
+        stale = advisory("triage", created=NOW - timedelta(days=52))
+        with redirect_stdout(io.StringIO()), self.assertRaises(SystemExit) as caught:
+            report([stale], now=NOW)
+        self.assertIn("still sit in triage", str(caught.exception))
+
+    def test_waiting_time_is_reported_so_the_message_is_actionable(self) -> None:
+        stale = advisory("triage", created=NOW - timedelta(days=52))
+        stream = io.StringIO()
+        with redirect_stdout(stream), self.assertRaises(SystemExit):
+            report([stale], now=NOW)
+        self.assertIn("waiting 52 days", stream.getvalue())
+
+    def test_published_advisories_do_not_block(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(report([advisory("published"), advisory("closed")], now=NOW), 0)
+
+    def test_draft_is_reported_but_does_not_block(self) -> None:
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            self.assertEqual(report([advisory("draft")], now=NOW), 0)
+        self.assertIn("accepted draft", stream.getvalue())
+
+    def test_empty_repository_passes(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(report([], now=NOW), 0)
+
+    def test_age_days_tolerates_a_missing_timestamp(self) -> None:
+        self.assertIsNone(age_days(None, NOW))
+        # The real GHSA-xmh3-cw7j-9gp5 submission timestamp: 51 whole days by
+        # 2026-08-08T00:00Z, and the count truncates rather than rounds.
+        self.assertEqual(age_days("2026-06-17T04:40:04Z", NOW), 51)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_operator_identity.py
+++ b/controller/tests/test_operator_identity.py
@@ -1,0 +1,153 @@
+"""Operator identity must be provable, not merely asserted.
+
+`X-Operator-Id` is a request header. Until 1.7.0 it was the only thing that ever
+set the operator on an audit event, so the audit trail attributed actions to a
+string the caller chose — which reads as identity while being a label. Reported
+in GHSA-xmh3-cw7j-9gp5.
+
+Named credentials (`API_BEARER_TOKENS`) make identity provable. The header is
+kept for single-token and loopback deployments, where one shared credential
+genuinely cannot distinguish operators, but it is then recorded as `source:
+"header"` so nothing downstream can mistake it for authentication.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.audit import get_current_operator
+from app.auth_policy import credentials_for, parse_operator_tokens
+from app.config import Settings
+from app.middleware.http import install_controller_http_middleware
+from app.runtime_policy import MIN_PRODUCTION_BEARER_TOKEN_LENGTH, validate_runtime_policy
+
+ALICE_TOKEN = "alice-" + "a" * MIN_PRODUCTION_BEARER_TOKEN_LENGTH
+BOB_TOKEN = "bob-" + "b" * MIN_PRODUCTION_BEARER_TOKEN_LENGTH
+SHARED_TOKEN = "shared-" + "s" * MIN_PRODUCTION_BEARER_TOKEN_LENGTH
+NAMED = f"alice:{ALICE_TOKEN},bob:{BOB_TOKEN}"
+
+
+def client_for(**overrides) -> TestClient:
+    application = FastAPI()
+
+    @application.get("/whoami")
+    def whoami() -> dict:
+        return get_current_operator().model_dump()
+
+    install_controller_http_middleware(
+        application,
+        settings=Settings(_env_file=None, **overrides),
+        rate_limiter=None,
+        metrics=SimpleNamespace(enabled=False),
+    )
+    return TestClient(application)
+
+
+class TokenParsingTests(unittest.TestCase):
+    def test_named_pairs_are_parsed(self) -> None:
+        credentials = parse_operator_tokens(NAMED)
+        self.assertEqual([c.operator_id for c in credentials], ["alice", "bob"])
+        self.assertTrue(all(c.verifies_identity for c in credentials))
+
+    def test_a_token_may_contain_colons(self) -> None:
+        (credential,) = parse_operator_tokens("alice:abc:def:ghi")
+        self.assertEqual(credential.operator_id, "alice")
+        self.assertEqual(credential.token, "abc:def:ghi")
+
+    def test_malformed_entries_are_skipped_not_guessed(self) -> None:
+        """A pair with no colon must not silently become a shared token."""
+        self.assertEqual(parse_operator_tokens("no-colon-here"), ())
+        self.assertEqual(parse_operator_tokens("  ,  , :,  x: "), ())
+
+    def test_the_shared_token_carries_no_identity(self) -> None:
+        (credential,) = credentials_for(
+            Settings(_env_file=None, API_BEARER_TOKEN=SHARED_TOKEN, API_BEARER_TOKENS="")
+        )
+        self.assertIsNone(credential.operator_id)
+        self.assertFalse(credential.verifies_identity)
+
+
+class VerifiedIdentityTests(unittest.TestCase):
+    def test_a_named_token_proves_who_the_caller_is(self) -> None:
+        response = client_for(API_BEARER_TOKENS=NAMED).get(
+            "/whoami", headers={"Authorization": f"Bearer {ALICE_TOKEN}"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["id"], "alice")
+        self.assertEqual(response.json()["source"], "token")
+
+    def test_a_forged_header_cannot_override_the_credential(self) -> None:
+        response = client_for(API_BEARER_TOKENS=NAMED).get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {ALICE_TOKEN}", "X-Operator-Id": "bob"},
+        )
+        body = response.json()
+        self.assertEqual(body["id"], "alice")
+        self.assertEqual(body["source"], "token")
+        self.assertEqual(body["asserted_id"], "bob", "the false claim must survive into the audit trail")
+
+    def test_an_agreeing_header_records_no_conflict(self) -> None:
+        body = client_for(API_BEARER_TOKENS=NAMED).get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {ALICE_TOKEN}", "X-Operator-Id": "alice"},
+        ).json()
+        self.assertEqual(body["id"], "alice")
+        self.assertIsNone(body["asserted_id"])
+
+    def test_a_named_token_satisfies_require_operator_id_without_a_header(self) -> None:
+        response = client_for(API_BEARER_TOKENS=NAMED, REQUIRE_OPERATOR_ID="true").get(
+            "/whoami", headers={"Authorization": f"Bearer {ALICE_TOKEN}"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["id"], "alice")
+
+    def test_a_wrong_token_is_refused_before_identity_is_considered(self) -> None:
+        response = client_for(API_BEARER_TOKENS=NAMED).get(
+            "/whoami", headers={"Authorization": "Bearer not-a-real-token", "X-Operator-Id": "alice"}
+        )
+        self.assertEqual(response.status_code, 401)
+
+
+class UnverifiedIdentityTests(unittest.TestCase):
+    def test_the_shared_token_leaves_identity_self_asserted(self) -> None:
+        body = client_for(API_BEARER_TOKEN=SHARED_TOKEN).get(
+            "/whoami",
+            headers={"Authorization": f"Bearer {SHARED_TOKEN}", "X-Operator-Id": "whoever"},
+        ).json()
+        self.assertEqual(body["id"], "whoever")
+        self.assertEqual(body["source"], "header", "one shared credential cannot distinguish operators")
+
+    def test_an_unauthenticated_loopback_request_is_still_attributed_by_header(self) -> None:
+        body = client_for(API_BIND_SCOPE="loopback").get(
+            "/whoami", headers={"X-Operator-Id": "local-dev"}
+        ).json()
+        self.assertEqual(body["id"], "local-dev")
+        self.assertEqual(body["source"], "header")
+
+    def test_no_claim_at_all_is_anonymous(self) -> None:
+        body = client_for(API_BIND_SCOPE="loopback").get("/whoami").json()
+        self.assertEqual(body["id"], "anonymous")
+        self.assertEqual(body["source"], "anonymous")
+
+
+class NamedTokenPolicyTests(unittest.TestCase):
+    def test_a_weak_named_token_is_a_startup_error(self) -> None:
+        report = validate_runtime_policy(
+            Settings(_env_file=None, API_BIND_SCOPE="exposed", API_BEARER_TOKENS="alice:short")
+        )
+        self.assertFalse(report.ok)
+        self.assertTrue(any("operator 'alice'" in error for error in report.errors), report.errors)
+
+    def test_named_tokens_alone_satisfy_the_requirement(self) -> None:
+        report = validate_runtime_policy(
+            Settings(_env_file=None, API_BIND_SCOPE="exposed", API_BEARER_TOKENS=NAMED)
+        )
+        self.assertEqual([e for e in report.errors if "BEARER" in e or "operator" in e], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_runtime_policy.py
+++ b/controller/tests/test_runtime_policy.py
@@ -87,7 +87,12 @@ class RuntimePolicyTests(unittest.TestCase):
         report = validate_runtime_policy(settings)
 
         self.assertFalse(report.ok)
-        self.assertIn("API_BEARER_TOKEN is required when APP_ENV=production", report.errors)
+        # The message now names the remedy as well as the requirement, so this
+        # asserts the requirement rather than the exact sentence.
+        self.assertTrue(
+            any(error.startswith("API_BEARER_TOKEN is required when APP_ENV=production") for error in report.errors),
+            report.errors,
+        )
         self.assertIn("REQUIRE_OPERATOR_ID=true is required when APP_ENV=production", report.errors)
         self.assertIn("AUTH_STATE_ENCRYPTION_KEY is required when APP_ENV=production", report.errors)
         self.assertIn(

--- a/controller/tests/test_skill_provenance.py
+++ b/controller/tests/test_skill_provenance.py
@@ -1,0 +1,118 @@
+"""A staged skill candidate's signature has to be checked, not just produced.
+
+GHSA-xmh3-cw7j-9gp5. Induction could sign a candidate envelope, but nothing on
+the read side ever verified one, so a signature was an assertion the artifact
+made about itself — the same shape as the pre-1.6.0 witness chain. Anyone able to
+write to the staging root could edit a staged skill, or add one, and it would be
+served as a governed candidate carrying provenance.
+
+Two other honesty gaps close here: an unsigned envelope was a dict shaped exactly
+like a signed one, and a candidate induced from a mock trace — no browser ever
+ran — was indistinguishable from a converged one.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.harness.induce import SkillCandidate
+from app.harness.register import SkillStagingRegistry
+
+
+def candidate(skill_id: str = "skill-1", **overrides) -> SkillCandidate:
+    payload = {
+        "skill_id": skill_id,
+        "name": "example",
+        "description": "example goal",
+        "contract_hash": "contract-hash",
+        "trace_hash": "trace-hash",
+        "verifier_backend": "programmatic",
+        "verifier_passed": True,
+        "verifier_confidence": 1.0,
+        "attempts": 1,
+    }
+    payload.update(overrides)
+    return SkillCandidate(**payload)
+
+
+def signed_envelope(contract_hash: str = "contract-hash", trace_hash: str = "trace-hash") -> dict:
+    return {"contract_hash": contract_hash, "trace_hash": trace_hash, "signature": "valid"}
+
+
+def accepting_verifier(envelope: dict) -> dict:
+    if envelope.get("signature") != "valid":
+        raise ValueError("bad signature")
+    return envelope
+
+
+class RegistryVerificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="auto-browser-skill-provenance-"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+    def stage(self, entry: SkillCandidate) -> None:
+        directory = self.root / entry.skill_id
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "candidate.json").write_text(entry.model_dump_json(), encoding="utf-8")
+
+    def registry(self, *, verify: bool) -> SkillStagingRegistry:
+        return SkillStagingRegistry(self.root, verifier=accepting_verifier if verify else None)
+
+    def test_a_valid_signature_is_accepted(self) -> None:
+        self.stage(candidate(signed=True, envelope=signed_envelope()))
+        self.assertEqual(self.registry(verify=True).get_candidate("skill-1").skill_id, "skill-1")
+
+    def test_a_forged_signature_is_refused(self) -> None:
+        self.stage(candidate(signed=True, envelope={**signed_envelope(), "signature": "forged"}))
+        with self.assertRaises(PermissionError):
+            self.registry(verify=True).get_candidate("skill-1")
+
+    def test_a_dropped_in_unsigned_candidate_is_refused(self) -> None:
+        """Writing a candidate straight into the staging root must not work."""
+        self.stage(candidate(envelope={"contract_hash": "x", "trace_hash": "y", "signed": False}))
+        with self.assertRaises(PermissionError):
+            self.registry(verify=True).get_candidate("skill-1")
+
+    def test_a_candidate_with_no_envelope_at_all_is_refused(self) -> None:
+        self.stage(candidate())
+        with self.assertRaises(PermissionError):
+            self.registry(verify=True).get_candidate("skill-1")
+
+    def test_a_signature_over_a_different_candidate_is_refused(self) -> None:
+        """A genuine signature stolen from another candidate is still a forgery."""
+        self.stage(
+            candidate(
+                signed=True,
+                contract_hash="mine",
+                envelope=signed_envelope(contract_hash="somebody-elses"),
+            )
+        )
+        with self.assertRaises(PermissionError):
+            self.registry(verify=True).get_candidate("skill-1")
+
+    def test_listing_omits_what_it_cannot_verify(self) -> None:
+        self.stage(candidate("good", signed=True, envelope=signed_envelope()))
+        self.stage(candidate("forged", signed=True, envelope={**signed_envelope(), "signature": "forged"}))
+        listed = {entry["skill_id"] for entry in self.registry(verify=True).list_candidates()}
+        self.assertEqual(listed, {"good"})
+
+    def test_an_unsigned_deployment_still_reads_its_own_candidates(self) -> None:
+        """No signer configured means nothing to check — not everything refused."""
+        self.stage(candidate(envelope={"contract_hash": "x", "signed": False}))
+        self.assertEqual(self.registry(verify=False).get_candidate("skill-1").skill_id, "skill-1")
+
+
+class CandidateHonestyTests(unittest.TestCase):
+    def test_unsigned_and_simulated_default_to_false_but_are_recorded(self) -> None:
+        entry = candidate()
+        self.assertFalse(entry.signed)
+        self.assertFalse(entry.simulated)
+        self.assertIn("simulated", json.loads(entry.model_dump_json()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controller/tests/test_witness_anchor.py
+++ b/controller/tests/test_witness_anchor.py
@@ -1,0 +1,139 @@
+"""The two witness limits 1.6.0 documented, now tested as behaviour.
+
+Tail truncation: signing cannot detect it. Drop the last k receipts and what
+remains is a shorter chain whose every signature still verifies, so `verify()`
+reported a clean chain. The anchor is a record of where the chain had got to,
+kept beside it, so a short chain stops looking like a complete one.
+
+Chain forking: appends were serialised with an `asyncio.Lock`, which orders one
+process. Two workers on a shared volume could read the same head and write two
+receipts claiming the same predecessor — a correctness bug, not a limit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+from app.models import OperatorIdentity
+from app.witness import WitnessReceipt, WitnessRecorder
+from app.witness_anchor import anchor_path, read_anchor
+
+
+def receipt(action: str) -> WitnessReceipt:
+    return WitnessReceipt(
+        receipt_id=action,
+        timestamp="2026-08-08T00:00:00Z",
+        profile="normal",
+        scope="sess-1",
+        event_type="action",
+        status="ok",
+        action=action,
+        action_class="read",
+        operator=OperatorIdentity(id="alice", source="token"),
+    )
+
+
+@pytest.fixture()
+def recorder(tmp_path_factory) -> WitnessRecorder:
+    root = Path(tempfile.mkdtemp(prefix="auto-browser-witness-anchor-"))
+    try:
+        yield WitnessRecorder(root)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_the_anchor_tracks_the_head_and_count(recorder: WitnessRecorder) -> None:
+    await recorder.startup()
+    for index in range(3):
+        written = await recorder.record("sess-1", **receipt(f"click-{index}").model_dump(exclude={"scope"}))
+
+    anchor = read_anchor(recorder._path("sess-1"))
+    assert anchor == {"head_hash": written.chain_hash, "receipt_count": 3}
+
+
+@pytest.mark.asyncio
+async def test_truncating_the_tail_is_detected(recorder: WitnessRecorder) -> None:
+    await recorder.startup()
+    for index in range(4):
+        await recorder.record("sess-1", **receipt(f"click-{index}").model_dump(exclude={"scope"}))
+
+    path = recorder._path("sess-1")
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    path.write_text("\n".join(lines[:2]) + "\n", encoding="utf-8")
+
+    result = await recorder.verify("sess-1")
+    # The surviving receipts are a perfectly valid chain — that is the point.
+    assert result["first_invalid_index"] is None
+    assert result["anchor"]["status"] == "truncated"
+    assert result["anchor"]["expected_receipt_count"] == 4
+    assert result["valid"] is False
+    assert "removed from the end" in result["reason"]
+
+
+@pytest.mark.asyncio
+async def test_a_chain_with_no_anchor_is_not_reported_as_tampered(recorder: WitnessRecorder) -> None:
+    """Chains written before this release must not start failing verification."""
+    await recorder.startup()
+    await recorder.record("sess-1", **receipt("click-0").model_dump(exclude={"scope"}))
+    anchor_path(recorder._path("sess-1")).unlink()
+
+    result = await recorder.verify("sess-1")
+    assert result["anchor"]["status"] == "unanchored"
+    assert result["valid"] is True
+
+
+@pytest.mark.asyncio
+async def test_an_intact_chain_still_verifies(recorder: WitnessRecorder) -> None:
+    await recorder.startup()
+    for index in range(3):
+        await recorder.record("sess-1", **receipt(f"click-{index}").model_dump(exclude={"scope"}))
+
+    result = await recorder.verify("sess-1")
+    assert result["valid"] is True
+    assert result["anchor"]["status"] == "ok"
+    assert result["receipt_count"] == 3
+
+
+def test_concurrent_writers_cannot_fork_the_chain() -> None:
+    """Threads bypass the asyncio lock, so this exercises the file lock itself.
+
+    Without it, two writers read the same head and both claim it as their
+    predecessor, and verify() reports a broken chain at the second one.
+    """
+    root = Path(tempfile.mkdtemp(prefix="auto-browser-witness-fork-"))
+    try:
+        recorder = WitnessRecorder(root)
+        asyncio.run(recorder.startup())
+        path = recorder._path("sess-1")
+
+        writers = 12
+        barrier = threading.Barrier(writers)
+
+        def append(index: int) -> None:
+            item = receipt(f"click-{index}")
+            barrier.wait()
+            recorder._append_locked(path, item)
+
+        threads = [threading.Thread(target=append, args=(index,)) for index in range(writers)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert len(lines) == writers, "every append must survive"
+
+        result = asyncio.run(recorder.verify("sess-1"))
+        assert result["valid"] is True, result.get("reason")
+        assert result["receipt_count"] == writers
+        assert json.loads(lines[-1])["chain_hash"] == read_anchor(path)["head_hash"]
+    finally:
+        shutil.rmtree(root, ignore_errors=True)

--- a/controller/tests/test_witness_signing.py
+++ b/controller/tests/test_witness_signing.py
@@ -107,7 +107,13 @@ async def test_a_rehashed_forgery_is_caught_by_signatures(signed_recorder: Witne
     path.write_text("\n".join(json.dumps(r) for r in receipts) + "\n", encoding="utf-8")
 
     chain = await signed_recorder.verify("sess-1")
-    assert chain["valid"] is True, "a re-hashed forgery is internally consistent — this is the gap"
+    # The hash walk itself still passes — a re-hashed forgery is internally
+    # consistent, which is exactly why signatures exist. Since 1.7.0 the anchor
+    # catches it too: the rewritten chain's head no longer matches the head
+    # recorded when the receipts were written.
+    assert chain["anchor"]["status"] == "diverged"
+    assert chain["valid"] is False
+    assert chain["first_invalid_index"] is None, "the chain walk found nothing wrong; the anchor did"
 
     signatures = await signed_recorder.verify_signatures("sess-1")
     assert signatures["valid"] is False

--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -29,5 +29,9 @@ services:
   controller:
     environment:
       API_BEARER_TOKEN: ${API_BEARER_TOKEN:?set API_BEARER_TOKEN before using the Codespaces overlay - it publishes the API on 0.0.0.0 and must not run unauthenticated}
+      # Overrides the base file's `loopback`. Compose refuses to start without a
+      # token above; this makes the controller itself refuse too, so the guard
+      # survives anyone copying these service definitions somewhere else.
+      API_BIND_SCOPE: exposed
     ports: !override
       - "0.0.0.0:${API_PORT:-8000}:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,12 @@ services:
     environment:
       APP_ENV: ${APP_ENV:-development}
       API_BEARER_TOKEN: ${API_BEARER_TOKEN:-}
+      # Declares what the publish mapping below already does: this API is bound
+      # to 127.0.0.1 and is not reachable off-box, which is the only reason it
+      # may run without a token. The controller cannot see the host publish
+      # mapping itself, and the setting defaults to `exposed`, so a compose file
+      # that publishes on 0.0.0.0 without saying so refuses to start.
+      API_BIND_SCOPE: ${API_BIND_SCOPE:-loopback}
       CONTROLLER_ALLOWED_HOSTS: ${CONTROLLER_ALLOWED_HOSTS:-localhost,127.0.0.1,::1,testserver}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       BROWSER_WS_ENDPOINT_FILE: /data/browser-profile/browser-ws-endpoint.txt

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,6 +15,7 @@ At minimum:
 
 ```env
 APP_ENV=production
+API_BIND_SCOPE=exposed
 API_BEARER_TOKEN=<strong-random-secret>
 REQUIRE_OPERATOR_ID=true
 AUTH_STATE_ENCRYPTION_KEY=<44-char-fernet-key>

--- a/docs/production-hardening.md
+++ b/docs/production-hardening.md
@@ -6,7 +6,12 @@ Ship Auto Browser as a safe **single-tenant private beta** first, then harden to
 
 ## Hard requirements for the private beta target
 
-- Production startup refuses to boot without:
+- Startup refuses to boot without `API_BEARER_TOKEN` (at least 32 characters)
+  whenever the API is reachable off-box — that is, `API_BIND_SCOPE=exposed`,
+  which is the default for any deployment that does not declare otherwise. The
+  shipped base compose declares `loopback` to match its `127.0.0.1` publish
+  mapping, which is the only reason `docker compose up` runs without a token.
+- Production startup additionally refuses to boot without:
   - `API_BEARER_TOKEN`
   - `REQUIRE_OPERATOR_ID=true`
   - `AUTH_STATE_ENCRYPTION_KEY`

--- a/docs/production-hardening.md
+++ b/docs/production-hardening.md
@@ -18,6 +18,12 @@ Ship Auto Browser as a safe **single-tenant private beta** first, then harden to
   - `REQUIRE_AUTH_STATE_ENCRYPTION=true`
   - `CONTROLLER_ALLOWED_HOSTS` configured for the controller ingress hostnames
   - request rate limiting enabled
+- Operator identity is only authentication when it comes from a named
+  credential (`API_BEARER_TOKENS=alice:token-a,bob:token-b`), which records
+  `source: "token"` on the audit event. With the shared `API_BEARER_TOKEN`,
+  `X-Operator-Id` is attribution only and is recorded as `source: "header"`.
+  When a header disagrees with the authenticated operator, the credential wins
+  and the claim is kept in `asserted_id`.
 - Request-rate limiting with 429 responses and reset headers
 - Metrics endpoint for scraping and alert wiring
 - Automated retention cleanup for:

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "auto-browser-langchain"
-version = "1.6.1"
+version = "1.7.0"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # console script against that dependency.
 [project]
 name = "auto-browser-mcp"
-version = "1.6.1"
+version = "1.7.0"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/check_open_advisories.py
+++ b/scripts/check_open_advisories.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""Block a release while a privately reported advisory sits unacknowledged.
+
+GHSA-xmh3-cw7j-9gp5 arrived through GitHub private vulnerability reporting on
+2026-06-17 and sat in `triage` for seven weeks. Nothing surfaced it: a private
+report appears in neither the issue list, the pull-request list, nor anything a
+maintainer routinely opens, and it was found only by listing advisories through
+the API while publishing an unrelated one. Meanwhile SECURITY.md promises to
+"acknowledge reports quickly".
+
+The fix has to attach to a process that is guaranteed to happen. Cutting a
+release is the only one, so the check lives in the release audit: a report still
+in `triage` means nobody has accepted it, and shipping past that is how seven
+weeks happen.
+
+`draft` advisories are reported but do not block — accepted-and-being-fixed is a
+legitimate place to be mid-release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REPO = "LvcidPsyche/auto-browser"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=None, help="owner/name (default: the origin remote)")
+    parser.add_argument(
+        "--from-json",
+        type=Path,
+        default=None,
+        help="Read the advisory list from a file instead of the API (tests).",
+    )
+    args = parser.parse_args()
+
+    if args.from_json is not None:
+        advisories = json.loads(args.from_json.read_text(encoding="utf-8"))
+    else:
+        advisories = fetch_advisories(args.repo or resolve_repo())
+
+    return report(advisories, now=datetime.now(timezone.utc))
+
+
+def resolve_repo() -> str:
+    """Derive owner/name from the origin remote so forks check themselves."""
+    result = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return DEFAULT_REPO
+    url = result.stdout.strip().removesuffix(".git")
+    if url.startswith("git@"):
+        url = url.partition(":")[2]
+    parts = [part for part in url.split("/") if part]
+    return "/".join(parts[-2:]) if len(parts) >= 2 else DEFAULT_REPO
+
+
+def fetch_advisories(repo: str) -> list[dict]:
+    """List repository security advisories via `gh`.
+
+    Raises rather than returning empty on any failure. An advisory check that
+    cannot reach the API and reports "nothing open" is indistinguishable from
+    success, which is the failure mode this whole script exists to prevent.
+    """
+    if shutil.which("gh") is None:
+        raise SystemExit(
+            "Missing required command: gh. The advisory check needs an authenticated "
+            "GitHub CLI; pass --skip-advisory-check to the release audit only if you "
+            "have just checked the advisory list by hand."
+        )
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/security-advisories", "--paginate"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"Could not list security advisories for {repo}:\n{result.stderr.strip()}"
+        )
+    return json.loads(result.stdout)
+
+
+def age_days(timestamp: str | None, now: datetime) -> int | None:
+    if not timestamp:
+        return None
+    moment = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    return (now - moment).days
+
+
+def report(advisories: list[dict], *, now: datetime) -> int:
+    unacknowledged = [entry for entry in advisories if entry.get("state") == "triage"]
+    drafts = [entry for entry in advisories if entry.get("state") == "draft"]
+
+    for entry in drafts:
+        age = age_days(entry.get("created_at"), now)
+        suffix = f" ({age}d old)" if age is not None else ""
+        print(f"note: {entry.get('ghsa_id')} is an accepted draft{suffix} — publish it with the fix.")
+
+    if not unacknowledged:
+        print(f"OK: no security advisory is waiting in triage ({len(advisories)} total).")
+        return 0
+
+    print()
+    for entry in unacknowledged:
+        age = age_days(entry.get("created_at") or entry.get("updated_at"), now)
+        suffix = f", waiting {age} days" if age is not None else ""
+        print(f"  {entry.get('ghsa_id')} [{entry.get('severity')}]{suffix}")
+        print(f"    {entry.get('summary')}")
+        print(f"    {entry.get('html_url')}")
+    print()
+    raise SystemExit(
+        f"Release blocked: {len(unacknowledged)} privately reported advisory/advisories "
+        "still sit in triage. Accept or close each one before shipping — SECURITY.md "
+        "promises reporters a quick acknowledgement."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_open_advisories.py
+++ b/scripts/check_open_advisories.py
@@ -23,7 +23,6 @@ import argparse
 import json
 import shutil
 import subprocess
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 

--- a/scripts/codex_host_bridge.py
+++ b/scripts/codex_host_bridge.py
@@ -18,6 +18,25 @@ from pathlib import Path
 from socketserver import ThreadingMixIn, UnixStreamServer
 from typing import Any
 
+SANDBOX_MODES = ("read-only", "workspace-write", "danger-full-access")
+DEFAULT_SANDBOX_MODE = "read-only"
+
+
+def build_sandbox_flags(*, allow_host_exec: bool, sandbox_mode: str) -> list[str]:
+    """Mirror of app/codex_sandbox.py — this script runs outside the container.
+
+    Codex is handed a screenshot and a prompt and asked for a JSON decision; it
+    is never meant to run shell commands here, so the default is a read-only
+    sandbox and the bypass is an explicit opt-in (GHSA-xmh3-cw7j-9gp5).
+    """
+    if allow_host_exec:
+        return ["--dangerously-bypass-approvals-and-sandbox"]
+    mode = (sandbox_mode or DEFAULT_SANDBOX_MODE).strip() or DEFAULT_SANDBOX_MODE
+    if mode not in SANDBOX_MODES:
+        raise SystemExit(f"CODEX_SANDBOX_MODE must be one of {', '.join(SANDBOX_MODES)} (got {mode!r})")
+    return ["-s", mode]
+
+
 CONFIG_OVERRIDES = (
     "project_doc_fallback_filenames=[]",
     "agents={}",
@@ -41,10 +60,21 @@ class CodexBridgeService:
         codex_path: str,
         default_model: str | None = None,
         request_timeout_seconds: float = 55.0,
+        sandbox_mode: str = DEFAULT_SANDBOX_MODE,
+        allow_host_exec: bool = False,
     ) -> None:
         self.codex_path = codex_path
         self.default_model = default_model
         self.request_timeout_seconds = request_timeout_seconds
+        self.sandbox_flags = build_sandbox_flags(allow_host_exec=allow_host_exec, sandbox_mode=sandbox_mode)
+        if allow_host_exec:
+            print(
+                "WARNING: CODEX_BRIDGE_ALLOW_HOST_EXEC is set. Codex runs with approvals and "
+                "sandboxing disabled, so a model decision can execute arbitrary commands on this "
+                "host. Only do this inside an environment that is itself sandboxed.",
+                file=sys.stderr,
+                flush=True,
+            )
 
     def handle_openai_decide(self, payload: dict[str, Any]) -> dict[str, Any]:
         prompt = str(payload.get("prompt") or "").strip()
@@ -82,11 +112,10 @@ class CodexBridgeService:
                 command.extend(["--model", model])
             for override in CONFIG_OVERRIDES:
                 command.extend(["-c", override])
+            command.extend(["exec", "--skip-git-repo-check"])
+            command.extend(self.sandbox_flags)
             command.extend(
                 [
-                    "exec",
-                    "--dangerously-bypass-approvals-and-sandbox",
-                    "--skip-git-repo-check",
                     "--cd",
                     tempdir,
                     "--ephemeral",
@@ -230,6 +259,9 @@ def main() -> int:
         codex_path=args.codex_path,
         default_model=args.model,
         request_timeout_seconds=args.request_timeout_seconds,
+        sandbox_mode=os.environ.get("CODEX_SANDBOX_MODE", DEFAULT_SANDBOX_MODE),
+        allow_host_exec=os.environ.get("CODEX_BRIDGE_ALLOW_HOST_EXEC", "").strip().lower()
+        in {"1", "true", "yes", "on"},
     )
     server = UnixHTTPServer(str(socket_path), service)
 

--- a/scripts/release_audit.py
+++ b/scripts/release_audit.py
@@ -39,12 +39,25 @@ SECRET_PATTERN = (
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run the auto-browser release audit.")
     parser.add_argument("--skip-doctor", action="store_true", help="Skip the bash-based readiness doctor.")
+    parser.add_argument(
+        "--skip-advisory-check",
+        action="store_true",
+        help="Skip the unacknowledged-advisory gate (offline dry-runs only).",
+    )
     args = parser.parse_args()
 
     os.chdir(ROOT)
     _check_launch_files()
     _require("git")
     _require("npm")
+
+    # Early, because it is the cheapest possible failure and the one most likely
+    # to mean "do not ship yet".
+    if args.skip_advisory_check:
+        print("Skipping the security-advisory triage check by request.")
+    else:
+        print("Checking for security advisories waiting in triage...")
+        _run([PYTHON, "scripts/check_open_advisories.py"])
 
     print("Running lint...")
     _run([PYTHON, "-m", "ruff", "check", "controller/app", "controller/tests", "scripts", "--select", "E9,F,I"])

--- a/scripts/release_audit.py
+++ b/scripts/release_audit.py
@@ -20,7 +20,9 @@ LAUNCH_FILES = [
     "ROADMAP.md",
     "TIPS.md",
     "docs/agent-evals.md",
-    "docs/launch.md",
+    # docs/launch.md was retired in 6a5f705 as launch-era material pinned to
+    # v1.2.1. This list was not updated, so the audit has failed at its first
+    # check ever since — which is also how we know it had not been run.
     "docs/mcp-clients.md",
     "docs/good-first-issues.md",
     "docs/assets/hero.svg",


### PR DESCRIPTION
Closes the design issues from [GHSA-xmh3-cw7j-9gp5](https://github.com/LvcidPsyche/auto-browser/security/advisories/GHSA-xmh3-cw7j-9gp5) that 1.6.1 fixed the patchable half of and listed the rest of as *Known and not yet addressed* — plus one item from the same report that list omitted, and two of the three witness limits documented in 1.6.0.

The thread running through all of it: **a control that fails open is not a control.** Authentication that switched itself off when no token was set, an operator identity anybody could assert, profiles with no owner, a signature nothing checked, and a sandbox flag that disabled the sandbox.

## Commits

| Commit | What it closes |
|---|---|
| `70756f9` | Release audit blocks while a privately reported advisory sits in triage |
| `9df144c` | API auth required whenever the controller is reachable off-box |
| `b717e45` | Operator identity provable via named credentials, not asserted in a header |
| `1db7a4b` | Auth profiles scoped to the operator who saved them |
| `f0c2499` | Codex sandboxed instead of bypassing approvals |
| `c683396` | Staged skill provenance verified on read, not only signed on write |
| `5e8b4e1` | Witness chain forking fixed; tail truncation made detectable |
| `dbec975` | 1.7.0 version bump, changelog, release-audit repair |

## Breaking change

`API_BIND_SCOPE` defaults to **`exposed`**, so a deployment that publishes the API without declaring itself loopback-only now refuses to start without an `API_BEARER_TOKEN` of 32+ characters — in any `APP_ENV`.

`docker compose up` on a clean checkout is unaffected: the base compose declares `loopback` to match its `127.0.0.1:8000:8000` publish mapping. A hand-rolled compose file publishing on `0.0.0.0` is the case that now fails closed, deliberately. A loopback bind host in `API_BIND_HOST`/`UVICORN_HOST`/`HOST` is detected for people running uvicorn directly.

## Two repairs found along the way

- **The release audit had not passed since v1.2.x.** It still required `docs/launch.md`, which `6a5f705` deliberately retired, so every run died at its first check before reaching lint, tests or the coverage gate.
- **Chain forking was a bug, not a limit.** `asyncio.Lock` orders tasks on one event loop — not the worker threads the append runs in, and not other processes.

## Test plan

- `controller/` suite: **956 passed, 5 skipped** (`py -3.12 -m pytest tests`), up from 904 on `main`.
- `scripts/release_audit.py --skip-doctor` passes end to end: lint, eval scoring, fixture validation, `pip-audit`, `npm audit`, three wheels built and inspected, 80% coverage gate, compile checks, secret scan, and the new advisory gate.
- `scripts/check_version_parity.py`: all 9 version strings agree on 1.7.0.
- New suites assert **effects, not decisions**: a reachable tokenless controller answers 401 to `/sessions` while `/healthz` stays open; a forged `X-Operator-Id` loses to the credential and is kept as `asserted_id`; operator B cannot read, export or open a session against operator A's profile; a re-signed candidate stolen from another skill is refused; truncating a chain file is detected; 12 concurrent writers produce a chain that still verifies.

### Not verified end to end

The Codex sandbox default is proven by test on both implementations, not by a live `codex exec`: `codex-cli 0.130.0` on the dev box refuses to load its `config.toml` (`model_reasoning_effort = "ultra"`, `service_tier = "priority"` are not valid variants there), so every Codex invocation fails before reaching a sandbox. `-s read-only` is confirmed present in `codex exec --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
