### PR TITLE
fix(packaging): replace the deprecated license table with an SPDX expression

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=68"]
+# >=77 is required by the PEP 639 SPDX `license` string below, not incidental:
+# the deprecated `license = { text = "MIT" }` table stops building after
+# 2027-02-18, and SPDX expressions are only understood from 77.0.0 on.
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,14 +10,16 @@ name = "auto-browser-client"
 version = "1.7.0"
 description = "Python client SDK and MCP stdio bridge for Auto Browser"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.11"
 dependencies = ["httpx>=0.27"]
 keywords = ["auto-browser", "mcp", "browser-automation", "playwright"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    # No "License ::" classifier: PEP 639 requires backends to reject a License
+    # classifier alongside an SPDX `license` expression. The expression is the
+    # single source of truth.
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["hatchling"]
+# >=1.27 for the PEP 639 SPDX `license` string below. Hatchling does not warn on
+# the deprecated table form the way setuptools does, so this package was moved
+# alongside the two setuptools ones rather than waiting for a build to break.
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
@@ -7,7 +10,7 @@ name = "auto-browser-langchain"
 version = "1.7.0"
 description = "LangChain / LangGraph / CrewAI integration for auto-browser"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.27",
@@ -16,7 +19,7 @@ keywords = ["auto-browser", "langchain", "langgraph", "crewai", "browser-automat
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    # No "License ::" classifier — see client/pyproject.toml.
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/packaging/auto-browser-mcp/pyproject.toml
+++ b/packaging/auto-browser-mcp/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools>=68"]
+# >=77 for the PEP 639 SPDX `license` string below (see client/pyproject.toml).
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 # Metapackage: exists so `uvx auto-browser-mcp` works without --from.
@@ -10,14 +11,14 @@ name = "auto-browser-mcp"
 version = "1.7.0"
 description = "MCP stdio bridge for Auto Browser (metapackage for `uvx auto-browser-mcp`)"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.11"
 dependencies = ["auto-browser-client>=1.5.0"]
 keywords = ["auto-browser", "mcp", "mcp-server", "browser-automation"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    # No "License ::" classifier — see client/pyproject.toml.
     "Programming Language :: Python :: 3",
 ]
 


### PR DESCRIPTION
## Why

`setuptools` deprecated `license = { text = "MIT" }`. Builds using the TOML-table form **stop being supported after 2027-02-18**.

Nothing in CI catches this — it surfaces only as a build warning inside `python -m build`, which is how it sat unnoticed across all three published packages.

## What changed

| Package | Backend | Change |
|---|---|---|
| `client` | setuptools | SPDX `license`, floor -> `setuptools>=77` |
| `packaging/auto-browser-mcp` | setuptools | SPDX `license`, floor -> `setuptools>=77` |
| `integrations/langchain` | hatchling | SPDX `license`, floor -> `hatchling>=1.27` |

Three coupled edits per package, not one:

1. `license = { text = "MIT" }` -> `license = "MIT"` (PEP 639 SPDX expression).
2. **Removed the `License :: OSI Approved :: MIT License` classifier.** Backends reject a License classifier alongside an SPDX expression rather than let one fact have two sources of truth.
3. **Raised the build-backend floor**, because that is where SPDX support landed.

`integrations/langchain` builds on hatchling, which does *not* warn on the table form, so it was moved with the other two instead of being left to break quietly later.

`controller/` declares no license and is not published to PyPI, so it is untouched.

## Verification

Checked against the **built artifacts**, not the source:

```
auto_browser_client-1.7.0     Metadata-Version: 2.4   License-Expression: MIT
auto_browser_langchain-1.7.0  Metadata-Version: 2.5   License-Expression: MIT
auto_browser_mcp-1.7.0        Metadata-Version: 2.4   License-Expression: MIT
```

No `Classifier: License` remains in any wheel, and all three build with zero deprecation warnings.

Local gates: ruff clean, version parity 9/9 at 1.7.0, bridge parity byte-identical, playwright pins matched, client 43 passed, langchain 31 passed.

## Note

This touches all three published package dirs, so it **arms the release trigger** (`git diff v1.7.0..main -- client/ integrations/langchain/ packaging/auto-browser-mcp/` is now non-empty). Metadata-only, no code change, so it wants folding into the next release rather than a release of its own.